### PR TITLE
Additions and fixes

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.39.2](https://img.shields.io/badge/AppVersion-v0.39.2-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -45,8 +45,8 @@ Kubernetes: `>= 1.30.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.rustfs.com/ | rustfs | 0.0.90 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 80.2.0 |
+| https://charts.rustfs.com/ | rustfs | 0.0.91 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 83.0.2 |
 
 ## Component Overview
 
@@ -439,6 +439,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilisation percentage for Bucketweb autoscaling. |
 | bucket.bucketweb.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage. Null disables memory-based scaling. |
 | bucket.bucketweb.containerSecurityContext | object | {} | Container security context for Bucketweb. Overrides global.containerSecurityContext. |
+| bucket.bucketweb.dnsConfig | object | {} | DNS configuration for Bucketweb pods. Overrides global.dnsConfig. |
 | bucket.bucketweb.enabled | bool | `false` | Enable the Bucketweb deployment (read-only object store browser). |
 | bucket.bucketweb.extraArgs | list | [] | Additional CLI arguments appended to the bucketweb command. |
 | bucket.bucketweb.extraContainers | list | [] | Extra sidecar containers for Bucketweb pods. |
@@ -461,8 +462,8 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.labels | object | {} | Extra labels applied to Bucketweb resources. |
 | bucket.bucketweb.nodeSelector | object | {} | Node selector for Bucketweb pod scheduling. |
 | bucket.bucketweb.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Bucketweb. |
-| bucket.bucketweb.pdb.maxUnavailable | string | `""` | Maximum unavailable Bucketweb pods during a disruption. |
-| bucket.bucketweb.pdb.minAvailable | string | `""` | Minimum available Bucketweb pods during a disruption. |
+| bucket.bucketweb.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Bucketweb pods during a disruption. |
+| bucket.bucketweb.pdb.minAvailable | int or string | `""` | Minimum available Bucketweb pods during a disruption. |
 | bucket.bucketweb.persistence | object | {} | Storage configuration for Bucketweb. Bucketweb is stateless; leave empty. |
 | bucket.bucketweb.podSecurityContext | object | {} | Pod security context for Bucketweb. Overrides global.podSecurityContext. |
 | bucket.bucketweb.priorityClassName | string | `""` | Priority class name for Bucketweb pods. |
@@ -471,7 +472,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the liveness probe. |
 | bucket.bucketweb.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the liveness probe. |
 | bucket.bucketweb.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the liveness probe. |
-| bucket.bucketweb.probes.liveness.port | int | `10902` | Port checked by the liveness probe. |
+| bucket.bucketweb.probes.liveness.port | int or string | `"http"` | Port checked by the liveness probe. |
 | bucket.bucketweb.probes.liveness.successThreshold | int | `1` | Consecutive successes before the container is considered live. |
 | bucket.bucketweb.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Bucketweb. |
@@ -479,7 +480,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the readiness probe. |
 | bucket.bucketweb.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the readiness probe. |
 | bucket.bucketweb.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the readiness probe. |
-| bucket.bucketweb.probes.readiness.port | int | `10902` | Port checked by the readiness probe. |
+| bucket.bucketweb.probes.readiness.port | int or string | `"http"` | Port checked by the readiness probe. |
 | bucket.bucketweb.probes.readiness.successThreshold | int | `1` | Consecutive successes before the pod is marked ready. |
 | bucket.bucketweb.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.probes.startup.enabled | bool | `true` | Enable the startup probe for Bucketweb. |
@@ -487,7 +488,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the startup probe. |
 | bucket.bucketweb.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the startup probe. |
 | bucket.bucketweb.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the startup probe. |
-| bucket.bucketweb.probes.startup.port | int | `10902` | Port checked by the startup probe. |
+| bucket.bucketweb.probes.startup.port | int or string | `"http"` | Port checked by the startup probe. |
 | bucket.bucketweb.probes.startup.successThreshold | int | `1` | Consecutive successes required before the startup probe is considered passed. |
 | bucket.bucketweb.probes.startup.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.replicaCount | int | `1` | Number of Bucketweb pod replicas. |
@@ -511,6 +512,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.affinity | object | {} | Affinity rules for Compactor pod scheduling. |
 | compactor.annotations | object | {} | Extra annotations applied to Compactor resources. |
 | compactor.containerSecurityContext | object | {} | Container security context for the Compactor. Overrides global.containerSecurityContext. |
+| compactor.dnsConfig | object | {} | DNS configuration for Compactor pods. Overrides global.dnsConfig. |
 | compactor.enabled | bool | `true` | Enable the Compactor StatefulSet. |
 | compactor.extraArgs[0] | string | `"--log.level=info"` |  |
 | compactor.extraArgs[1] | string | `"--log.format=logfmt"` |  |
@@ -538,8 +540,8 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.labels | object | {} | Extra labels applied to Compactor resources. |
 | compactor.nodeSelector | object | {} | Node selector for Compactor pod scheduling. |
 | compactor.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the Compactor. |
-| compactor.pdb.maxUnavailable | string | `""` | Maximum unavailable Compactor pods during a disruption. |
-| compactor.pdb.minAvailable | string | `""` | Minimum available Compactor pods during a disruption. |
+| compactor.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Compactor pods during a disruption. |
+| compactor.pdb.minAvailable | int or string | `""` | Minimum available Compactor pods during a disruption. |
 | compactor.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | compactor.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Compactor working directory. |
 | compactor.persistence.size | string | `"10Gi"` | Storage capacity for the Compactor PVC (used as a scratch space during compaction). |
@@ -552,7 +554,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Compactor liveness probe. |
 | compactor.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Compactor liveness probe. |
 | compactor.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Compactor liveness probe. |
-| compactor.probes.liveness.port | int | `10902` | Port checked by the Compactor liveness probe. |
+| compactor.probes.liveness.port | int or string | `"http"` | Port checked by the Compactor liveness probe. |
 | compactor.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Compactor container is considered live. |
 | compactor.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Compactor liveness probe times out. |
 | compactor.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Compactor. |
@@ -560,7 +562,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Compactor readiness probe. |
 | compactor.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Compactor readiness probe. |
 | compactor.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Compactor readiness probe. |
-| compactor.probes.readiness.port | int | `10902` | Port checked by the Compactor readiness probe. |
+| compactor.probes.readiness.port | int or string | `"http"` | Port checked by the Compactor readiness probe. |
 | compactor.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Compactor pod is marked ready. |
 | compactor.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Compactor readiness probe times out. |
 | compactor.probes.startup.enabled | bool | `true` | Enable the startup probe for the Compactor. |
@@ -568,7 +570,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Compactor startup probe. |
 | compactor.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Compactor startup probe. |
 | compactor.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Compactor startup probe. |
-| compactor.probes.startup.port | int | `10902` | Port checked by the Compactor startup probe. |
+| compactor.probes.startup.port | int or string | `"http"` | Port checked by the Compactor startup probe. |
 | compactor.probes.startup.successThreshold | int | `1` | Consecutive successes before the Compactor startup probe is considered passed. |
 | compactor.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Compactor startup probe times out. |
 | compactor.replicaCount | int | `1` | Number of Compactor replicas. Must remain 1 — running multiple compactors against the same bucket causes data corruption. |
@@ -602,6 +604,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | global.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mount the root filesystem as read-only. |
 | global.containerSecurityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root user. |
+| global.dnsConfig | object | {} | DNS configuration applied to every pod. Component-level values override this. |
 | global.extraContainers | list | [] | Extra sidecar containers added to every pod by default. |
 | global.extraEnv | list | [] | Extra environment variables injected into every main container by default. |
 | global.extraEnvFrom | list | [] | Extra environment variable sources (ConfigMap, Secret) for every main container. |
@@ -610,16 +613,17 @@ The table below documents all available values. Top-level keys group settings by
 | global.extraVolumes | list | [] | Additional volumes available to every pod by default. |
 | global.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy applied to every container. One of Always, IfNotPresent, Never. |
 | global.image.repository | string | `"quay.io/thanos/thanos"` | Docker repository for all Thanos containers by default. |
-| global.image.tag | string | `"v0.39.2"` | Container image tag. Changing this upgrades all components at once. |
+| global.image.tag | string | `"v0.41.0"` | Container image tag. Changing this upgrades all components at once. |
 | global.imagePullSecrets | list | [] | List of imagePullSecrets applied to every pod by default. |
+| global.networkPolicies | bool | `false` | Create a NetworkPolicy for every enabled component. When true each component gets a NetworkPolicy that allows ingress on its service ports from within the namespace and permits all egress. |
 | global.nodeSelector | object | {} | Node selector applied to every pod by default. |
 | global.objstore.config | string | `"type: GCS\nconfig:\n  bucket: change-me\n  endpoint: storage.googleapis.com\n  region: eu-west-1\n  insecure: false\n\n# Example for S3\n# type: S3\n# config:\n#   bucket: my-s3-bucket\n#   endpoint: s3.eu-west-1.amazonaws.com\n#   region: eu-west-1\n#   access_key: myaccess\n#   secret_key: mysecret\n"` | Inline object store configuration rendered into the Secret when `createSecret` is true. Processed via `tpl`, so Helm template syntax (e.g. `{{ .Release.Name }}`) is valid inside the string. Refer to https://thanos.io/tip/thanos/storage.md/ for the full schema. |
 | global.objstore.createSecret | bool | `false` | When true, the chart creates a Kubernetes Secret named `secretName` containing the inline `config` below. Set to false when the Secret is managed externally (Vault, External Secrets Operator, kubectl, etc.). |
 | global.objstore.secretKey | string | `"objstore.yml"` | Key inside the Secret whose value is the object store YAML. |
 | global.objstore.secretName | string | `"thanos-objstore"` | Name of the Kubernetes Secret that carries the object store config. All components mount this Secret as a file. |
 | global.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for every component. Individual components can override this with their own pdb.enabled. |
-| global.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during a disruption. Cannot be set at the same time as minAvailable. |
-| global.pdb.minAvailable | string | `""` | Minimum number of available pods during a disruption. Cannot be set at the same time as maxUnavailable. |
+| global.pdb.maxUnavailable | int or string | `""` | Maximum number of unavailable pods during a disruption. Cannot be set at the same time as minAvailable. |
+| global.pdb.minAvailable | int or string | `""` | Minimum number of available pods during a disruption. Cannot be set at the same time as maxUnavailable. |
 | global.podAnnotations | object | {} | Annotations added to every pod by default. Component-level annotations are merged on top. |
 | global.podSecurityContext | object | {} | Pod-level security context applied to every pod. Component-level values override this. |
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
@@ -662,6 +666,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilisation percentage for Query autoscaling. |
 | query.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for Query autoscaling. Null disables memory-based scaling. |
 | query.containerSecurityContext | object | {} | Container security context for Query. Overrides global.containerSecurityContext. |
+| query.dnsConfig | object | {} | DNS configuration for Query pods. Overrides global.dnsConfig. |
 | query.enabled | bool | `true` | Enable the Query Deployment. |
 | query.extraArgs[0] | string | `"--log.level=info"` |  |
 | query.extraContainers | list | [] | Extra sidecar containers for Query pods. |
@@ -688,8 +693,8 @@ The table below documents all available values. Top-level keys group settings by
 | query.labels | object | {} | Extra labels applied to Query resources. |
 | query.nodeSelector | object | {} | Node selector for Query pod scheduling. |
 | query.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Query. |
-| query.pdb.maxUnavailable | string | `""` | Maximum unavailable Query pods during a disruption. |
-| query.pdb.minAvailable | string | `""` | Minimum available Query pods during a disruption. |
+| query.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Query pods during a disruption. |
+| query.pdb.minAvailable | int or string | `""` | Minimum available Query pods during a disruption. |
 | query.podSecurityContext | object | {} | Pod security context for Query pods. Overrides global.podSecurityContext. |
 | query.priorityClassName | string | `""` | Priority class name for Query pods. |
 | query.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Query. |
@@ -697,7 +702,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query liveness probe. |
 | query.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query liveness probe. |
 | query.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query liveness probe. |
-| query.probes.liveness.port | int | `9090` | Port checked by the Query liveness probe. |
+| query.probes.liveness.port | int or string | `"http"` | Port checked by the Query liveness probe. |
 | query.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query container is considered live. |
 | query.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query liveness probe times out. |
 | query.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query. |
@@ -705,7 +710,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query readiness probe. |
 | query.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query readiness probe. |
 | query.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query readiness probe. |
-| query.probes.readiness.port | int | `9090` | Port checked by the Query readiness probe. |
+| query.probes.readiness.port | int or string | `"http"` | Port checked by the Query readiness probe. |
 | query.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query pod is marked ready. |
 | query.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query readiness probe times out. |
 | query.probes.startup.enabled | bool | `true` | Enable the startup probe for Query. |
@@ -713,7 +718,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query startup probe. |
 | query.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query startup probe. |
 | query.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query startup probe. |
-| query.probes.startup.port | int | `9090` | Port checked by the Query startup probe. |
+| query.probes.startup.port | int or string | `"http"` | Port checked by the Query startup probe. |
 | query.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query startup probe is considered passed. |
 | query.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query startup probe times out. |
 | query.replicaCount | int | `2` | Number of Query pod replicas. Two or more is recommended for HA. |
@@ -745,6 +750,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for Query Frontend autoscaling. Null disables memory-based scaling. |
 | queryFrontend.cacheConfig | string | `""` | Optional result cache configuration (Memcached, Redis, or in-memory) passed as an inline YAML string. See https://thanos.io/tip/components/query-frontend.md/ |
 | queryFrontend.containerSecurityContext | object | {} | Container security context for Query Frontend. Overrides global.containerSecurityContext. |
+| queryFrontend.dnsConfig | object | {} | DNS configuration for Query Frontend pods. Overrides global.dnsConfig. |
 | queryFrontend.downstreamUrl | string | `""` | Downstream URL of the Query component. Leave empty to use the in-chart Query service endpoint (auto-resolved). |
 | queryFrontend.enabled | bool | `false` | Enable the Query Frontend Deployment. |
 | queryFrontend.extraArgs | list | [] | Additional CLI arguments appended to the `thanos query-frontend` command. |
@@ -768,8 +774,8 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.labels | object | {} | Extra labels applied to Query Frontend resources. |
 | queryFrontend.nodeSelector | object | {} | Node selector for Query Frontend pod scheduling. |
 | queryFrontend.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Query Frontend. |
-| queryFrontend.pdb.maxUnavailable | string | `""` | Maximum unavailable Query Frontend pods during a disruption. |
-| queryFrontend.pdb.minAvailable | string | `""` | Minimum available Query Frontend pods during a disruption. |
+| queryFrontend.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Query Frontend pods during a disruption. |
+| queryFrontend.pdb.minAvailable | int or string | `""` | Minimum available Query Frontend pods during a disruption. |
 | queryFrontend.podSecurityContext | object | {} | Pod security context for Query Frontend pods. Overrides global.podSecurityContext. |
 | queryFrontend.priorityClassName | string | `""` | Priority class name for Query Frontend pods. |
 | queryFrontend.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Query Frontend. |
@@ -777,7 +783,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query Frontend liveness probe. |
-| queryFrontend.probes.liveness.port | int | `9090` | Port checked by the Query Frontend liveness probe. |
+| queryFrontend.probes.liveness.port | int or string | `"http"` | Port checked by the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query Frontend container is considered live. |
 | queryFrontend.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query Frontend liveness probe times out. |
 | queryFrontend.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query Frontend. |
@@ -785,7 +791,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query Frontend readiness probe. |
-| queryFrontend.probes.readiness.port | int | `9090` | Port checked by the Query Frontend readiness probe. |
+| queryFrontend.probes.readiness.port | int or string | `"http"` | Port checked by the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query Frontend pod is marked ready. |
 | queryFrontend.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query Frontend readiness probe times out. |
 | queryFrontend.probes.startup.enabled | bool | `true` | Enable the startup probe for Query Frontend. |
@@ -793,7 +799,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query Frontend startup probe. |
 | queryFrontend.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query Frontend startup probe. |
 | queryFrontend.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query Frontend startup probe. |
-| queryFrontend.probes.startup.port | int | `9090` | Port checked by the Query Frontend startup probe. |
+| queryFrontend.probes.startup.port | int or string | `"http"` | Port checked by the Query Frontend startup probe. |
 | queryFrontend.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query Frontend startup probe is considered passed. |
 | queryFrontend.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query Frontend startup probe times out. |
 | queryFrontend.replicaCount | int | `2` | Number of Query Frontend pod replicas. |
@@ -816,6 +822,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.affinity | object | {} | Affinity rules for Receive pod scheduling. |
 | receive.annotations | object | {} | Extra annotations applied to Receive resources. |
 | receive.containerSecurityContext | object | {} | Container security context for Receive. Overrides global.containerSecurityContext. |
+| receive.dnsConfig | object | {} | DNS configuration for Receive pods. Overrides global.dnsConfig. |
 | receive.enabled | bool | `true` | Enable the Receive StatefulSet. |
 | receive.extraArgs | list | [] | Additional CLI arguments appended to the `thanos receive` command. |
 | receive.extraContainers | list | [] | Extra sidecar containers for Receive pods. |
@@ -845,8 +852,8 @@ The table below documents all available values. Top-level keys group settings by
 | receive.labels | object | {} | Extra labels applied to Receive resources. |
 | receive.nodeSelector | object | {} | Node selector for Receive pod scheduling. |
 | receive.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Receive. |
-| receive.pdb.maxUnavailable | string | `""` | Maximum unavailable Receive pods during a disruption. |
-| receive.pdb.minAvailable | string | `""` | Minimum available Receive pods during a disruption. |
+| receive.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Receive pods during a disruption. |
+| receive.pdb.minAvailable | int or string | `""` | Minimum available Receive pods during a disruption. |
 | receive.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | receive.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Receive TSDB WAL. |
 | receive.persistence.size | string | `"10Gi"` | Storage capacity for the Receive PVC. Should be sized to hold at least `tsdb.retention` worth of data. |
@@ -859,7 +866,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Receive liveness probe. |
 | receive.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Receive liveness probe. |
 | receive.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Receive liveness probe. |
-| receive.probes.liveness.port | int | `10902` | Port checked by the Receive liveness probe. |
+| receive.probes.liveness.port | int or string | `"http"` | Port checked by the Receive liveness probe. |
 | receive.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Receive container is considered live. |
 | receive.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Receive liveness probe times out. |
 | receive.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Receive. |
@@ -867,7 +874,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Receive readiness probe. |
 | receive.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Receive readiness probe. |
 | receive.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Receive readiness probe. |
-| receive.probes.readiness.port | int | `10902` | Port checked by the Receive readiness probe. |
+| receive.probes.readiness.port | int or string | `"http"` | Port checked by the Receive readiness probe. |
 | receive.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Receive pod is marked ready. |
 | receive.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Receive readiness probe times out. |
 | receive.probes.startup.enabled | bool | `true` | Enable the startup probe for Receive. |
@@ -875,7 +882,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Receive startup probe. |
 | receive.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Receive startup probe. |
 | receive.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Receive startup probe. |
-| receive.probes.startup.port | int | `10902` | Port checked by the Receive startup probe. |
+| receive.probes.startup.port | int or string | `"http"` | Port checked by the Receive startup probe. |
 | receive.probes.startup.successThreshold | int | `1` | Consecutive successes before the Receive startup probe is considered passed. |
 | receive.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Receive startup probe times out. |
 | receive.replicaCount | int | `3` | Number of Receive pod replicas. Minimum 3 is recommended for replication factor 2 (write quorum = floor(replicaCount/2)+1). |
@@ -917,6 +924,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.autoImportPrometheusRules.sidecar.image.repository | string | `"alpine/kubectl"` | Repository for the kubectl sidecar that reads PrometheusRule CRDs. |
 | ruler.autoImportPrometheusRules.sidecar.image.tag | string | `"latest"` | Tag for the kubectl sidecar image. |
 | ruler.containerSecurityContext | object | {} | Container security context for Ruler. Overrides global.containerSecurityContext. |
+| ruler.dnsConfig | object | {} | DNS configuration for Ruler pods. Overrides global.dnsConfig. |
 | ruler.enabled | bool | `false` | Enable the Ruler StatefulSet. |
 | ruler.extraArgs | list | [] | Additional CLI arguments appended to the `thanos rule` command. |
 | ruler.extraContainers | list | [] | Extra sidecar containers for Ruler pods. |
@@ -939,8 +947,8 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.labels | object | {} | Extra labels applied to Ruler resources. |
 | ruler.nodeSelector | object | {} | Node selector for Ruler pod scheduling. |
 | ruler.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the Ruler. |
-| ruler.pdb.maxUnavailable | string | `""` | Maximum unavailable Ruler pods during a disruption. |
-| ruler.pdb.minAvailable | string | `""` | Minimum available Ruler pods during a disruption. |
+| ruler.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Ruler pods during a disruption. |
+| ruler.pdb.minAvailable | int or string | `""` | Minimum available Ruler pods during a disruption. |
 | ruler.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | ruler.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ruler data directory. |
 | ruler.persistence.size | string | `"10Gi"` | Storage capacity for the Ruler PVC. |
@@ -953,7 +961,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Ruler liveness probe. |
 | ruler.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Ruler liveness probe. |
 | ruler.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Ruler liveness probe. |
-| ruler.probes.liveness.port | int | `10902` | Port checked by the Ruler liveness probe. |
+| ruler.probes.liveness.port | int or string | `"http"` | Port checked by the Ruler liveness probe. |
 | ruler.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Ruler container is considered live. |
 | ruler.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Ruler liveness probe times out. |
 | ruler.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Ruler. |
@@ -961,7 +969,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Ruler readiness probe. |
 | ruler.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Ruler readiness probe. |
 | ruler.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Ruler readiness probe. |
-| ruler.probes.readiness.port | int | `10902` | Port checked by the Ruler readiness probe. |
+| ruler.probes.readiness.port | int or string | `"http"` | Port checked by the Ruler readiness probe. |
 | ruler.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Ruler pod is marked ready. |
 | ruler.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Ruler readiness probe times out. |
 | ruler.probes.startup.enabled | bool | `true` | Enable the startup probe for the Ruler. |
@@ -969,7 +977,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Ruler startup probe. |
 | ruler.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Ruler startup probe. |
 | ruler.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Ruler startup probe. |
-| ruler.probes.startup.port | int | `10902` | Port checked by the Ruler startup probe. |
+| ruler.probes.startup.port | int or string | `"http"` | Port checked by the Ruler startup probe. |
 | ruler.probes.startup.successThreshold | int | `1` | Consecutive successes before the Ruler startup probe is considered passed. |
 | ruler.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Ruler startup probe times out. |
 | ruler.query.urls | list | [] | List of Query component base URLs used by the Ruler to evaluate rules. |
@@ -1008,6 +1016,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for Store Gateway autoscaling. Null disables memory-based scaling. |
 | storegateway.cachingBucketConfig | string | `""` | Optional caching bucket configuration (e.g. Memcached) that wraps the object store to reduce the number of object store API calls. Provide as an inline YAML string. See https://thanos.io/tip/components/store.md/#caching-bucket |
 | storegateway.containerSecurityContext | object | {} | Container security context for Store Gateway. Overrides global.containerSecurityContext. |
+| storegateway.dnsConfig | object | {} | DNS configuration for Store Gateway pods. Overrides global.dnsConfig. |
 | storegateway.enabled | bool | `true` | Enable the Store Gateway StatefulSet. |
 | storegateway.extraArgs | list | [] | Additional CLI arguments appended to the `thanos store` command. |
 | storegateway.extraContainers | list | [] | Extra sidecar containers for Store Gateway pods. |
@@ -1034,8 +1043,8 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.labels | object | {} | Extra labels applied to Store Gateway resources. |
 | storegateway.nodeSelector | object | {} | Node selector for Store Gateway pod scheduling. |
 | storegateway.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the Store Gateway. |
-| storegateway.pdb.maxUnavailable | string | `""` | Maximum unavailable Store Gateway pods during a disruption. |
-| storegateway.pdb.minAvailable | string | `""` | Minimum available Store Gateway pods during a disruption. |
+| storegateway.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Store Gateway pods during a disruption. |
+| storegateway.pdb.minAvailable | int or string | `""` | Minimum available Store Gateway pods during a disruption. |
 | storegateway.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storegateway.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Store Gateway index cache and chunk store. |
 | storegateway.persistence.size | string | `"10Gi"` | Storage capacity for the Store Gateway PVC. |
@@ -1048,7 +1057,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Store Gateway liveness probe. |
 | storegateway.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Store Gateway liveness probe. |
 | storegateway.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Store Gateway liveness probe. |
-| storegateway.probes.liveness.port | int | `10902` | Port checked by the Store Gateway liveness probe. |
+| storegateway.probes.liveness.port | int or string | `"http"` | Port checked by the Store Gateway liveness probe. |
 | storegateway.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Store Gateway container is considered live. |
 | storegateway.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Store Gateway liveness probe times out. |
 | storegateway.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Store Gateway. |
@@ -1056,7 +1065,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Store Gateway readiness probe. |
 | storegateway.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Store Gateway readiness probe. |
 | storegateway.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Store Gateway readiness probe. |
-| storegateway.probes.readiness.port | int | `10902` | Port checked by the Store Gateway readiness probe. |
+| storegateway.probes.readiness.port | int or string | `"http"` | Port checked by the Store Gateway readiness probe. |
 | storegateway.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Store Gateway pod is marked ready. |
 | storegateway.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Store Gateway readiness probe times out. |
 | storegateway.probes.startup.enabled | bool | `true` | Enable the startup probe for the Store Gateway. |
@@ -1064,7 +1073,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Store Gateway startup probe. |
 | storegateway.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Store Gateway startup probe. |
 | storegateway.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Store Gateway startup probe. |
-| storegateway.probes.startup.port | int | `10902` | Port checked by the Store Gateway startup probe. |
+| storegateway.probes.startup.port | int or string | `"http"` | Port checked by the Store Gateway startup probe. |
 | storegateway.probes.startup.successThreshold | int | `1` | Consecutive successes before the Store Gateway startup probe is considered passed. |
 | storegateway.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Store Gateway startup probe times out. |
 | storegateway.replicaCount | int | `2` | Number of Store Gateway pod replicas. Two or more is recommended for HA. |

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -819,6 +819,77 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query Frontend scraping. |
 | queryFrontend.tolerations | list | [] | Tolerations for Query Frontend pod scheduling. |
 | queryFrontend.topologySpreadConstraints | list | [] | Topology spread constraints for Query Frontend pods. |
+| queryTls.affinity | object | {} | Affinity rules for Query TLS pod scheduling. |
+| queryTls.annotations | object | {} | Extra annotations applied to Query TLS resources. |
+| queryTls.autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler for Query TLS. |
+| queryTls.autoscaling.maxReplicas | int | `5` | Maximum number of Query TLS replicas. |
+| queryTls.autoscaling.minReplicas | int | `2` | Minimum number of Query TLS replicas. |
+| queryTls.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilisation percentage for Query TLS autoscaling. |
+| queryTls.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for Query TLS autoscaling. Null disables memory-based scaling. |
+| queryTls.containerSecurityContext | object | {} | Container security context for Query TLS. Overrides global.containerSecurityContext. |
+| queryTls.dnsConfig | object | {} | DNS configuration for Query TLS pods. Overrides global.dnsConfig. |
+| queryTls.enabled | bool | `false` | Enable the Query TLS Deployment. When enabled, the plain Query automatically adds Query TLS as an endpoint. |
+| queryTls.extraArgs[0] | string | `"--log.level=info"` |  |
+| queryTls.extraContainers | list | [] | Extra sidecar containers for Query TLS pods. |
+| queryTls.extraEnv | list | [] | Extra environment variables injected into the Query TLS container. |
+| queryTls.extraEnvFrom | list | [] | Extra environment variable sources for the Query TLS container. |
+| queryTls.extraInitContainers | list | [] | Extra init containers for Query TLS pods. |
+| queryTls.extraVolumeMounts | list | [] | Extra volume mounts for the Query TLS container. |
+| queryTls.extraVolumes | list | [] | Extra volumes for Query TLS pods. |
+| queryTls.labels | object | {} | Extra labels applied to Query TLS resources. |
+| queryTls.nodeSelector | object | {} | Node selector for Query TLS pod scheduling. |
+| queryTls.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Query TLS. |
+| queryTls.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Query TLS pods during a disruption. |
+| queryTls.pdb.minAvailable | int or string | `""` | Minimum available Query TLS pods during a disruption. |
+| queryTls.podSecurityContext | object | {} | Pod security context for Query TLS pods. Overrides global.podSecurityContext. |
+| queryTls.priorityClassName | string | `""` | Priority class name for Query TLS pods. |
+| queryTls.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Query TLS. |
+| queryTls.probes.liveness.failureThreshold | int | `6` | Consecutive failures before the Query TLS container is restarted. |
+| queryTls.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query TLS liveness probe. |
+| queryTls.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query TLS liveness probe. |
+| queryTls.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query TLS liveness probe. |
+| queryTls.probes.liveness.port | int or string | `"http"` | Port checked by the Query TLS liveness probe. |
+| queryTls.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query TLS container is considered live. |
+| queryTls.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query TLS liveness probe times out. |
+| queryTls.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query TLS. |
+| queryTls.probes.readiness.failureThreshold | int | `6` | Consecutive failures before the Query TLS pod is marked not-ready. |
+| queryTls.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query TLS readiness probe. |
+| queryTls.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query TLS readiness probe. |
+| queryTls.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query TLS readiness probe. |
+| queryTls.probes.readiness.port | int or string | `"http"` | Port checked by the Query TLS readiness probe. |
+| queryTls.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query TLS pod is marked ready. |
+| queryTls.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query TLS readiness probe times out. |
+| queryTls.probes.startup.enabled | bool | `true` | Enable the startup probe for Query TLS. |
+| queryTls.probes.startup.failureThreshold | int | `60` | Consecutive failures during Query TLS startup before the container is killed. |
+| queryTls.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query TLS startup probe. |
+| queryTls.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query TLS startup probe. |
+| queryTls.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query TLS startup probe. |
+| queryTls.probes.startup.port | int or string | `"http"` | Port checked by the Query TLS startup probe. |
+| queryTls.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query TLS startup probe is considered passed. |
+| queryTls.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query TLS startup probe times out. |
+| queryTls.replicaCount | int | `2` | Number of Query TLS pod replicas. |
+| queryTls.replicaLabels | list | `["prometheus_replica"]` | Label names that identify replica identity for result deduplication. |
+| queryTls.resources | object | {} | Resource requests and limits for the Query TLS container. |
+| queryTls.service.annotations | object | {} | Extra annotations for the Query TLS Service. |
+| queryTls.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Query TLS Service. |
+| queryTls.service.httpPort | int | `9090` | HTTP/PromQL port exposed by the Query TLS Service. |
+| queryTls.service.labels | object | {} | Extra labels for the Query TLS Service. |
+| queryTls.service.type | string | `"ClusterIP"` | Kubernetes Service type for Query TLS. |
+| queryTls.serviceMonitor.annotations | object | {} | Extra annotations for the Query TLS ServiceMonitor. |
+| queryTls.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Query TLS. |
+| queryTls.serviceMonitor.interval | string | `""` | Scrape interval for Query TLS. Empty uses the Prometheus operator default. |
+| queryTls.serviceMonitor.labels | object | {} | Extra labels for the Query TLS ServiceMonitor. |
+| queryTls.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Query TLS metrics are ingested. |
+| queryTls.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Query TLS metrics are ingested. |
+| queryTls.serviceMonitor.scheme | string | `""` | Scrape scheme for Query TLS (http or https). |
+| queryTls.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query TLS. Empty uses the Prometheus operator default. |
+| queryTls.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query TLS scraping. |
+| queryTls.stores | list | [] | List of remote gRPC Store API endpoints that require TLS. Unlike plain Query, no in-chart components are wired automatically. |
+| queryTls.tls.ca | string | `""` | Path to the CA certificate file used to verify the remote endpoint. Leave empty to use the system trust store. |
+| queryTls.tls.cert | string | `""` | Path to the TLS client certificate file (PEM). Leave empty when the remote endpoint uses a publicly trusted CA. |
+| queryTls.tls.key | string | `""` | Path to the TLS client private key file (PEM). |
+| queryTls.tolerations | list | [] | Tolerations for Query TLS pod scheduling. |
+| queryTls.topologySpreadConstraints | list | [] | Topology spread constraints for Query TLS pods. |
 | receive.affinity | object | {} | Affinity rules for Receive pod scheduling. |
 | receive.annotations | object | {} | Extra annotations applied to Receive resources. |
 | receive.containerSecurityContext | object | {} | Container security context for Receive. Overrides global.containerSecurityContext. |

--- a/charts/thanos/templates/NOTES.txt
+++ b/charts/thanos/templates/NOTES.txt
@@ -5,6 +5,7 @@ Components enabled:
 - compactor: {{ .Values.compactor.enabled }}
 - query: {{ .Values.query.enabled }}
 - query-frontend: {{ .Values.queryFrontend.enabled }}
+- query-tls: {{ .Values.queryTls.enabled }}
 - receive: {{ .Values.receive.enabled }}
 - ruler: {{ .Values.ruler.enabled }}
 - storegateway: {{ .Values.storegateway.enabled }}

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/part-of: thanos
 {{- end }}
 
 {{- if $annotations }}
-{{ toYaml $annotations | indent 2 }}
+  {{- toYaml $annotations | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -55,7 +55,7 @@ app.kubernetes.io/part-of: thanos
 {{- $psc := $comp.podSecurityContext | default $root.Values.global.podSecurityContext -}}
 {{- if $psc }}
 securityContext:
-{{ toYaml $psc | nindent 2 }}
+  {{- toYaml $psc | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -66,7 +66,15 @@ securityContext:
 {{- $csc := $comp.containerSecurityContext | default $root.Values.global.containerSecurityContext -}}
 {{- if $csc }}
 securityContext:
-{{ toYaml $csc | nindent 2 }}
+  {{- toYaml $csc | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.dnsConfig" -}}
+{{- $component := (index .Values .component) | default dict -}}
+{{- with ($component.dnsConfig | default .Values.global.dnsConfig) -}}
+dnsConfig:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -141,7 +149,7 @@ startupProbe:
 {{- $volsComp := $comp.extraVolumes | default list -}}
 {{- if or (gt (len $volsGlob) 0) (gt (len $volsComp) 0) }}
 volumes:
-{{ include "thanos.extraVolumeItems" (dict "root" $root "key" $key) | nindent 0 }}
+  {{- include "thanos.extraVolumeItems" (dict "root" $root "key" $key) | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -169,10 +177,132 @@ volumes:
 {{- $mtsComp := $comp.extraVolumeMounts | default list -}}
 {{- if or (gt (len $mtsGlob) 0) (gt (len $mtsComp) 0) }}
 volumeMounts:
-{{ include "thanos.extraMountItems" (dict "root" $root "key" $key) | nindent 0 }}
+  {{- include "thanos.extraMountItems" (dict "root" $root "key" $key) | nindent 2 }}
 {{- end }}
 {{- end }}
 
+
+{{- /* ============================== */ -}}
+{{- /* Scheduling and placement       */ -}}
+{{- /* ============================== */ -}}
+
+{{- define "thanos.affinity" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- with ($component.affinity | default .Values.global.affinity) -}}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.nodeSelector" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- with ($component.nodeSelector | default .Values.global.nodeSelector) -}}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.priorityClassName" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- with ($component.priorityClassName | default .Values.global.priorityClassName) -}}
+priorityClassName: {{ . }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.tolerations" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- with ($component.tolerations | default .Values.global.tolerations) -}}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.topologySpreadConstraints" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- with ($component.topologySpreadConstraints | default .Values.global.topologySpreadConstraints) -}}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- /* ============================== */ -}}
+{{- /* Extra env / envFrom helpers    */ -}}
+{{- /* ============================== */ -}}
+
+{{- define "thanos.extraEnvItems" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- $merged := dict -}}
+{{- range (.Values.global.extraEnv | default list) }}
+{{- $_ := set $merged .name . }}
+{{- end }}
+{{- range ($component.extraEnv | default list) }}
+{{- $_ := set $merged .name . }}
+{{- end }}
+{{- range (keys $merged | sortAlpha) }}
+- {{ toYaml (index $merged .) | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.extraEnvBlock" -}}
+{{- if include "thanos.extraEnvItems" $ }}
+env:
+  {{- include "thanos.extraEnvItems" $ | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.extraEnvFromItems" -}}
+{{- $component := index .Values .component | default dict -}}
+{{- $merged := dict -}}
+{{- range (.Values.global.extraEnvFrom | default list) }}
+{{- $_ := set $merged .name . }}
+{{- end }}
+{{- range ($component.extraEnvFrom | default list) }}
+{{- $_ := set $merged .name . }}
+{{- end }}
+{{- range (keys $merged | sortAlpha) }}
+- {{ toYaml (index $merged .) | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.extraEnvFromBlock" -}}
+{{- if include "thanos.extraEnvFromItems" $ }}
+env:
+  {{- include "thanos.extraEnvFromItems" $ | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- /* ============================== */ -}}
+{{- /* Init / sidecar containers      */ -}}
+{{- /* ============================== */ -}}
+
+{{- define "thanos.initContainers" -}}
+{{- $root := .root -}}
+{{- $component := (index .Values .component) | default dict -}}
+{{- $icGlob := .Values.global.extraInitContainers | default list -}}
+{{- $icComp := $component.extraInitContainers | default list -}}
+{{- if or (gt (len $icGlob) 0) (gt (len $icComp) 0) }}
+initContainers:
+  {{- range $icGlob }}
+  - {{ tpl (toYaml .) $root | nindent 4 }}
+  {{- end }}
+  {{- range $icComp }}
+  - {{ tpl (toYaml .) $root | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "thanos.extraContainers" -}}
+{{- $root := .root -}}
+{{- $component := (index .Values .component) | default dict -}}
+{{- $cGlob := .Values.global.extraContainers | default list -}}
+{{- $cComp := $component.extraContainers | default list -}}
+{{- range $cGlob }}
+- {{ tpl (toYaml .) $root | nindent 2 }}
+{{- end }}
+{{- range $cComp }}
+- {{ tpl (toYaml .) $root | nindent 2 }}
+{{- end }}
+{{- end }}
 
 {{- /* ============================== */ -}}
 {{- /* Receive headless service name  */ -}}
@@ -239,7 +369,7 @@ Render imagePullSecrets from global.image.imagePullSecrets if any
 {{- define "thanos.imagePullSecrets" -}}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+  {{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}
 {{- end -}}
 
@@ -258,18 +388,18 @@ metadata:
   name: {{ include "thanos.compName" (list $root $comp) }}
   namespace: {{ $root.Release.Namespace }}
   labels:
-{{ include "thanos.labels" $root | indent 4 }}
+    {{- include "thanos.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $comp }}
   {{- with $cfg.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-{{ toYaml $cfg.parentRefs | indent 4 }}
+    {{- toYaml $cfg.parentRefs | nindent 4 }}
   {{- with $cfg.hostnames }}
   hostnames:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - backendRefs:
@@ -292,18 +422,18 @@ metadata:
   name: {{ include "thanos.compName" (list $root $comp) }}-grpc
   namespace: {{ $root.Release.Namespace }}
   labels:
-{{ include "thanos.labels" $root | indent 4 }}
+    {{- include "thanos.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $comp }}
   {{- with $cfg.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-{{ toYaml $cfg.parentRefs | indent 4 }}
+    {{- toYaml $cfg.parentRefs | nindent 4 }}
   {{- with $cfg.hostnames }}
   hostnames:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - backendRefs:

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -1,14 +1,21 @@
 {{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled }}
+{{- $ctx := dict "Values" (dict "bucketweb" .Values.bucket.bucketweb "global" .Values.global) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.bucket.bucketweb.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
+    {{- with .Values.bucket.bucketweb.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.bucket.bucketweb.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/component: bucketweb
@@ -16,15 +23,15 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucketweb
       annotations:
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{- $ctx := dict "Values" (dict "bucketweb" .Values.bucket.bucketweb "global" .Values.global) }}
-      {{ include "thanos.podSC" (dict "root" $ctx "key" "bucketweb") | nindent 6 }}
+      {{- include "thanos.affinity" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" $ctx "key" "bucketweb") | nindent 6 }}
       containers:
         - name: bucketweb
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -38,6 +45,8 @@ spec:
           {{- range .Values.bucket.bucketweb.extraArgs }}
             - {{ . | quote }}
           {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 10 }}
           ports:
             - name: http
               containerPort: {{ .Values.bucket.bucketweb.service.port }}
@@ -45,11 +54,18 @@ spec:
             - name: objstore
               mountPath: /etc/thanos
               readOnly: true
-          {{ include "thanos.extraMountItems" (dict "root" $ctx "key" "bucketweb") | nindent 10 }}
-          {{ include "thanos.containerSC" (dict "root" $ctx "key" "bucketweb") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" $ctx "key" "bucketweb") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" $ctx "key" "bucketweb") | nindent 10 }}
           resources:
-{{ toYaml .Values.bucket.bucketweb.resources | indent 12 }}
-          {{ include "thanos.httpProbes" (dict "root" $ctx "key" "bucketweb" "port" .Values.bucket.bucketweb.service.port) | nindent 10 }}
+            {{- toYaml .Values.bucket.bucketweb.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" $ctx "key" "bucketweb" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" $ctx.Values "component" "bucketweb" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" $ctx.Values "component" "bucketweb" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
       volumes:
         - name: objstore
           secret:
@@ -57,5 +73,5 @@ spec:
             items:
               - key: {{ .Values.global.objstore.secretKey }}
                 path: objstore.yml
-      {{ include "thanos.extraVolumesBlock" (dict "root" $ctx "key" "bucketweb") | nindent 6 }}
+      {{- include "thanos.extraVolumeItems" (dict "root" $ctx "key" "bucketweb") | nindent 6 }}
 {{- end }}

--- a/charts/thanos/templates/bucket/hpa.yaml
+++ b/charts/thanos/templates/bucket/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/bucket/ingress.yaml
+++ b/charts/thanos/templates/bucket/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.bucket.bucketweb.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.bucket.bucketweb.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 spec:
   {{- with .Values.bucket.bucketweb.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "bucketweb") }}
                 port:
-                  number: {{ $.Values.bucket.bucketweb.service.port }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.bucket.bucketweb.ingress.tls | indent 4 }}
+    {{- toYaml .Values.bucket.bucketweb.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/bucket/networkpolicy.yaml
+++ b/charts/thanos/templates/bucket/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+  name: {{ include "thanos.compName" (list . "bucketweb") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: bucketweb
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/bucket/pdb.yaml
+++ b/charts/thanos/templates/bucket/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled .Values.bucket.bucketweb.pdb.enabled }}
+{{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled (or .Values.bucket.bucketweb.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.bucket.bucketweb.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.bucket.bucketweb.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: bucketweb
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.bucket.bucketweb.pdb.minAvailable }}
-  minAvailable: {{ .Values.bucket.bucketweb.pdb.minAvailable | quote }}
-  {{- else if .Values.bucket.bucketweb.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.bucket.bucketweb.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/bucket/secret-objstore.yaml
+++ b/charts/thanos/templates/bucket/secret-objstore.yaml
@@ -4,11 +4,11 @@ kind: Secret
 metadata:
   name: {{ .Values.global.objstore.secretName }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 type: Opaque
 stringData:
   {{ .Values.global.objstore.secretKey }}: |
-{{ tpl .Values.global.objstore.config . | indent 4 }}
+    {{- tpl .Values.global.objstore.config . | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/bucket/service.yaml
+++ b/charts/thanos/templates/bucket/service.yaml
@@ -4,9 +4,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.bucket.bucketweb.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
+    {{- with .Values.bucket.bucketweb.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.bucket.bucketweb.service.type }}
   ports:

--- a/charts/thanos/templates/compactor/ingress.yaml
+++ b/charts/thanos/templates/compactor/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.compactor.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.compactor.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
 spec:
   {{- with .Values.compactor.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "compactor") }}
                 port:
-                  number: {{ $.Values.compactor.service.port }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.compactor.ingress.tls | indent 4 }}
+    {{- toYaml .Values.compactor.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/compactor/networkpolicy.yaml
+++ b/charts/thanos/templates/compactor/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.compactor.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+  name: {{ include "thanos.compName" (list . "compactor") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/compactor/pdb.yaml
+++ b/charts/thanos/templates/compactor/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.compactor.enabled .Values.compactor.pdb.enabled }}
+{{- if and .Values.compactor.enabled (or .Values.compactor.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.compactor.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.compactor.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: compactor
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.compactor.pdb.minAvailable }}
-  minAvailable: {{ .Values.compactor.pdb.minAvailable | quote }}
-  {{- else if .Values.compactor.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.compactor.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/compactor/service.yaml
+++ b/charts/thanos/templates/compactor/service.yaml
@@ -4,9 +4,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.compactor.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
+    {{- with .Values.compactor.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.compactor.service.type }}
   ports:

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -4,9 +4,15 @@ kind: StatefulSet
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.compactor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
+    {{- with .Values.compactor.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   serviceName: {{ include "thanos.compName" (list . "compactor") }}
   replicas: 1
@@ -17,18 +23,18 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: compactor
       annotations:
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
+        checksum/objstore-configuration: {{ .Values.global.objstore.config | sha256sum }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{ include "thanos.podSC" (dict "root" . "key" "compactor") | nindent 6 }}
-      {{- if .Values.compactor.extraInitContainers }}
-      initContainers:
-        {{- tpl (toYaml .Values.compactor.extraInitContainers) . | nindent 8 }}
-      {{- end }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "compactor") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "compactor") | nindent 6 }}
       containers:
         - name: compactor
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -41,6 +47,8 @@ spec:
           {{- range .Values.compactor.extraArgs }}
             - {{ . | quote }}
           {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "compactor") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "compactor") | nindent 10 }}
           ports:
             - name: http
               containerPort: {{ .Values.compactor.service.port }}
@@ -50,11 +58,18 @@ spec:
             - name: objstore
               mountPath: /etc/thanos
               readOnly: true
-          {{ include "thanos.extraMountItems" (dict "root" . "key" "compactor") | nindent 10 }}
-          {{ include "thanos.containerSC" (dict "root" . "key" "compactor") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "compactor") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "compactor") | nindent 10 }}
           resources:
-{{ toYaml .Values.compactor.resources | indent 12 }}
-          {{ include "thanos.httpProbes" (dict "root" . "key" "compactor" "port" .Values.compactor.service.port) | nindent 10 }}
+            {{- toYaml .Values.compactor.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "compactor" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "compactor" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "compactor") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "compactor" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "compactor") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "compactor") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "compactor") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "compactor") | nindent 6 }}
       volumes:
         - name: objstore
           secret:
@@ -66,7 +81,7 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
-      {{ include "thanos.extraVolumeItems" (dict "root" . "key" "compactor") | nindent 6 }}
+        {{- include "thanos.extraVolumeItems" (dict "root" . "key" "compactor") | nindent 8 }}
   {{- if .Values.compactor.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/thanos/templates/compactor/vpa.yaml
+++ b/charts/thanos/templates/compactor/vpa.yaml
@@ -4,7 +4,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query-frontend/configmap-cache.yaml
+++ b/charts/thanos/templates/query-frontend/configmap-cache.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}-cache
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 data:
   cache.yaml: |
-{{ tpl .Values.queryFrontend.cacheConfig . | indent 4 }}
+    {{- tpl .Values.queryFrontend.cacheConfig . | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -4,9 +4,15 @@ kind: Deployment
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.queryFrontend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
+    {{- with .Values.queryFrontend.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.queryFrontend.replicaCount }}
   selector:
@@ -16,18 +22,15 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query-frontend
       annotations:
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{ include "thanos.podSC" (dict "root" . "key" "queryFrontend") | nindent 6 }}
-      {{- if .Values.queryFrontend.extraInitContainers }}
-      initContainers:
-        {{- tpl (toYaml .Values.queryFrontend.extraInitContainers) . | nindent 8 }}
-      {{- end }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "queryFrontend") | nindent 6 }}
       containers:
         - name: query-frontend
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -42,6 +45,8 @@ spec:
           {{- range .Values.queryFrontend.extraArgs }}
             - {{ . | quote }}
           {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "queryFrontend") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "queryFrontend") | nindent 10 }}
           ports:
             - name: http
               containerPort: {{ .Values.queryFrontend.service.port }}
@@ -50,21 +55,28 @@ spec:
             - name: cache
               mountPath: /etc/thanos/cache.yaml
               subPath: cache.yaml
-          {{ include "thanos.extraMountItems" (dict "root" . "key" "queryFrontend") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "queryFrontend") | nindent 12 }}
           {{- else }}
-          {{ include "thanos.extraMountsBlock" (dict "root" . "key" "queryFrontend") | nindent 10 }}
+          {{- include "thanos.extraMountsBlock" (dict "root" . "key" "queryFrontend") | nindent 10 }}
           {{- end }}
-          {{ include "thanos.containerSC" (dict "root" . "key" "queryFrontend") | nindent 10 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "queryFrontend") | nindent 10 }}
           resources:
-{{ toYaml .Values.queryFrontend.resources | indent 12 }}
-          {{ include "thanos.httpProbes" (dict "root" . "key" "queryFrontend" "port" .Values.queryFrontend.service.port) | nindent 10 }}
+            {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "queryFrontend" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "queryFrontend" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "queryFrontend" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
       {{- if .Values.queryFrontend.cacheConfig }}
       volumes:
         - name: cache
           configMap:
             name: {{ include "thanos.compName" (list . "query-frontend") }}-cache
-      {{ include "thanos.extraVolumeItems" (dict "root" . "key" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.extraVolumeItems" (dict "root" . "key" "queryFrontend") | nindent 6 }}
       {{- else }}
-      {{ include "thanos.extraVolumesBlock" (dict "root" . "key" "queryFrontend") | nindent 6 }}
+      {{- include "thanos.extraVolumesBlock" (dict "root" . "key" "queryFrontend") | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/thanos/templates/query-frontend/hpa.yaml
+++ b/charts/thanos/templates/query-frontend/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query-frontend/ingress.yaml
+++ b/charts/thanos/templates/query-frontend/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.queryFrontend.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.queryFrontend.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 spec:
   {{- with .Values.queryFrontend.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "query-frontend") }}
                 port:
-                  number: {{ $.Values.queryFrontend.service.port }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.queryFrontend.ingress.tls | indent 4 }}
+    {{- toYaml .Values.queryFrontend.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/query-frontend/networkpolicy.yaml
+++ b/charts/thanos/templates/query-frontend/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.queryFrontend.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+  name: {{ include "thanos.compName" (list . "query-frontend") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/query-frontend/pdb.yaml
+++ b/charts/thanos/templates/query-frontend/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pdb.enabled }}
+{{- if and .Values.queryFrontend.enabled (or .Values.queryFrontend.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.queryFrontend.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.queryFrontend.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: query-frontend
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.queryFrontend.pdb.minAvailable }}
-  minAvailable: {{ .Values.queryFrontend.pdb.minAvailable | quote }}
-  {{- else if .Values.queryFrontend.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.queryFrontend.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/query-frontend/service.yaml
+++ b/charts/thanos/templates/query-frontend/service.yaml
@@ -4,9 +4,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.queryFrontend.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
+    {{- with .Values.queryFrontend.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.queryFrontend.service.type }}
   ports:

--- a/charts/thanos/templates/query-tls/deployment.yaml
+++ b/charts/thanos/templates/query-tls/deployment.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.queryTls.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+    {{- with .Values.queryTls.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.queryTls.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  replicas: {{ .Values.queryTls.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+      labels:
+        app.kubernetes.io/component: query-tls
+        {{- include "thanos.labels" . | nindent 8 }}
+    spec:
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      containers:
+        - args:
+            - query
+            {{- range .Values.queryTls.stores }}
+            - --endpoint={{ . }}
+            {{- end }}
+            - --grpc-address=0.0.0.0:{{ .Values.queryTls.service.grpcPort }}
+            {{- if .Values.queryTls.tls.ca }}
+            - --grpc-client-tls-ca={{ .Values.queryTls.tls.ca }}
+            {{- end }}
+            {{- if .Values.queryTls.tls.cert }}
+            - --grpc-client-tls-cert={{ .Values.queryTls.tls.cert }}
+            {{- end }}
+            {{- if .Values.queryTls.tls.key }}
+            - --grpc-client-tls-key={{ .Values.queryTls.tls.key }}
+            {{- end }}
+            - --grpc-client-tls-secure
+            - --http-address=0.0.0.0:{{ .Values.queryTls.service.httpPort }}
+            {{- range .Values.queryTls.replicaLabels }}
+            - --query.replica-label={{ . }}
+            {{- end }}
+            {{- range .Values.queryTls.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "queryTls") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "queryTls") | nindent 10 }}
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          name: query-tls
+          ports:
+            - containerPort: {{ .Values.queryTls.service.grpcPort }}
+              name: grpc
+            - containerPort: {{ .Values.queryTls.service.httpPort }}
+              name: http
+          {{- include "thanos.extraMountsBlock" (dict "root" . "key" "queryTls") | nindent 10 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "queryTls") | nindent 10 }}
+          resources:
+            {{- toYaml .Values.queryTls.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "queryTls" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "queryTls" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "queryTls" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "queryTls") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      {{- include "thanos.extraVolumesBlock" (dict "root" . "key" "queryTls") | nindent 6 }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/hpa.yaml
+++ b/charts/thanos/templates/query-tls/hpa.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.queryTls.enabled .Values.queryTls.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  maxReplicas: {{ .Values.queryTls.autoscaling.maxReplicas }}
+  metrics:
+    {{- $cpu := .Values.queryTls.autoscaling.targetCPUUtilizationPercentage }}
+    {{- $mem := .Values.queryTls.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if or $cpu $mem }}
+    {{- if $cpu }}
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: {{ $cpu }}
+          type: Utilization
+      type: Resource
+    {{- end }}
+    {{- if $mem }}
+    - resource:
+        name: memory
+        target:
+          averageUtilization: {{ $mem }}
+          type: Utilization
+      type: Resource
+    {{- end }}
+    {{- else }}
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    {{- end }}
+  minReplicas: {{ .Values.queryTls.autoscaling.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.queryTls.autoscaling.targetKind | default "Deployment" }}
+    name: {{ include "thanos.compName" (list . "query-tls") }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/networkpolicy.yaml
+++ b/charts/thanos/templates/query-tls/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.queryTls.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: query-tls
+    {{- include "thanos.labels" . | nindent 4 }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/query-tls/pdb.yaml
+++ b/charts/thanos/templates/query-tls/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.queryTls.enabled (or .Values.queryTls.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $maxUnavail := .Values.queryTls.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
+{{- $minAvail := .Values.queryTls.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  {{- if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
+  {{- else if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/service.yaml
+++ b/charts/thanos/templates/query-tls/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.queryTls.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+    {{- with .Values.queryTls.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.queryTls.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  ports:
+    - name: grpc
+      port: {{ .Values.queryTls.service.grpcPort }}
+      targetPort: grpc
+    - name: http
+      port: {{ .Values.queryTls.service.httpPort }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: query-tls
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  type: {{ .Values.queryTls.service.type }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/servicemonitor.yaml
+++ b/charts/thanos/templates/query-tls/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.queryTls.enabled (or .Values.queryTls.serviceMonitor.enabled .Values.global.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+  labels:
+    {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
+    {{- if .Values.queryTls.serviceMonitor.labels }}{{ toYaml .Values.queryTls.serviceMonitor.labels | nindent 4 }}{{- end }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  endpoints:
+    - interval: {{ default .Values.global.serviceMonitor.interval .Values.queryTls.serviceMonitor.interval | quote }}
+      {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.queryTls.serviceMonitor.metricRelabelings) }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      path: /metrics
+      port: http
+      {{- with (default .Values.global.serviceMonitor.relabelings .Values.queryTls.serviceMonitor.relabelings) }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.queryTls.serviceMonitor.scrapeTimeout | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: thanos
+{{- end }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - query
             - --http-address=0.0.0.0:{{ .Values.query.service.httpPort }}
             - --grpc-address=0.0.0.0:{{ .Values.query.service.grpcPort }}
+          {{- if .Values.queryTls.enabled }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "query-tls") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+          {{- end }}
           {{- if .Values.storegateway.enabled }}
             # - --endpoint={{ include "thanos.compName" (list . "storegateway") }}:{{ .Values.storegateway.service.grpcPort }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -4,9 +4,15 @@ kind: Deployment
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.query.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
+    {{- with .Values.query.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.query.replicaCount }}
   selector:
@@ -16,18 +22,15 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query
       annotations:
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{ include "thanos.podSC" (dict "root" . "key" "query") | nindent 6 }}
-      {{- if .Values.query.extraInitContainers }}
-      initContainers:
-        {{- tpl (toYaml .Values.query.extraInitContainers) . | nindent 8 }}
-      {{- end }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "query") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "query") | nindent 6 }}
       containers:
         - name: query
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -48,20 +51,29 @@ spec:
             - --query.replica-label={{ . }}
           {{- end }}
           {{- range .Values.query.stores }}
-            - --store={{ . }}
+            - --endpoint={{ . }}
           {{- end }}
           {{- range .Values.query.extraArgs }}
             - {{ . | quote }}
           {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "query") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "query") | nindent 10 }}
           ports:
             - name: http
               containerPort: {{ .Values.query.service.httpPort }}
             - name: grpc
               containerPort: {{ .Values.query.service.grpcPort }}
-          {{ include "thanos.extraMountsBlock" (dict "root" . "key" "query") | nindent 10 }}
-          {{ include "thanos.containerSC" (dict "root" . "key" "query") | nindent 10 }}
+          {{- include "thanos.extraMountsBlock" (dict "root" . "key" "query") | nindent 10 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "query") | nindent 10 }}
           resources:
-{{ toYaml .Values.query.resources | indent 12 }}
-          {{ include "thanos.httpProbes" (dict "root" . "key" "query" "port" .Values.query.service.httpPort) | nindent 10 }}
-      {{ include "thanos.extraVolumesBlock" (dict "root" . "key" "query") | nindent 6 }}
+            {{- toYaml .Values.query.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "query" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "query" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "query") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "query" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "query") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "query") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "query") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "query") | nindent 6 }}
+      {{- include "thanos.extraVolumesBlock" (dict "root" . "key" "query") | nindent 6 }}
 {{- end }}

--- a/charts/thanos/templates/query/hpa.yaml
+++ b/charts/thanos/templates/query/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query/ingress.yaml
+++ b/charts/thanos/templates/query/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.query.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
 spec:
   {{- with .Values.query.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "query") }}
                 port:
-                  number: {{ $.Values.query.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.query.ingress.tls | indent 4 }}
+    {{- toYaml .Values.query.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/query/networkpolicy.yaml
+++ b/charts/thanos/templates/query/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.query.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
+  name: {{ include "thanos.compName" (list . "query") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/query/pdb.yaml
+++ b/charts/thanos/templates/query/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.query.enabled .Values.query.pdb.enabled }}
+{{- if and .Values.query.enabled (or .Values.query.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.query.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.query.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: query
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.query.pdb.minAvailable }}
-  minAvailable: {{ .Values.query.pdb.minAvailable | quote }}
-  {{- else if .Values.query.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.query.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/query/service.yaml
+++ b/charts/thanos/templates/query/service.yaml
@@ -4,9 +4,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.query.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
+    {{- with .Values.query.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.query.service.type }}
   ports:

--- a/charts/thanos/templates/receive/configmap-hashrings.yaml
+++ b/charts/thanos/templates/receive/configmap-hashrings.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "receive-hashrings") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive-hashrings") | nindent 4 }}
 data:
   hashrings.json: |
-{{ include "thanos.receive.hashrings" . | nindent 4 }}
+    {{- include "thanos.receive.hashrings" . | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/receive/ingress.yaml
+++ b/charts/thanos/templates/receive/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.receive.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.receive.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
 spec:
   {{- with .Values.receive.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "receive") }}
                 port:
-                  number: {{ $.Values.receive.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.receive.ingress.tls | indent 4 }}
+    {{- toYaml .Values.receive.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/receive/networkpolicy.yaml
+++ b/charts/thanos/templates/receive/networkpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.receive.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
+  name: {{ include "thanos.compName" (list . "receive") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+        - port: remote-write
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: receive
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/receive/pdb.yaml
+++ b/charts/thanos/templates/receive/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.receive.enabled .Values.receive.pdb.enabled }}
+{{- if and .Values.receive.enabled (or .Values.receive.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.receive.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.receive.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: receive
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.receive.pdb.minAvailable }}
-  minAvailable: {{ .Values.receive.pdb.minAvailable | quote }}
-  {{- else if .Values.receive.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.receive.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -4,9 +4,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.receive.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
+    {{- with .Values.receive.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.receive.service.type }}
   ports:
@@ -25,9 +31,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}-headless
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.receive.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
+    {{- with .Values.receive.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -4,9 +4,15 @@ kind: StatefulSet
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.receive.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
+    {{- with .Values.receive.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   serviceName: {{ include "thanos.receiveHeadless" . }}
   replicas: {{ .Values.receive.replicaCount }}
@@ -17,23 +23,21 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: receive
       annotations:
-{{- $anns := dict -}}
-{{- if .Values.global.podAnnotations }}
-{{- $anns = merge $anns .Values.global.podAnnotations -}}
-{{- end }}
-{{- $_ := set $anns "checksum/hashrings" (include "thanos.receive.hashrings" . | sha256sum) -}}
-{{ toYaml $anns | nindent 8 }}
+        {{- $anns := dict -}}
+        {{- if .Values.global.podAnnotations }}
+        {{- $anns = merge $anns .Values.global.podAnnotations -}}
+        {{- end }}
+        {{- $_ := set $anns "checksum/hashrings" (include "thanos.receive.hashrings" . | sha256sum) -}}
+        {{- $_ := set $anns "checksum/objstore-configuration" (.Values.global.objstore.config | sha256sum) -}}
+        {{- toYaml $anns | nindent 8 }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{ include "thanos.podSC" (dict "root" . "key" "receive") | nindent 6 }}
-      {{- if .Values.receive.extraInitContainers }}
-      initContainers:
-        {{- tpl (toYaml .Values.receive.extraInitContainers) . | nindent 8 }}
-      {{- end }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "receive") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "receive") | nindent 6 }}
       containers:
         - name: receive
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -61,13 +65,6 @@ spec:
             {{- range .Values.receive.extraArgs }}
             - {{ . | quote }}
             {{- end }}
-          ports:
-            - name: grpc
-              containerPort: {{ .Values.receive.service.grpcPort }}
-            - name: http
-              containerPort: {{ default 10902 .Values.receive.service.httpPort }}
-            - name: remote-write
-              containerPort: {{ .Values.receive.service.remoteWritePort }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -81,17 +78,33 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- include "thanos.extraEnvItems" (dict "Values" .Values "component" "receive") | nindent 12 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "receive") | nindent 10 }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.receive.service.grpcPort }}
+            - name: http
+              containerPort: {{ default 10902 .Values.receive.service.httpPort }}
+            - name: remote-write
+              containerPort: {{ .Values.receive.service.remoteWritePort }}
           volumeMounts:
             - name: data
               mountPath: /var/thanos/receive
             - name: thanos-config
               mountPath: /etc/thanos
               readOnly: true
-{{ include "thanos.extraMountItems" (dict "root" . "key" "receive") | nindent 10 }}
-{{ include "thanos.containerSC" (dict "root" . "key" "receive") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "receive") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "receive") | nindent 10 }}
           resources:
-{{ toYaml (.Values.receive.resources | default dict) | indent 12 }}
-{{ include "thanos.httpProbes" (dict "root" . "key" "receive" "port" (default 10902 .Values.receive.service.httpPort)) | nindent 10 }}
+            {{- toYaml (.Values.receive.resources | default dict) | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "receive" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "receive") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "receive") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "receive") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "receive") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "receive") | nindent 6 }}
       volumes:
         - name: thanos-config
           projected:
@@ -110,7 +123,7 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
-{{ include "thanos.extraVolumeItems" (dict "root" . "key" "receive") | nindent 6 }}
+        {{- include "thanos.extraVolumeItems" (dict "root" . "key" "receive") | nindent 8 }}
   {{- if .Values.receive.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/thanos/templates/receive/vpa.yaml
+++ b/charts/thanos/templates/receive/vpa.yaml
@@ -4,7 +4,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
+++ b/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-am
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-am") | nindent 4 }}
 data:
   alertmanagers.yaml: |
-{{ toYaml (tpl .Values.ruler.alertmanagers.config .) | indent 4 }}
+    {{- toYaml (tpl .Values.ruler.alertmanagers.config .) | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/ruler/configmap-query.yaml
+++ b/charts/thanos/templates/ruler/configmap-query.yaml
@@ -4,16 +4,16 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-query
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-query") | nindent 4 }}
 data:
   query-urls.yaml: |
     query:
       urls:
-{{- if .Values.ruler.query.urls }}
-{{ toYaml .Values.ruler.query.urls | indent 8 }}
-{{- else }}
+        {{- if .Values.ruler.query.urls }}
+        {{- toYaml .Values.ruler.query.urls | nindent 8 }}
+        {{- else }}
         - http://{{ include "thanos.compName" (list . "query") }}:{{ .Values.query.service.httpPort }}
-{{- end }}
+        {{- end }}
 {{- end }}

--- a/charts/thanos/templates/ruler/configmaprules.yaml
+++ b/charts/thanos/templates/ruler/configmaprules.yaml
@@ -4,12 +4,12 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-rules
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-rules") | nindent 4 }}
 data:
 {{- range $fname, $content := .Values.ruler.rules }}
   {{ $fname }}: |
-{{ toYaml (tpl $content $) | indent 4 }}
+    {{- toYaml (tpl $content $) | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/thanos/templates/ruler/ingress.yaml
+++ b/charts/thanos/templates/ruler/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.ruler.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.ruler.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
 spec:
   {{- with .Values.ruler.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "ruler") }}
                 port:
-                  number: {{ $.Values.ruler.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.ruler.ingress.tls | indent 4 }}
+    {{- toYaml .Values.ruler.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/ruler/networkpolicy.yaml
+++ b/charts/thanos/templates/ruler/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.ruler.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+  name: {{ include "thanos.compName" (list . "ruler") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/ruler/pdb.yaml
+++ b/charts/thanos/templates/ruler/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.ruler.enabled .Values.ruler.pdb.enabled }}
+{{- if and .Values.ruler.enabled (or .Values.ruler.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.ruler.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.ruler.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: ruler
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.ruler.pdb.minAvailable }}
-  minAvailable: {{ .Values.ruler.pdb.minAvailable | quote }}
-  {{- else if .Values.ruler.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.ruler.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ruler.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thanos.compName" (list . "ruler") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.ruler.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
+    {{- with .Values.ruler.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.ruler.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.ruler.service.httpPort }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -4,9 +4,15 @@ kind: StatefulSet
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.ruler.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
+    {{- with .Values.ruler.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   serviceName: {{ include "thanos.compName" (list . "ruler") }}
   replicas: {{ .Values.ruler.replicaCount }}
@@ -17,18 +23,18 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: ruler
       annotations:
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
+        checksum/objstore-configuration: {{ .Values.global.objstore.config | sha256sum }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{ include "thanos.podSC" (dict "root" . "key" "ruler") | nindent 6 }}
-      {{- if .Values.ruler.extraInitContainers }}
-      initContainers:
-        {{- tpl (toYaml .Values.ruler.extraInitContainers) . | nindent 8 }}
-      {{- end }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "ruler") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "ruler") | nindent 6 }}
       containers:
         - name: ruler
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -49,6 +55,8 @@ spec:
           {{- range .Values.ruler.extraArgs }}
             - {{ . | quote }}
           {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "ruler") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "ruler") | nindent 10 }}
           ports:
             - name: http
               containerPort: {{ .Values.ruler.service.httpPort }}
@@ -67,11 +75,11 @@ spec:
             - name: query
               mountPath: /etc/thanos/query-urls.yaml
               subPath: query-urls.yaml
-          {{ include "thanos.extraMountItems" (dict "root" . "key" "ruler") | nindent 10 }}
-          {{ include "thanos.containerSC" (dict "root" . "key" "ruler") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "ruler") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "ruler") | nindent 10 }}
           resources:
-{{ toYaml .Values.ruler.resources | indent 12 }}
-          {{ include "thanos.httpProbes" (dict "root" . "key" "ruler" "port" .Values.ruler.service.httpPort) | nindent 10 }}
+            {{- toYaml .Values.ruler.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "ruler" "port" "http") | nindent 10 }}
 
         {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
         - name: prometheus-rule-importer
@@ -86,7 +94,13 @@ spec:
             - name: rule-importer-script
               mountPath: /scripts
         {{- end }}
-
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "ruler" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "ruler") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "ruler" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "ruler") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "ruler") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "ruler") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       volumes:
         - name: rules
           configMap:
@@ -113,7 +127,7 @@ spec:
           emptyDir: {}
       {{- end }}
 
-      {{ include "thanos.extraVolumeItems" (dict "root" . "key" "ruler") | nindent 6 }}
+      {{- include "thanos.extraVolumeItems" (dict "root" . "key" "ruler") | nindent 6 }}
 
   {{- if .Values.ruler.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/thanos/templates/rustfs/init-bucket.yaml
+++ b/charts/thanos/templates/rustfs/init-bucket.yaml
@@ -8,7 +8,7 @@ kind: Job
 metadata:
   name: {{ include "thanos.compName" (list . "init-bucket") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
 spec:
   backoffLimit: 10
   template:

--- a/charts/thanos/templates/serviceaccount.yaml
+++ b/charts/thanos/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "thanos.serviceAccountName" . }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.global.serviceAccount.annotations | indent 4 }}
+    {{- toYaml .Values.global.serviceAccount.annotations | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/storegateway/configmap-caching.yaml
+++ b/charts/thanos/templates/storegateway/configmap-caching.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}-caching
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway-caching") | nindent 4 }}
 data:
   caching-bucket.yaml: |
-{{ toYaml (tpl .Values.storegateway.cachingBucketConfig .) | indent 4 }}
+    {{- toYaml (tpl .Values.storegateway.cachingBucketConfig .) | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/storegateway/hpa.yaml
+++ b/charts/thanos/templates/storegateway/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/storegateway/ingress.yaml
+++ b/charts/thanos/templates/storegateway/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.storegateway.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.storegateway.ingress.annotations | nindent 4 }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway") | nindent 4 }}
 spec:
   {{- with .Values.storegateway.ingress.className }}
@@ -24,9 +24,9 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "storegateway") }}
                 port:
-                  number: {{ $.Values.storegateway.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:
-{{ toYaml .Values.storegateway.ingress.tls | indent 4 }}
+    {{- toYaml .Values.storegateway.ingress.tls | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/storegateway/networkpolicy.yaml
+++ b/charts/thanos/templates/storegateway/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.storegateway.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+  name: {{ include "thanos.compName" (list . "storegateway") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: storegateway
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/storegateway/pdb.yaml
+++ b/charts/thanos/templates/storegateway/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.storegateway.enabled .Values.storegateway.pdb.enabled }}
+{{- if and .Values.storegateway.enabled (or .Values.storegateway.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.storegateway.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.storegateway.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway") | nindent 4 }}
 spec:
@@ -12,9 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: storegateway
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.storegateway.pdb.minAvailable }}
-  minAvailable: {{ .Values.storegateway.pdb.minAvailable | quote }}
-  {{- else if .Values.storegateway.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.storegateway.pdb.maxUnavailable | quote }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/storegateway/service.yaml
+++ b/charts/thanos/templates/storegateway/service.yaml
@@ -4,9 +4,15 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.storegateway.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway") | nindent 4 }}
+    {{- with .Values.storegateway.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.storegateway.service.type }}
   ports:

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -4,9 +4,15 @@ kind: StatefulSet
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   labels:
-{{ include "thanos.labels" . | indent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.storegateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway") | nindent 4 }}
+    {{- with .Values.storegateway.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   serviceName: {{ include "thanos.compName" (list . "storegateway") }}
   replicas: {{ .Values.storegateway.replicaCount }}
@@ -17,18 +23,18 @@ spec:
   template:
     metadata:
       labels:
-{{ include "thanos.labels" . | indent 8 }}
+        {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: storegateway
       annotations:
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
+        checksum/objstore-configuration: {{ .Values.global.objstore.config | sha256sum }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{ include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{ include "thanos.podSC" (dict "root" . "key" "storegateway") | nindent 6 }}
-      {{- if .Values.storegateway.extraInitContainers }}
-      initContainers:
-        {{- tpl (toYaml .Values.storegateway.extraInitContainers) . | nindent 8 }}
-      {{- end }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "storegateway") | nindent 6 }}
       containers:
         - name: storegateway
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
@@ -45,6 +51,8 @@ spec:
           {{- range .Values.storegateway.extraArgs }}
             - {{ . | quote }}
           {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "storegateway") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "storegateway") | nindent 10 }}
           ports:
             - name: grpc
               containerPort: {{ .Values.storegateway.service.grpcPort }}
@@ -61,11 +69,18 @@ spec:
               mountPath: /etc/thanos/caching-bucket.yaml
               subPath: caching-bucket.yaml
           {{- end }}
-          {{ include "thanos.extraMountItems" (dict "root" . "key" "storegateway") | nindent 10 }}
-          {{ include "thanos.containerSC" (dict "root" . "key" "storegateway") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "storegateway") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "storegateway") | nindent 10 }}
           resources:
-{{ toYaml .Values.storegateway.resources | indent 12 }}
-          {{ include "thanos.httpProbes" (dict "root" . "key" "storegateway" "port" .Values.storegateway.service.httpPort) | nindent 10 }}
+            {{- toYaml .Values.storegateway.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "storegateway" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "storegateway" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "storegateway" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
       volumes:
         - name: objstore
           secret:
@@ -82,7 +97,7 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
-      {{ include "thanos.extraVolumeItems" (dict "root" . "key" "storegateway") | nindent 6 }}
+        {{- include "thanos.extraVolumeItems" (dict "root" . "key" "storegateway") | nindent 8 }}
   {{- if .Values.storegateway.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -331,14 +331,28 @@
                   "description": "Maximum unavailable Bucketweb pods during a disruption.",
                   "required": [],
                   "title": "maxUnavailable",
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "minAvailable": {
                   "default": "",
                   "description": "Minimum available Bucketweb pods during a disruption.",
                   "required": [],
                   "title": "minAvailable",
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -414,11 +428,18 @@
                       "type": "integer"
                     },
                     "port": {
-                      "default": 10902,
+                      "default": "http",
                       "description": "Port checked by the liveness probe.",
                       "required": [],
                       "title": "port",
-                      "type": "integer"
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "successThreshold": {
                       "default": 1,
@@ -488,11 +509,18 @@
                       "type": "integer"
                     },
                     "port": {
-                      "default": 10902,
+                      "default": "http",
                       "description": "Port checked by the readiness probe.",
                       "required": [],
                       "title": "port",
-                      "type": "integer"
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "successThreshold": {
                       "default": 1,
@@ -562,11 +590,18 @@
                       "type": "integer"
                     },
                     "port": {
-                      "default": 10902,
+                      "default": "http",
                       "description": "Port checked by the startup probe.",
                       "required": [],
                       "title": "port",
-                      "type": "integer"
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "successThreshold": {
                       "default": 1,
@@ -764,6 +799,13 @@
               "required": [],
               "title": "topologySpreadConstraints",
               "type": "array"
+            },
+            "dnsConfig": {
+              "additionalProperties": true,
+              "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+              "required": [],
+              "title": "dnsConfig",
+              "type": "object"
             }
           },
           "required": [
@@ -777,6 +819,7 @@
             "resources",
             "podSecurityContext",
             "containerSecurityContext",
+            "dnsConfig",
             "extraEnv",
             "extraEnvFrom",
             "extraInitContainers",
@@ -1110,14 +1153,28 @@
               "description": "Maximum unavailable Compactor pods during a disruption.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum available Compactor pods during a disruption.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -1253,11 +1310,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Compactor liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -1327,11 +1391,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Compactor readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -1401,11 +1472,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Compactor startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -1691,6 +1769,13 @@
           ],
           "title": "vpa",
           "type": "object"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
         }
       },
       "required": [
@@ -1705,6 +1790,7 @@
         "resources",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraEnv",
         "extraEnvFrom",
         "extraInitContainers",
@@ -1809,6 +1895,13 @@
             "runAsNonRoot"
           ],
           "title": "containerSecurityContext",
+          "type": "object"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration applied to every pod. Component-level values override this.",
+          "required": [],
+          "title": "dnsConfig",
           "type": "object"
         },
         "extraContainers": {
@@ -1973,14 +2066,28 @@
               "description": "Maximum number of unavailable pods during a disruption.\nCannot be set at the same time as minAvailable.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum number of available pods during a disruption.\nCannot be set at the same time as maxUnavailable.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -2329,6 +2436,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "networkPolicies": {
+          "default": false,
+          "description": "Create a NetworkPolicy for every enabled component. When true each component gets a NetworkPolicy that allows ingress on its service ports from within the namespace and permits all egress.",
+          "required": [],
+          "title": "networkPolicies",
+          "type": "boolean"
         }
       },
       "required": [
@@ -2339,10 +2453,12 @@
         "podAnnotations",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraVolumes",
         "extraVolumeMounts",
         "resources",
         "nodeSelector",
+        "networkPolicies",
         "tolerations",
         "affinity",
         "topologySpreadConstraints",
@@ -2756,14 +2872,28 @@
               "description": "Maximum unavailable Query pods during a disruption.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum available Query pods during a disruption.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -2832,11 +2962,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -2906,11 +3043,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -2980,11 +3124,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3214,6 +3365,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
         }
       },
       "required": [
@@ -3230,6 +3388,7 @@
         "resources",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraEnv",
         "extraEnvFrom",
         "extraInitContainers",
@@ -3589,14 +3748,28 @@
               "description": "Maximum unavailable Query Frontend pods during a disruption.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum available Query Frontend pods during a disruption.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -3665,11 +3838,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query Frontend liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3739,11 +3919,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query Frontend readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3813,11 +4000,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query Frontend startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -4015,6 +4209,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
         }
       },
       "required": [
@@ -4030,6 +4231,7 @@
         "extraArgs",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraEnv",
         "extraEnvFrom",
         "extraInitContainers",
@@ -4201,7 +4403,7 @@
               "properties": {
                 "enabled": {
                   "default": true,
-                  "description": "Auto-generate a single default hashring whose endpoints are derived\nfrom the StatefulSet pod DNS names:\n`\u003cpod-0\u003e.\u003cheadless-svc\u003e:10901 ... \u003cpod-N\u003e.\u003cheadless-svc\u003e:10901`.",
+                  "description": "Auto-generate a single default hashring whose endpoints are derived\nfrom the StatefulSet pod DNS names:\n`<pod-0>.<headless-svc>:10901 ... <pod-N>.<headless-svc>:10901`.",
                   "required": [],
                   "title": "enabled",
                   "type": "boolean"
@@ -4418,14 +4620,28 @@
               "description": "Maximum unavailable Receive pods during a disruption.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum available Receive pods during a disruption.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -4561,11 +4777,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Receive liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -4635,11 +4858,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Receive readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -4709,11 +4939,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Receive startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5048,6 +5285,13 @@
           ],
           "title": "vpa",
           "type": "object"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
         }
       },
       "required": [
@@ -5066,6 +5310,7 @@
         "extraArgs",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraEnv",
         "extraEnvFrom",
         "extraInitContainers",
@@ -5457,14 +5702,28 @@
               "description": "Maximum unavailable Ruler pods during a disruption.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum available Ruler pods during a disruption.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -5600,11 +5859,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Ruler liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5674,11 +5940,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Ruler readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5748,11 +6021,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Ruler startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5987,6 +6267,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
         }
       },
       "required": [
@@ -6005,6 +6292,7 @@
         "extraArgs",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraEnv",
         "extraEnvFrom",
         "extraInitContainers",
@@ -6497,14 +6785,28 @@
               "description": "Maximum unavailable Store Gateway pods during a disruption.",
               "required": [],
               "title": "maxUnavailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "minAvailable": {
               "default": "",
               "description": "Minimum available Store Gateway pods during a disruption.",
               "required": [],
               "title": "minAvailable",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "required": [
@@ -6640,11 +6942,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Store Gateway liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -6714,11 +7023,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Store Gateway readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -6788,11 +7104,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Store Gateway startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -6998,6 +7321,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
         }
       },
       "required": [
@@ -7014,6 +7344,7 @@
         "extraArgs",
         "podSecurityContext",
         "containerSecurityContext",
+        "dnsConfig",
         "extraEnv",
         "extraEnvFrom",
         "extraInitContainers",

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -7364,6 +7364,756 @@
       ],
       "title": "storegateway",
       "type": "object"
+    },
+    "queryTls": {
+      "additionalProperties": true,
+      "description": "Query TLS component — TLS-enabled Query for reaching remote gRPC Store API endpoints.",
+      "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "description": "Affinity rules for Query pod scheduling.",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Extra annotations applied to Query resources.",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "autoscaling": {
+          "additionalProperties": true,
+          "description": "HorizontalPodAutoscaler configuration for the Query component.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable HorizontalPodAutoscaler for the Query component.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxReplicas": {
+              "default": 5,
+              "description": "Maximum number of Query replicas.",
+              "required": [],
+              "title": "maxReplicas",
+              "type": "integer"
+            },
+            "minReplicas": {
+              "default": 2,
+              "description": "Minimum number of Query replicas.",
+              "required": [],
+              "title": "minReplicas",
+              "type": "integer"
+            },
+            "targetCPUUtilizationPercentage": {
+              "default": 80,
+              "description": "Target CPU utilisation percentage for Query autoscaling.",
+              "required": [],
+              "title": "targetCPUUtilizationPercentage",
+              "type": "integer"
+            },
+            "targetMemoryUtilizationPercentage": {
+              "default": "null",
+              "description": "Target memory utilisation percentage for Query autoscaling. Null disables memory-based scaling.",
+              "required": [],
+              "title": "targetMemoryUtilizationPercentage",
+              "type": "null"
+            }
+          },
+          "required": [
+            "enabled",
+            "minReplicas",
+            "maxReplicas",
+            "targetCPUUtilizationPercentage",
+            "targetMemoryUtilizationPercentage"
+          ],
+          "title": "autoscaling",
+          "type": "object"
+        },
+        "containerSecurityContext": {
+          "additionalProperties": true,
+          "description": "Container security context for Query. Overrides global.containerSecurityContext.",
+          "required": [],
+          "title": "containerSecurityContext",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable the Query Deployment.",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "extraArgs": {
+          "description": "Additional CLI arguments appended to the `thanos query` command.",
+          "items": {
+            "anyOf": [
+              {
+                "required": [],
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "required": [],
+          "title": "extraArgs",
+          "type": "array"
+        },
+        "extraContainers": {
+          "description": "Extra sidecar containers for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraContainers",
+          "type": "array"
+        },
+        "extraEnv": {
+          "description": "Extra environment variables injected into the Query container.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraEnv",
+          "type": "array"
+        },
+        "extraEnvFrom": {
+          "description": "Extra environment variable sources for the Query container.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraEnvFrom",
+          "type": "array"
+        },
+        "extraInitContainers": {
+          "description": "Extra init containers for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraInitContainers",
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "description": "Extra volume mounts for the Query container.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraVolumeMounts",
+          "type": "array"
+        },
+        "extraVolumes": {
+          "description": "Extra volumes for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraVolumes",
+          "type": "array"
+        },
+        "labels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Query resources.",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "nodeSelector": {
+          "additionalProperties": true,
+          "description": "Node selector for Query pod scheduling.",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
+        },
+        "pdb": {
+          "additionalProperties": true,
+          "description": "PodDisruptionBudget configuration for the Query component.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable a PodDisruptionBudget for Query.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "default": "",
+              "description": "Maximum unavailable Query pods during a disruption.",
+              "required": [],
+              "title": "maxUnavailable",
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "minAvailable": {
+              "default": "",
+              "description": "Minimum available Query pods during a disruption.",
+              "required": [],
+              "title": "minAvailable",
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "enabled",
+            "minAvailable",
+            "maxUnavailable"
+          ],
+          "title": "pdb",
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "additionalProperties": true,
+          "description": "Pod security context for Query pods. Overrides global.podSecurityContext.",
+          "required": [],
+          "title": "podSecurityContext",
+          "type": "object"
+        },
+        "priorityClassName": {
+          "default": "",
+          "description": "Priority class name for Query pods.",
+          "required": [],
+          "title": "priorityClassName",
+          "type": "string"
+        },
+        "probes": {
+          "additionalProperties": true,
+          "description": "Health and readiness probe configuration for the Query component.",
+          "properties": {
+            "liveness": {
+              "additionalProperties": true,
+              "description": "Liveness probe for the Query component.",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Enable the liveness probe for Query.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "default": 6,
+                  "description": "Consecutive failures before the Query container is restarted.",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "default": 30,
+                  "description": "Seconds to wait before starting the Query liveness probe.",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/-/healthy",
+                  "description": "HTTP path checked by the Query liveness probe.",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 10,
+                  "description": "How often (seconds) to run the Query liveness probe.",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "port": {
+                  "default": "http",
+                  "description": "Port checked by the Query liveness probe.",
+                  "required": [],
+                  "title": "port",
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Consecutive successes before the Query container is considered live.",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "default": 5,
+                  "description": "Seconds after which the Query liveness probe times out.",
+                  "required": [],
+                  "title": "timeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled",
+                "path",
+                "port",
+                "initialDelaySeconds",
+                "periodSeconds",
+                "timeoutSeconds",
+                "failureThreshold",
+                "successThreshold"
+              ],
+              "title": "liveness",
+              "type": "object"
+            },
+            "readiness": {
+              "additionalProperties": true,
+              "description": "Readiness probe for the Query component.",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Enable the readiness probe for Query.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "default": 6,
+                  "description": "Consecutive failures before the Query pod is marked not-ready.",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "default": 5,
+                  "description": "Seconds to wait before starting the Query readiness probe.",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/-/ready",
+                  "description": "HTTP path checked by the Query readiness probe.",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 10,
+                  "description": "How often (seconds) to run the Query readiness probe.",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "port": {
+                  "default": "http",
+                  "description": "Port checked by the Query readiness probe.",
+                  "required": [],
+                  "title": "port",
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Consecutive successes before the Query pod is marked ready.",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "default": 5,
+                  "description": "Seconds after which the Query readiness probe times out.",
+                  "required": [],
+                  "title": "timeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled",
+                "path",
+                "port",
+                "initialDelaySeconds",
+                "periodSeconds",
+                "timeoutSeconds",
+                "failureThreshold",
+                "successThreshold"
+              ],
+              "title": "readiness",
+              "type": "object"
+            },
+            "startup": {
+              "additionalProperties": true,
+              "description": "Startup probe for the Query component.",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Enable the startup probe for Query.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "default": 60,
+                  "description": "Consecutive failures during Query startup before the container is killed.",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "default": 0,
+                  "description": "Seconds to wait before starting the Query startup probe.",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/-/ready",
+                  "description": "HTTP path checked by the Query startup probe.",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 5,
+                  "description": "How often (seconds) to run the Query startup probe.",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "port": {
+                  "default": "http",
+                  "description": "Port checked by the Query startup probe.",
+                  "required": [],
+                  "title": "port",
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Consecutive successes before the Query startup probe is considered passed.",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "default": 5,
+                  "description": "Seconds after which the Query startup probe times out.",
+                  "required": [],
+                  "title": "timeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled",
+                "path",
+                "port",
+                "initialDelaySeconds",
+                "periodSeconds",
+                "timeoutSeconds",
+                "failureThreshold",
+                "successThreshold"
+              ],
+              "title": "startup",
+              "type": "object"
+            }
+          },
+          "required": [
+            "readiness",
+            "liveness",
+            "startup"
+          ],
+          "title": "probes",
+          "type": "object"
+        },
+        "replicaCount": {
+          "default": 2,
+          "description": "Number of Query pod replicas. Two or more is recommended for HA.",
+          "required": [],
+          "title": "replicaCount",
+          "type": "integer"
+        },
+        "replicaLabels": {
+          "description": "Label names that identify replica identity for result deduplication.",
+          "items": {
+            "anyOf": [
+              {
+                "required": [],
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "required": [],
+          "title": "replicaLabels",
+          "type": "array"
+        },
+        "resources": {
+          "additionalProperties": true,
+          "description": "Resource requests and limits for the Query container.",
+          "required": [],
+          "title": "resources",
+          "type": "object"
+        },
+        "service": {
+          "additionalProperties": true,
+          "description": "Kubernetes Service configuration for the Query component.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Query Service.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "grpcPort": {
+              "default": 10901,
+              "description": "gRPC Store API port exposed by the Query Service.",
+              "required": [],
+              "title": "grpcPort",
+              "type": "integer"
+            },
+            "httpPort": {
+              "default": 9090,
+              "description": "HTTP/PromQL port exposed by the Query Service.",
+              "required": [],
+              "title": "httpPort",
+              "type": "integer"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Extra labels for the Query Service.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "type": {
+              "default": "ClusterIP",
+              "description": "Kubernetes Service type for the Query component.",
+              "required": [],
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "httpPort",
+            "grpcPort",
+            "annotations",
+            "labels"
+          ],
+          "title": "service",
+          "type": "object"
+        },
+        "serviceMonitor": {
+          "additionalProperties": true,
+          "description": "Prometheus Operator ServiceMonitor configuration for the Query component.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Query ServiceMonitor.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Enable a Prometheus Operator ServiceMonitor for Query.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "interval": {
+              "default": "",
+              "description": "Scrape interval for Query. Empty uses the Prometheus operator default.",
+              "required": [],
+              "title": "interval",
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Extra labels for the Query ServiceMonitor.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "metricRelabelings": {
+              "description": "Metric relabeling rules applied after Query metrics are ingested.",
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "metricRelabelings",
+              "type": "array"
+            },
+            "relabelings": {
+              "description": "Relabeling rules applied before Query metrics are ingested.",
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "relabelings",
+              "type": "array"
+            },
+            "scheme": {
+              "default": "",
+              "description": "Scrape scheme for Query (http or https).",
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "default": "",
+              "description": "Scrape timeout for Query. Empty uses the Prometheus operator default.",
+              "required": [],
+              "title": "scrapeTimeout",
+              "type": "string"
+            },
+            "tlsConfig": {
+              "additionalProperties": true,
+              "description": "TLS configuration for Query scraping.",
+              "required": [],
+              "title": "tlsConfig",
+              "type": "object"
+            }
+          },
+          "required": [
+            "enabled",
+            "labels",
+            "annotations",
+            "interval",
+            "scrapeTimeout",
+            "scheme",
+            "tlsConfig",
+            "relabelings",
+            "metricRelabelings"
+          ],
+          "title": "serviceMonitor",
+          "type": "object"
+        },
+        "stores": {
+          "description": "List of gRPC Store API endpoints that Query should connect to.\nIn-chart components (Receive, Store Gateway, Ruler) are wired automatically.\nAdd external Prometheus sidecars or remote store gateways here.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "stores",
+          "type": "array"
+        },
+        "tolerations": {
+          "description": "Tolerations for Query pod scheduling.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "topologySpreadConstraints",
+          "type": "array"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
+        },
+        "tls": {
+          "additionalProperties": true,
+          "description": "TLS client configuration for outbound gRPC connections.",
+          "properties": {
+            "cert": {
+              "default": "",
+              "description": "Path to the TLS client certificate file (PEM).",
+              "required": [],
+              "title": "cert",
+              "type": "string"
+            },
+            "key": {
+              "default": "",
+              "description": "Path to the TLS client private key file (PEM).",
+              "required": [],
+              "title": "key",
+              "type": "string"
+            },
+            "ca": {
+              "default": "",
+              "description": "Path to the CA certificate file used to verify the remote endpoint.",
+              "required": [],
+              "title": "ca",
+              "type": "string"
+            }
+          },
+          "required": [
+            "cert",
+            "key",
+            "ca"
+          ],
+          "title": "tls",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enabled",
+        "replicaCount",
+        "service",
+        "autoscaling",
+        "stores",
+        "replicaLabels",
+        "extraArgs",
+        "resources",
+        "podSecurityContext",
+        "containerSecurityContext",
+        "dnsConfig",
+        "extraEnv",
+        "extraEnvFrom",
+        "extraInitContainers",
+        "extraContainers",
+        "probes",
+        "nodeSelector",
+        "tolerations",
+        "affinity",
+        "topologySpreadConstraints",
+        "priorityClassName",
+        "extraVolumes",
+        "extraVolumeMounts",
+        "annotations",
+        "labels",
+        "serviceMonitor",
+        "pdb",
+        "tls"
+      ],
+      "title": "queryTls",
+      "type": "object"
     }
   },
   "required": [
@@ -7371,6 +8121,7 @@
     "bucket",
     "compactor",
     "query",
+    "queryTls",
     "queryFrontend",
     "storegateway",
     "receive",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1046,6 +1046,237 @@ query:
     maxUnavailable: ""
 
 # ======================================================================
+# Query TLS component
+# A second Query tier that connects to remote Store API endpoints
+# over TLS. The plain Query automatically fans out to this component,
+# so users only need to point Grafana at the plain Query.
+# ======================================================================
+# Query TLS component — TLS-enabled Query for reaching remote gRPC Store API endpoints.
+queryTls:
+  # -- Enable the Query TLS Deployment. When enabled, the plain Query
+  # automatically adds Query TLS as an endpoint.
+  enabled: false
+
+  # -- Number of Query TLS pod replicas.
+  replicaCount: 2
+
+  # Kubernetes Service configuration for Query TLS.
+  service:
+    # -- Extra annotations for the Query TLS Service.
+    # @default -- {}
+    annotations: {}
+    # -- gRPC Store API port exposed by the Query TLS Service.
+    grpcPort: 10901
+    # -- HTTP/PromQL port exposed by the Query TLS Service.
+    httpPort: 9090
+    # -- Extra labels for the Query TLS Service.
+    # @default -- {}
+    labels: {}
+    # -- Kubernetes Service type for Query TLS.
+    type: ClusterIP
+
+  # HorizontalPodAutoscaler configuration for Query TLS.
+  autoscaling:
+    # -- Enable HorizontalPodAutoscaler for Query TLS.
+    enabled: false
+    # -- Maximum number of Query TLS replicas.
+    maxReplicas: 5
+    # -- Minimum number of Query TLS replicas.
+    minReplicas: 2
+    # -- Target CPU utilisation percentage for Query TLS autoscaling.
+    targetCPUUtilizationPercentage: 80
+    # -- Target memory utilisation percentage for Query TLS autoscaling. Null disables memory-based scaling.
+    targetMemoryUtilizationPercentage: null
+
+  # -- List of remote gRPC Store API endpoints that require TLS.
+  # Unlike plain Query, no in-chart components are wired automatically.
+  # @default -- []
+  stores: []
+  # Example:
+  # stores:
+  #   - thanos-gateway.remote-cluster.example.com:443
+  #   - dnssrv+_grpc._tcp.thanos-storegateway.remote.svc.cluster.local
+
+  # -- Label names that identify replica identity for result deduplication.
+  replicaLabels:
+    - prometheus_replica
+
+  # Additional CLI arguments appended to the `thanos query` command.
+  # Note: --grpc-client-tls-secure is always added automatically.
+  extraArgs:
+    - --log.level=info
+
+  # TLS client configuration for outbound gRPC connections.
+  tls:
+    # -- Path to the CA certificate file used to verify the remote endpoint.
+    # Leave empty to use the system trust store.
+    ca: ""
+    # -- Path to the TLS client certificate file (PEM).
+    # Leave empty when the remote endpoint uses a publicly trusted CA.
+    cert: ""
+    # -- Path to the TLS client private key file (PEM).
+    key: ""
+
+  # -- Resource requests and limits for the Query TLS container.
+  # @default -- {}
+  resources: {}
+
+  # -- Pod security context for Query TLS pods. Overrides global.podSecurityContext.
+  # @default -- {}
+  podSecurityContext: {}
+
+  # -- Container security context for Query TLS. Overrides global.containerSecurityContext.
+  # @default -- {}
+  containerSecurityContext: {}
+
+  # -- DNS configuration for Query TLS pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
+  # -- Extra environment variables injected into the Query TLS container.
+  # @default -- []
+  extraEnv: []
+
+  # -- Extra environment variable sources for the Query TLS container.
+  # @default -- []
+  extraEnvFrom: []
+
+  # -- Extra init containers for Query TLS pods.
+  # @default -- []
+  extraInitContainers: []
+
+  # -- Extra sidecar containers for Query TLS pods.
+  # @default -- []
+  extraContainers: []
+
+  # Health and readiness probe configuration for the Query TLS component.
+  probes:
+    # Readiness probe for the Query TLS component.
+    readiness:
+      # -- Enable the readiness probe for Query TLS.
+      enabled: true
+      # -- HTTP path checked by the Query TLS readiness probe.
+      path: /-/ready
+      # -- (int or string) Port checked by the Query TLS readiness probe.
+      port: http
+      # -- Seconds to wait before starting the Query TLS readiness probe.
+      initialDelaySeconds: 5
+      # -- How often (seconds) to run the Query TLS readiness probe.
+      periodSeconds: 10
+      # -- Seconds after which the Query TLS readiness probe times out.
+      timeoutSeconds: 5
+      # -- Consecutive failures before the Query TLS pod is marked not-ready.
+      failureThreshold: 6
+      # -- Consecutive successes before the Query TLS pod is marked ready.
+      successThreshold: 1
+    # Liveness probe for the Query TLS component.
+    liveness:
+      # -- Enable the liveness probe for Query TLS.
+      enabled: true
+      # -- HTTP path checked by the Query TLS liveness probe.
+      path: /-/healthy
+      # -- (int or string) Port checked by the Query TLS liveness probe.
+      port: http
+      # -- Seconds to wait before starting the Query TLS liveness probe.
+      initialDelaySeconds: 30
+      # -- How often (seconds) to run the Query TLS liveness probe.
+      periodSeconds: 10
+      # -- Seconds after which the Query TLS liveness probe times out.
+      timeoutSeconds: 5
+      # -- Consecutive failures before the Query TLS container is restarted.
+      failureThreshold: 6
+      # -- Consecutive successes before the Query TLS container is considered live.
+      successThreshold: 1
+    # Startup probe for the Query TLS component.
+    startup:
+      # -- Enable the startup probe for Query TLS.
+      enabled: true
+      # -- HTTP path checked by the Query TLS startup probe.
+      path: /-/ready
+      # -- (int or string) Port checked by the Query TLS startup probe.
+      port: http
+      # -- Seconds to wait before starting the Query TLS startup probe.
+      initialDelaySeconds: 0
+      # -- How often (seconds) to run the Query TLS startup probe.
+      periodSeconds: 5
+      # -- Seconds after which the Query TLS startup probe times out.
+      timeoutSeconds: 5
+      # -- Consecutive failures during Query TLS startup before the container is killed.
+      failureThreshold: 60
+      # -- Consecutive successes before the Query TLS startup probe is considered passed.
+      successThreshold: 1
+
+  # -- Node selector for Query TLS pod scheduling.
+  # @default -- {}
+  nodeSelector: {}
+
+  # -- Tolerations for Query TLS pod scheduling.
+  # @default -- []
+  tolerations: []
+
+  # -- Affinity rules for Query TLS pod scheduling.
+  # @default -- {}
+  affinity: {}
+
+  # -- Topology spread constraints for Query TLS pods.
+  # @default -- []
+  topologySpreadConstraints: []
+
+  # -- Priority class name for Query TLS pods.
+  priorityClassName: ""
+
+  # -- Extra volumes for Query TLS pods.
+  # @default -- []
+  extraVolumes: []
+
+  # -- Extra volume mounts for the Query TLS container.
+  # @default -- []
+  extraVolumeMounts: []
+
+  # -- Extra annotations applied to Query TLS resources.
+  # @default -- {}
+  annotations: {}
+
+  # -- Extra labels applied to Query TLS resources.
+  # @default -- {}
+  labels: {}
+
+  # Prometheus Operator ServiceMonitor configuration for Query TLS.
+  serviceMonitor:
+    # -- Enable a Prometheus Operator ServiceMonitor for Query TLS.
+    enabled: false
+    # -- Extra annotations for the Query TLS ServiceMonitor.
+    # @default -- {}
+    annotations: {}
+    # -- Extra labels for the Query TLS ServiceMonitor.
+    # @default -- {}
+    labels: {}
+    # -- Scrape interval for Query TLS. Empty uses the Prometheus operator default.
+    interval: ""
+    # -- Scrape timeout for Query TLS. Empty uses the Prometheus operator default.
+    scrapeTimeout: ""
+    # -- Scrape scheme for Query TLS (http or https).
+    scheme: ""
+    # -- TLS configuration for Query TLS scraping.
+    # @default -- {}
+    tlsConfig: {}
+    # -- Relabeling rules applied before Query TLS metrics are ingested.
+    # @default -- []
+    relabelings: []
+    # -- Metric relabeling rules applied after Query TLS metrics are ingested.
+    # @default -- []
+    metricRelabelings: []
+
+  # PodDisruptionBudget configuration for Query TLS.
+  pdb:
+    # -- Enable a PodDisruptionBudget for Query TLS.
+    enabled: false
+    # -- (int or string) Maximum unavailable Query TLS pods during a disruption.
+    maxUnavailable: ""
+    # -- (int or string) Minimum available Query TLS pods during a disruption.
+    minAvailable: ""
+
+# ======================================================================
 # Query Frontend component
 # Optional caching and query-splitting layer in front of Query.
 # Reduces load for repeated or heavy long-range queries.

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -55,6 +55,15 @@ global:
     # -- Require the container to run as a non-root user.
     runAsNonRoot: true
 
+  # -- DNS configuration applied to every pod. Component-level values override this.
+  # @default -- {}
+  dnsConfig: {}
+  # Example:
+  # dnsConfig:
+  #   options:
+  #     - name: ndots
+  #       value: "1"
+
   # -- Additional volumes available to every pod by default.
   # @default -- []
   extraVolumes: []
@@ -101,6 +110,11 @@ global:
   # -- Extra sidecar containers added to every pod by default.
   # @default -- []
   extraContainers: []
+
+  # -- Create a NetworkPolicy for every enabled component. When true each
+  # component gets a NetworkPolicy that allows ingress on its service ports
+  # from within the namespace and permits all egress.
+  networkPolicies: false
 
   # Object store configuration shared by all components that read or write
   # blocks (Receive, Store Gateway, Compactor, Ruler).
@@ -233,10 +247,10 @@ global:
     # -- Enable a PodDisruptionBudget for every component. Individual
     # components can override this with their own pdb.enabled.
     enabled: false
-    # -- Minimum number of available pods during a disruption.
+    # -- (int or string) Minimum number of available pods during a disruption.
     # Cannot be set at the same time as maxUnavailable.
     minAvailable: ""
-    # -- Maximum number of unavailable pods during a disruption.
+    # -- (int or string) Maximum number of unavailable pods during a disruption.
     # Cannot be set at the same time as minAvailable.
     maxUnavailable: ""
 
@@ -347,6 +361,10 @@ bucket:
     # @default -- {}
     containerSecurityContext: {}
 
+    # -- DNS configuration for Bucketweb pods. Overrides global.dnsConfig.
+    # @default -- {}
+    dnsConfig: {}
+
     # -- Extra environment variables injected into the Bucketweb container.
     # @default -- []
     extraEnv: []
@@ -371,8 +389,8 @@ bucket:
         enabled: true
         # -- HTTP path checked by the readiness probe.
         path: /-/ready
-        # -- Port checked by the readiness probe.
-        port: 10902
+        # -- (int or string) Port checked by the readiness probe.
+        port: http
         # -- Seconds to wait before starting the readiness probe.
         initialDelaySeconds: 5
         # -- How often (seconds) to run the readiness probe.
@@ -389,8 +407,8 @@ bucket:
         enabled: true
         # -- HTTP path checked by the liveness probe.
         path: /-/healthy
-        # -- Port checked by the liveness probe.
-        port: 10902
+        # -- (int or string) Port checked by the liveness probe.
+        port: http
         # -- Seconds to wait before starting the liveness probe.
         initialDelaySeconds: 30
         # -- How often (seconds) to run the liveness probe.
@@ -407,8 +425,8 @@ bucket:
         enabled: true
         # -- HTTP path checked by the startup probe.
         path: /-/ready
-        # -- Port checked by the startup probe.
-        port: 10902
+        # -- (int or string) Port checked by the startup probe.
+        port: http
         # -- Seconds to wait before starting the startup probe.
         initialDelaySeconds: 0
         # -- How often (seconds) to run the startup probe.
@@ -489,9 +507,9 @@ bucket:
     pdb:
       # -- Enable a PodDisruptionBudget for Bucketweb.
       enabled: false
-      # -- Minimum available Bucketweb pods during a disruption.
+      # -- (int or string) Minimum available Bucketweb pods during a disruption.
       minAvailable: ""
-      # -- Maximum unavailable Bucketweb pods during a disruption.
+      # -- (int or string) Maximum unavailable Bucketweb pods during a disruption.
       maxUnavailable: ""
 
 # ======================================================================
@@ -608,6 +626,10 @@ compactor:
   # @default -- {}
   containerSecurityContext: {}
 
+  # -- DNS configuration for Compactor pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
   # -- Extra environment variables injected into the Compactor container.
   # @default -- []
   extraEnv: []
@@ -632,8 +654,8 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor readiness probe.
       path: /-/ready
-      # -- Port checked by the Compactor readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Compactor readiness probe.
+      port: http
       # -- Seconds to wait before starting the Compactor readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Compactor readiness probe.
@@ -650,8 +672,8 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor liveness probe.
       path: /-/healthy
-      # -- Port checked by the Compactor liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Compactor liveness probe.
+      port: http
       # -- Seconds to wait before starting the Compactor liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Compactor liveness probe.
@@ -668,8 +690,8 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor startup probe.
       path: /-/ready
-      # -- Port checked by the Compactor startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Compactor startup probe.
+      port: http
       # -- Seconds to wait before starting the Compactor startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Compactor startup probe.
@@ -746,9 +768,9 @@ compactor:
   pdb:
     # -- Enable a PodDisruptionBudget for the Compactor.
     enabled: false
-    # -- Minimum available Compactor pods during a disruption.
+    # -- (int or string) Minimum available Compactor pods during a disruption.
     minAvailable: ""
-    # -- Maximum unavailable Compactor pods during a disruption.
+    # -- (int or string) Maximum unavailable Compactor pods during a disruption.
     maxUnavailable: ""
 
 # ======================================================================
@@ -854,6 +876,7 @@ query:
   # Example:
   # stores:
   #   - dnssrv+_grpc._tcp.thanos-storegateway.monitoring.svc.cluster.local
+  #   - thanos-gateway.mydomain.com:443
 
   # Label names that identify replica identity for result deduplication.
   replicaLabels:
@@ -874,6 +897,10 @@ query:
   # -- Container security context for Query. Overrides global.containerSecurityContext.
   # @default -- {}
   containerSecurityContext: {}
+
+  # -- DNS configuration for Query pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
 
   # -- Extra environment variables injected into the Query container.
   # @default -- []
@@ -899,8 +926,8 @@ query:
       enabled: true
       # -- HTTP path checked by the Query readiness probe.
       path: /-/ready
-      # -- Port checked by the Query readiness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query readiness probe.
+      port: http
       # -- Seconds to wait before starting the Query readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Query readiness probe.
@@ -917,8 +944,8 @@ query:
       enabled: true
       # -- HTTP path checked by the Query liveness probe.
       path: /-/healthy
-      # -- Port checked by the Query liveness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query liveness probe.
+      port: http
       # -- Seconds to wait before starting the Query liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Query liveness probe.
@@ -935,8 +962,8 @@ query:
       enabled: true
       # -- HTTP path checked by the Query startup probe.
       path: /-/ready
-      # -- Port checked by the Query startup probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query startup probe.
+      port: http
       # -- Seconds to wait before starting the Query startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Query startup probe.
@@ -1013,9 +1040,9 @@ query:
   pdb:
     # -- Enable a PodDisruptionBudget for Query.
     enabled: false
-    # -- Minimum available Query pods during a disruption.
+    # -- (int or string) Minimum available Query pods during a disruption.
     minAvailable: ""
-    # -- Maximum unavailable Query pods during a disruption.
+    # -- (int or string) Maximum unavailable Query pods during a disruption.
     maxUnavailable: ""
 
 # ======================================================================
@@ -1114,6 +1141,10 @@ queryFrontend:
   # @default -- {}
   containerSecurityContext: {}
 
+  # -- DNS configuration for Query Frontend pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
   # -- Extra environment variables injected into the Query Frontend container.
   # @default -- []
   extraEnv: []
@@ -1138,8 +1169,8 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend readiness probe.
       path: /-/ready
-      # -- Port checked by the Query Frontend readiness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query Frontend readiness probe.
+      port: http
       # -- Seconds to wait before starting the Query Frontend readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Query Frontend readiness probe.
@@ -1156,8 +1187,8 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend liveness probe.
       path: /-/healthy
-      # -- Port checked by the Query Frontend liveness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query Frontend liveness probe.
+      port: http
       # -- Seconds to wait before starting the Query Frontend liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Query Frontend liveness probe.
@@ -1174,8 +1205,8 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend startup probe.
       path: /-/ready
-      # -- Port checked by the Query Frontend startup probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query Frontend startup probe.
+      port: http
       # -- Seconds to wait before starting the Query Frontend startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Query Frontend startup probe.
@@ -1252,9 +1283,9 @@ queryFrontend:
   pdb:
     # -- Enable a PodDisruptionBudget for Query Frontend.
     enabled: false
-    # -- Minimum available Query Frontend pods during a disruption.
+    # -- (int or string) Minimum available Query Frontend pods during a disruption.
     minAvailable: ""
-    # -- Maximum unavailable Query Frontend pods during a disruption.
+    # -- (int or string) Maximum unavailable Query Frontend pods during a disruption.
     maxUnavailable: ""
 
 # ======================================================================
@@ -1380,6 +1411,10 @@ storegateway:
   # @default -- {}
   containerSecurityContext: {}
 
+  # -- DNS configuration for Store Gateway pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
   # -- Extra environment variables injected into the Store Gateway container.
   # @default -- []
   extraEnv: []
@@ -1404,8 +1439,8 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway readiness probe.
       path: /-/ready
-      # -- Port checked by the Store Gateway readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Store Gateway readiness probe.
+      port: http
       # -- Seconds to wait before starting the Store Gateway readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Store Gateway readiness probe.
@@ -1422,8 +1457,8 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway liveness probe.
       path: /-/healthy
-      # -- Port checked by the Store Gateway liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Store Gateway liveness probe.
+      port: http
       # -- Seconds to wait before starting the Store Gateway liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Store Gateway liveness probe.
@@ -1440,8 +1475,8 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway startup probe.
       path: /-/ready
-      # -- Port checked by the Store Gateway startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Store Gateway startup probe.
+      port: http
       # -- Seconds to wait before starting the Store Gateway startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Store Gateway startup probe.
@@ -1518,9 +1553,9 @@ storegateway:
   pdb:
     # -- Enable a PodDisruptionBudget for the Store Gateway.
     enabled: false
-    # -- Minimum available Store Gateway pods during a disruption.
+    # -- (int or string) Minimum available Store Gateway pods during a disruption.
     minAvailable: ""
-    # -- Maximum unavailable Store Gateway pods during a disruption.
+    # -- (int or string) Maximum unavailable Store Gateway pods during a disruption.
     maxUnavailable: ""
 
 # ======================================================================
@@ -1685,6 +1720,10 @@ receive:
   # @default -- {}
   containerSecurityContext: {}
 
+  # -- DNS configuration for Receive pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
   # -- Extra environment variables injected into the Receive container.
   # @default -- []
   extraEnv: []
@@ -1709,8 +1748,8 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive readiness probe.
       path: /-/ready
-      # -- Port checked by the Receive readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Receive readiness probe.
+      port: http
       # -- Seconds to wait before starting the Receive readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Receive readiness probe.
@@ -1727,8 +1766,8 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive liveness probe.
       path: /-/healthy
-      # -- Port checked by the Receive liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Receive liveness probe.
+      port: http
       # -- Seconds to wait before starting the Receive liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Receive liveness probe.
@@ -1745,8 +1784,8 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive startup probe.
       path: /-/ready
-      # -- Port checked by the Receive startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Receive startup probe.
+      port: http
       # -- Seconds to wait before starting the Receive startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Receive startup probe.
@@ -1823,9 +1862,9 @@ receive:
   pdb:
     # -- Enable a PodDisruptionBudget for Receive.
     enabled: false
-    # -- Minimum available Receive pods during a disruption.
+    # -- (int or string) Minimum available Receive pods during a disruption.
     minAvailable: ""
-    # -- Maximum unavailable Receive pods during a disruption.
+    # -- (int or string) Maximum unavailable Receive pods during a disruption.
     maxUnavailable: ""
 
 # ======================================================================
@@ -1970,6 +2009,10 @@ ruler:
   # @default -- {}
   containerSecurityContext: {}
 
+  # -- DNS configuration for Ruler pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
   # -- Extra environment variables injected into the Ruler container.
   # @default -- []
   extraEnv: []
@@ -1994,8 +2037,8 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler readiness probe.
       path: /-/ready
-      # -- Port checked by the Ruler readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Ruler readiness probe.
+      port: http
       # -- Seconds to wait before starting the Ruler readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Ruler readiness probe.
@@ -2012,8 +2055,8 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler liveness probe.
       path: /-/healthy
-      # -- Port checked by the Ruler liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Ruler liveness probe.
+      port: http
       # -- Seconds to wait before starting the Ruler liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Ruler liveness probe.
@@ -2030,8 +2073,8 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler startup probe.
       path: /-/ready
-      # -- Port checked by the Ruler startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Ruler startup probe.
+      port: http
       # -- Seconds to wait before starting the Ruler startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Ruler startup probe.
@@ -2108,9 +2151,9 @@ ruler:
   pdb:
     # -- Enable a PodDisruptionBudget for the Ruler.
     enabled: false
-    # -- Minimum available Ruler pods during a disruption.
+    # -- (int or string) Minimum available Ruler pods during a disruption.
     minAvailable: ""
-    # -- Maximum unavailable Ruler pods during a disruption.
+    # -- (int or string) Maximum unavailable Ruler pods during a disruption.
     maxUnavailable: ""
 
 # ======================================================================


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The chart as it is now seems to be incomplete since many of the values defined are not used, so I've changed that.
I found a bug where the query command does not accept the --store command line parameter.
I added a missing Service for Thanos Ruler.
I added optional NetworkPolicy resources.
I made it so appropriate pods roll if the object store configuration is modified.
Other minor changes mentioned in my main write up below:

Commit message follows:

A number of the global.* and $component.* variables defined in values.yaml were not actually used in the templates. Update the templates so that they are used.
The following variables now have an effect where they didn't before:
- *.affinity
- *.extraContainers
- *.extraEnv
- *.extraEnvFrom
- *.extraInitContainers
- *.nodeSelector
- *.priorityClassName
- *.tolerations
- *.topologySpreadConstraints
- bucket.bucketweb.replicaCount
- global.pdb
- $component.annotations
- $component.labels
- $component.service.annotations
- $component.service.labels

Add the ability to configure the dnsConfig field of the pods.

Add optional NetworkPolicy resources driven by a new global.networkPolicies boolean value that defaults to false.

Add a Service for Thanos ruler.

Fix that the query pod does not understand the `--store` command line option. Replace it with `--endpoint` instead.

Have the *.pdb.maxUnavailable and *.pdb.minAvailable variables accept both integer and string values.

Use port names instead of numbers in the Ingress resources and the probes. Note that the thanos.httpProbes template could be simplified to no longer receive a port parameter and just always use the http port name, however I didn't change that in case the flexibility is still required at some point.

Add a checksum/objstore-configuration annotation to resources that mount the object store configuration so that pods roll if it is changed.

Replace indent with nindent in templates and add leading indents changing the initial {{ to {{- so that the templates are indented nicely.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
