### PR TITLE
fix(ruler): incorrectly formatted ConfigMap for query-urls

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.3.4
+version: 0.4.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -348,6 +348,26 @@ initContainers:
 {{- end -}}
 {{- end -}}
 
+{{- /* ============================== */ -}}
+{{- /* Ruler query URLs helpers       */ -}}
+{{- /* ============================== */ -}}
+
+{{- define "thanos.ruler.queryUrls" -}}
+{{- $urls := .Values.ruler.query.urls -}}
+{{- if not $urls -}}
+{{- $urls = list (printf "http://%s:%v" (include "thanos.compName" (list . "query")) .Values.query.service.httpPort) -}}
+{{- end }}
+{{- range $url := $urls }}
+{{- $u := urlParse $url }}
+- static_configs:
+    - {{ $u.host }}
+  scheme: {{ $u.scheme }}
+{{- if and $u.path (ne $u.path "/") }}
+  path_prefix: {{ $u.path }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Resolve the ServiceAccount name.
 If global.serviceAccount.create is true, we default to "<release>-thanos"

--- a/charts/thanos/templates/ruler/configmap-query.yaml
+++ b/charts/thanos/templates/ruler/configmap-query.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.ruler.enabled }}
+{{- $urls := .Values.ruler.query.urls }}
+{{- if not $urls }}
+{{- $urls = list (printf "http://%s:%v" (include "thanos.compName" (list . "query")) .Values.query.service.httpPort) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,11 +13,13 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-query") | nindent 4 }}
 data:
   query-urls.yaml: |
-    query:
-      urls:
-        {{- if .Values.ruler.query.urls }}
-        {{- toYaml .Values.ruler.query.urls | nindent 8 }}
-        {{- else }}
-        - http://{{ include "thanos.compName" (list . "query") }}:{{ .Values.query.service.httpPort }}
-        {{- end }}
+    {{- range $url := $urls }}
+    {{- $u := urlParse $url }}
+    - static_configs:
+        - {{ $u.host }}
+      scheme: {{ $u.scheme }}
+    {{- if and $u.path (ne $u.path "/") }}
+      path_prefix: {{ $u.path }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/thanos/templates/ruler/configmap-query.yaml
+++ b/charts/thanos/templates/ruler/configmap-query.yaml
@@ -1,8 +1,4 @@
 {{- if .Values.ruler.enabled }}
-{{- $urls := .Values.ruler.query.urls }}
-{{- if not $urls }}
-{{- $urls = list (printf "http://%s:%v" (include "thanos.compName" (list . "query")) .Values.query.service.httpPort) }}
-{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,13 +9,5 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-query") | nindent 4 }}
 data:
   query-urls.yaml: |
-    {{- range $url := $urls }}
-    {{- $u := urlParse $url }}
-    - static_configs:
-        - {{ $u.host }}
-      scheme: {{ $u.scheme }}
-    {{- if and $u.path (ne $u.path "/") }}
-      path_prefix: {{ $u.path }}
-    {{- end }}
-    {{- end }}
+    {{- include "thanos.ruler.queryUrls" . | nindent 4 }}
 {{- end }}

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -665,6 +665,80 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: renders query configmap data as a clientconfig list with default URL
+    template: ruler/configmap-query.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: data["query-urls.yaml"]
+          value: |
+            - static_configs:
+                - RELEASE-NAME-thanos-query:9090
+              scheme: http
+
+  - it: renders query configmap data as a clientconfig list from a provided URL
+    template: ruler/configmap-query.yaml
+    set:
+      ruler.enabled: true
+      ruler.query.urls:
+        - http://thanos-prod-query-frontend:9090
+    asserts:
+      - equal:
+          path: data["query-urls.yaml"]
+          value: |
+            - static_configs:
+                - thanos-prod-query-frontend:9090
+              scheme: http
+
+  - it: emits https scheme and path_prefix when URL has a path
+    template: ruler/configmap-query.yaml
+    set:
+      ruler.enabled: true
+      ruler.query.urls:
+        - https://secure-query.example.com:8443/api
+    asserts:
+      - equal:
+          path: data["query-urls.yaml"]
+          value: |
+            - static_configs:
+                - secure-query.example.com:8443
+              scheme: https
+              path_prefix: /api
+
+  - it: renders multiple URLs as separate clientconfig entries
+    template: ruler/configmap-query.yaml
+    set:
+      ruler.enabled: true
+      ruler.query.urls:
+        - http://query-a:9090
+        - https://query-b:9090/api
+    asserts:
+      - equal:
+          path: data["query-urls.yaml"]
+          value: |
+            - static_configs:
+                - query-a:9090
+              scheme: http
+            - static_configs:
+                - query-b:9090
+              scheme: https
+              path_prefix: /api
+
+  - it: omits path_prefix when URL path is just /
+    template: ruler/configmap-query.yaml
+    set:
+      ruler.enabled: true
+      ruler.query.urls:
+        - http://query-a:9090/
+    asserts:
+      - equal:
+          path: data["query-urls.yaml"]
+          value: |
+            - static_configs:
+                - query-a:9090
+              scheme: http
+
   # -- ConfigMap auto-import prometheus rules -----------------------------
 
   - it: renders rule-importer configmap when autoImport is enabled


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it
Fixes the formatting of the produced ConfigMap for query-urls, with the suffix `-query` (e.g.: `thanos-RELEASE-NAME-ruler-query`). This should allow Thanos Ruler pods to start without the error:
```
ts=2026-04-14T13:52:04.022860576Z caller=main.go:151 level=error err="yaml: unmarshal errors:\n  line 1: cannot unmarshal !!map into []clientconfig.Config\nquery configuration\nmain.runRule\n\t/app/cmd/thanos/rule.go:344\nmain.registerRule.func1\n\t/app/cmd/thanos/rule.go:258\nmain.main\n\t/app/cmd/thanos/main.go:149\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1268\npreparing rule command failed\nmain.main\n\t/app/cmd/thanos/main.go:151\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1268"
```


#### Which issue this PR fixes

- fixes #49 

#### Special notes for your reviewer:
@hamdikh I bumped the Chart version to `0.4.1`, because I noticed you suggested it be updated to `0.4.0` in [this other PR comment](https://github.com/thanos-community/helm-charts/pull/55#discussion_r3086294957).
Let me know if you want me to change the version to something else, thanks.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
