### PR TITLE
fix: incorrectly formatted ConfigMap for Alertmanager config

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.3.4
+version: 0.4.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -909,7 +909,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.vpa.updateMode | string | `"Auto"` | VPA update mode for Receive. One of Auto, Off, or Initial. |
 | ruler.affinity | object | {} | Affinity rules for Ruler pod scheduling. |
 | ruler.alertQueryUrl | string | `""` | URL used in rule alert annotations to link back to a Thanos query UI. |
-| ruler.alertmanagers.config | string | `"static_configs:\n  - targets: [\"alertmanager.monitoring.svc.cluster.local:9093\"]\n"` |  |
+| ruler.alertmanagers.config | string | `"alertmanagers:\n  - static_configs:\n      - alertmanager.monitoring.svc.cluster.local:9093\n    scheme: http\n    api_version: v2\n"` |  |
 | ruler.annotations | object | {} | Extra annotations applied to Ruler resources. |
 | ruler.autoImportPrometheusRules.enabled | bool | `true` | Enable automatic import of PrometheusRule CRDs from the cluster into the Ruler. Requires kube-prometheus-stack (or any Prometheus Operator deployment) to be present in the cluster. |
 | ruler.autoImportPrometheusRules.labelSelector | object | {} | Label selector used to filter which PrometheusRule CRDs are imported. Empty selector imports all PrometheusRule resources visible to the sidecar. |

--- a/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
+++ b/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
@@ -9,5 +9,5 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-am") | nindent 4 }}
 data:
   alertmanagers.yaml: |
-    {{- toYaml (tpl .Values.ruler.alertmanagers.config .) | nindent 4 }}
+    {{- tpl .Values.ruler.alertmanagers.config . | nindent 4 }}
 {{- end }}

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -644,6 +644,60 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: renders alertmanagers configmap data as a valid alert.AlertingConfig with default values
+    template: ruler/configmap-alertmanagers.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: data["alertmanagers.yaml"]
+          value: |
+            alertmanagers:
+              - static_configs:
+                  - alertmanager-operated.monitoring.svc.cluster.local:9093
+                scheme: http
+                api_version: v2
+
+  - it: renders alertmanagers configmap with user-provided config
+    template: ruler/configmap-alertmanagers.yaml
+    set:
+      ruler.enabled: true
+      ruler.alertmanagers.config: |
+        alertmanagers:
+          - static_configs:
+              - custom-alertmanager.example.com:9093
+            scheme: https
+            api_version: v2
+    asserts:
+      - equal:
+          path: data["alertmanagers.yaml"]
+          value: |
+            alertmanagers:
+              - static_configs:
+                  - custom-alertmanager.example.com:9093
+                scheme: https
+                api_version: v2
+
+  - it: renders alertmanagers configmap with templated values via tpl
+    template: ruler/configmap-alertmanagers.yaml
+    set:
+      ruler.enabled: true
+      ruler.alertmanagers.config: |
+        alertmanagers:
+          - static_configs:
+              - {{ .Release.Name }}-am:9093
+            scheme: http
+            api_version: v2
+    asserts:
+      - equal:
+          path: data["alertmanagers.yaml"]
+          value: |
+            alertmanagers:
+              - static_configs:
+                  - RELEASE-NAME-am:9093
+                scheme: http
+                api_version: v2
+
   # -- ConfigMap query ---------------------------------------------------
 
   - it: renders query configmap when ruler is enabled

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -654,7 +654,7 @@ tests:
           value: |
             alertmanagers:
               - static_configs:
-                  - alertmanager-operated.monitoring.svc.cluster.local:9093
+                  - alertmanager.monitoring.svc.cluster.local:9093
                 scheme: http
                 api_version: v2
 

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1852,8 +1852,11 @@ ruler:
   # See https://thanos.io/tip/components/rule.md/#flags for the full schema.
   alertmanagers:
     config: |
-      static_configs:
-        - targets: ["alertmanager.monitoring.svc.cluster.local:9093"]
+      alertmanagers:
+        - static_configs:
+            - alertmanager.monitoring.svc.cluster.local:9093
+          scheme: http
+          api_version: v2
 
   # -- URL used in rule alert annotations to link back to a Thanos query UI.
   alertQueryUrl: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the formatting of the produced ConfigMap for Alertmanager configs, with the suffix `-am` (e.g.: `thanos-RELEASE-NAME-ruler-am`). This should allow Thanos Ruler pods to start without the error:

```
ts=2026-04-14T15:51:09.778169679Z caller=main.go:151 level=error err="yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `static_...` into alert.AlertingConfig\npreparing rule command failed\nmain.main\n\t/app/cmd/thanos/main.go:151\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1268"
```

#### Which issue this PR fixes

- fixes #50

#### Special notes for your reviewer:
@hamdikh Similarly to PR #56, I bumped the Chart version to `0.4.2`, because I noticed you suggested it be updated to `0.4.0` in [this other PR comment](https://github.com/thanos-community/helm-charts/pull/55#discussion_r3086294957).
Let me know if you want me to change the version to something else, thanks.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
