### PR TITLE
feat(networkpolicy): Add optional NetworkPolicy resources

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.4.5
+version: 0.5.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -472,7 +472,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the liveness probe. |
 | bucket.bucketweb.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the liveness probe. |
 | bucket.bucketweb.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the liveness probe. |
-| bucket.bucketweb.probes.liveness.port | int | `10902` | Port checked by the liveness probe. |
+| bucket.bucketweb.probes.liveness.port | int or string | `"http"` | Port checked by the liveness probe. |
 | bucket.bucketweb.probes.liveness.successThreshold | int | `1` | Consecutive successes before the container is considered live. |
 | bucket.bucketweb.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Bucketweb. |
@@ -480,7 +480,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the readiness probe. |
 | bucket.bucketweb.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the readiness probe. |
 | bucket.bucketweb.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the readiness probe. |
-| bucket.bucketweb.probes.readiness.port | int | `10902` | Port checked by the readiness probe. |
+| bucket.bucketweb.probes.readiness.port | int or string | `"http"` | Port checked by the readiness probe. |
 | bucket.bucketweb.probes.readiness.successThreshold | int | `1` | Consecutive successes before the pod is marked ready. |
 | bucket.bucketweb.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.probes.startup.enabled | bool | `true` | Enable the startup probe for Bucketweb. |
@@ -488,7 +488,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the startup probe. |
 | bucket.bucketweb.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the startup probe. |
 | bucket.bucketweb.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the startup probe. |
-| bucket.bucketweb.probes.startup.port | int | `10902` | Port checked by the startup probe. |
+| bucket.bucketweb.probes.startup.port | int or string | `"http"` | Port checked by the startup probe. |
 | bucket.bucketweb.probes.startup.successThreshold | int | `1` | Consecutive successes required before the startup probe is considered passed. |
 | bucket.bucketweb.probes.startup.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.replicaCount | int | `1` | Number of Bucketweb pod replicas. |
@@ -554,7 +554,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Compactor liveness probe. |
 | compactor.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Compactor liveness probe. |
 | compactor.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Compactor liveness probe. |
-| compactor.probes.liveness.port | int | `10902` | Port checked by the Compactor liveness probe. |
+| compactor.probes.liveness.port | int or string | `"http"` | Port checked by the Compactor liveness probe. |
 | compactor.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Compactor container is considered live. |
 | compactor.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Compactor liveness probe times out. |
 | compactor.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Compactor. |
@@ -562,7 +562,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Compactor readiness probe. |
 | compactor.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Compactor readiness probe. |
 | compactor.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Compactor readiness probe. |
-| compactor.probes.readiness.port | int | `10902` | Port checked by the Compactor readiness probe. |
+| compactor.probes.readiness.port | int or string | `"http"` | Port checked by the Compactor readiness probe. |
 | compactor.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Compactor pod is marked ready. |
 | compactor.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Compactor readiness probe times out. |
 | compactor.probes.startup.enabled | bool | `true` | Enable the startup probe for the Compactor. |
@@ -570,7 +570,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Compactor startup probe. |
 | compactor.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Compactor startup probe. |
 | compactor.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Compactor startup probe. |
-| compactor.probes.startup.port | int | `10902` | Port checked by the Compactor startup probe. |
+| compactor.probes.startup.port | int or string | `"http"` | Port checked by the Compactor startup probe. |
 | compactor.probes.startup.successThreshold | int | `1` | Consecutive successes before the Compactor startup probe is considered passed. |
 | compactor.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Compactor startup probe times out. |
 | compactor.replicaCount | int | `1` | Number of Compactor replicas. Must remain 1 — running multiple compactors against the same bucket causes data corruption. |
@@ -615,6 +615,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.image.repository | string | `"quay.io/thanos/thanos"` | Docker repository for all Thanos containers by default. |
 | global.image.tag | string | `"v0.41.0"` | Container image tag. Changing this upgrades all components at once. |
 | global.imagePullSecrets | list | [] | List of imagePullSecrets applied to every pod by default. |
+| global.networkPolicies | bool | `false` | Create a NetworkPolicy for every enabled component. When true each component gets a NetworkPolicy that allows ingress on its service ports from within the namespace and permits all egress. |
 | global.nodeSelector | object | {} | Node selector applied to every pod by default. |
 | global.objstore.config | string | `"type: GCS\nconfig:\n  bucket: change-me\n  endpoint: storage.googleapis.com\n  region: eu-west-1\n  insecure: false\n\n# Example for S3\n# type: S3\n# config:\n#   bucket: my-s3-bucket\n#   endpoint: s3.eu-west-1.amazonaws.com\n#   region: eu-west-1\n#   access_key: myaccess\n#   secret_key: mysecret\n"` | Inline object store configuration rendered into the Secret when `createSecret` is true. Processed via `tpl`, so Helm template syntax (e.g. `{{ .Release.Name }}`) is valid inside the string. Refer to https://thanos.io/tip/thanos/storage.md/ for the full schema. |
 | global.objstore.createSecret | bool | `false` | When true, the chart creates a Kubernetes Secret named `secretName` containing the inline `config` below. Set to false when the Secret is managed externally (Vault, External Secrets Operator, kubectl, etc.). |
@@ -701,7 +702,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query liveness probe. |
 | query.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query liveness probe. |
 | query.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query liveness probe. |
-| query.probes.liveness.port | int | `9090` | Port checked by the Query liveness probe. |
+| query.probes.liveness.port | int or string | `"http"` | Port checked by the Query liveness probe. |
 | query.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query container is considered live. |
 | query.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query liveness probe times out. |
 | query.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query. |
@@ -709,7 +710,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query readiness probe. |
 | query.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query readiness probe. |
 | query.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query readiness probe. |
-| query.probes.readiness.port | int | `9090` | Port checked by the Query readiness probe. |
+| query.probes.readiness.port | int or string | `"http"` | Port checked by the Query readiness probe. |
 | query.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query pod is marked ready. |
 | query.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query readiness probe times out. |
 | query.probes.startup.enabled | bool | `true` | Enable the startup probe for Query. |
@@ -717,7 +718,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query startup probe. |
 | query.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query startup probe. |
 | query.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query startup probe. |
-| query.probes.startup.port | int | `9090` | Port checked by the Query startup probe. |
+| query.probes.startup.port | int or string | `"http"` | Port checked by the Query startup probe. |
 | query.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query startup probe is considered passed. |
 | query.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query startup probe times out. |
 | query.replicaCount | int | `2` | Number of Query pod replicas. Two or more is recommended for HA. |
@@ -782,7 +783,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query Frontend liveness probe. |
-| queryFrontend.probes.liveness.port | int | `9090` | Port checked by the Query Frontend liveness probe. |
+| queryFrontend.probes.liveness.port | int or string | `"http"` | Port checked by the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query Frontend container is considered live. |
 | queryFrontend.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query Frontend liveness probe times out. |
 | queryFrontend.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query Frontend. |
@@ -790,7 +791,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query Frontend readiness probe. |
-| queryFrontend.probes.readiness.port | int | `9090` | Port checked by the Query Frontend readiness probe. |
+| queryFrontend.probes.readiness.port | int or string | `"http"` | Port checked by the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query Frontend pod is marked ready. |
 | queryFrontend.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query Frontend readiness probe times out. |
 | queryFrontend.probes.startup.enabled | bool | `true` | Enable the startup probe for Query Frontend. |
@@ -798,7 +799,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query Frontend startup probe. |
 | queryFrontend.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query Frontend startup probe. |
 | queryFrontend.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query Frontend startup probe. |
-| queryFrontend.probes.startup.port | int | `9090` | Port checked by the Query Frontend startup probe. |
+| queryFrontend.probes.startup.port | int or string | `"http"` | Port checked by the Query Frontend startup probe. |
 | queryFrontend.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query Frontend startup probe is considered passed. |
 | queryFrontend.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query Frontend startup probe times out. |
 | queryFrontend.replicaCount | int | `2` | Number of Query Frontend pod replicas. |
@@ -865,7 +866,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Receive liveness probe. |
 | receive.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Receive liveness probe. |
 | receive.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Receive liveness probe. |
-| receive.probes.liveness.port | int | `10902` | Port checked by the Receive liveness probe. |
+| receive.probes.liveness.port | int or string | `"http"` | Port checked by the Receive liveness probe. |
 | receive.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Receive container is considered live. |
 | receive.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Receive liveness probe times out. |
 | receive.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Receive. |
@@ -873,7 +874,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Receive readiness probe. |
 | receive.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Receive readiness probe. |
 | receive.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Receive readiness probe. |
-| receive.probes.readiness.port | int | `10902` | Port checked by the Receive readiness probe. |
+| receive.probes.readiness.port | int or string | `"http"` | Port checked by the Receive readiness probe. |
 | receive.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Receive pod is marked ready. |
 | receive.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Receive readiness probe times out. |
 | receive.probes.startup.enabled | bool | `true` | Enable the startup probe for Receive. |
@@ -881,7 +882,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Receive startup probe. |
 | receive.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Receive startup probe. |
 | receive.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Receive startup probe. |
-| receive.probes.startup.port | int | `10902` | Port checked by the Receive startup probe. |
+| receive.probes.startup.port | int or string | `"http"` | Port checked by the Receive startup probe. |
 | receive.probes.startup.successThreshold | int | `1` | Consecutive successes before the Receive startup probe is considered passed. |
 | receive.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Receive startup probe times out. |
 | receive.replicaCount | int | `3` | Number of Receive pod replicas. Minimum 3 is recommended for replication factor 2 (write quorum = floor(replicaCount/2)+1). |
@@ -960,7 +961,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Ruler liveness probe. |
 | ruler.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Ruler liveness probe. |
 | ruler.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Ruler liveness probe. |
-| ruler.probes.liveness.port | int | `10902` | Port checked by the Ruler liveness probe. |
+| ruler.probes.liveness.port | int or string | `"http"` | Port checked by the Ruler liveness probe. |
 | ruler.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Ruler container is considered live. |
 | ruler.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Ruler liveness probe times out. |
 | ruler.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Ruler. |
@@ -968,7 +969,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Ruler readiness probe. |
 | ruler.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Ruler readiness probe. |
 | ruler.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Ruler readiness probe. |
-| ruler.probes.readiness.port | int | `10902` | Port checked by the Ruler readiness probe. |
+| ruler.probes.readiness.port | int or string | `"http"` | Port checked by the Ruler readiness probe. |
 | ruler.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Ruler pod is marked ready. |
 | ruler.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Ruler readiness probe times out. |
 | ruler.probes.startup.enabled | bool | `true` | Enable the startup probe for the Ruler. |
@@ -976,7 +977,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Ruler startup probe. |
 | ruler.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Ruler startup probe. |
 | ruler.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Ruler startup probe. |
-| ruler.probes.startup.port | int | `10902` | Port checked by the Ruler startup probe. |
+| ruler.probes.startup.port | int or string | `"http"` | Port checked by the Ruler startup probe. |
 | ruler.probes.startup.successThreshold | int | `1` | Consecutive successes before the Ruler startup probe is considered passed. |
 | ruler.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Ruler startup probe times out. |
 | ruler.query.urls | list | [] | List of Query component base URLs used by the Ruler to evaluate rules. |
@@ -1056,7 +1057,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Store Gateway liveness probe. |
 | storegateway.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Store Gateway liveness probe. |
 | storegateway.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Store Gateway liveness probe. |
-| storegateway.probes.liveness.port | int | `10902` | Port checked by the Store Gateway liveness probe. |
+| storegateway.probes.liveness.port | int or string | `"http"` | Port checked by the Store Gateway liveness probe. |
 | storegateway.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Store Gateway container is considered live. |
 | storegateway.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Store Gateway liveness probe times out. |
 | storegateway.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Store Gateway. |
@@ -1064,7 +1065,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Store Gateway readiness probe. |
 | storegateway.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Store Gateway readiness probe. |
 | storegateway.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Store Gateway readiness probe. |
-| storegateway.probes.readiness.port | int | `10902` | Port checked by the Store Gateway readiness probe. |
+| storegateway.probes.readiness.port | int or string | `"http"` | Port checked by the Store Gateway readiness probe. |
 | storegateway.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Store Gateway pod is marked ready. |
 | storegateway.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Store Gateway readiness probe times out. |
 | storegateway.probes.startup.enabled | bool | `true` | Enable the startup probe for the Store Gateway. |
@@ -1072,7 +1073,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Store Gateway startup probe. |
 | storegateway.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Store Gateway startup probe. |
 | storegateway.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Store Gateway startup probe. |
-| storegateway.probes.startup.port | int | `10902` | Port checked by the Store Gateway startup probe. |
+| storegateway.probes.startup.port | int or string | `"http"` | Port checked by the Store Gateway startup probe. |
 | storegateway.probes.startup.successThreshold | int | `1` | Consecutive successes before the Store Gateway startup probe is considered passed. |
 | storegateway.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Store Gateway startup probe times out. |
 | storegateway.replicaCount | int | `2` | Number of Store Gateway pod replicas. Two or more is recommended for HA. |

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" $ctx "key" "bucketweb") | nindent 10 }}
           resources:
             {{- toYaml .Values.bucket.bucketweb.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" $ctx "key" "bucketweb" "port" .Values.bucket.bucketweb.service.port) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" $ctx "key" "bucketweb" "port" "http") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" $ctx.Values "component" "bucketweb" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" $ctx.Values "component" "bucketweb" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/bucket/ingress.yaml
+++ b/charts/thanos/templates/bucket/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "bucketweb") }}
                 port:
-                  number: {{ $.Values.bucket.bucketweb.service.port }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/bucket/networkpolicy.yaml
+++ b/charts/thanos/templates/bucket/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+  name: {{ include "thanos.compName" (list . "bucketweb") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: bucketweb
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/compactor/ingress.yaml
+++ b/charts/thanos/templates/compactor/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "compactor") }}
                 port:
-                  number: {{ $.Values.compactor.service.port }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/compactor/networkpolicy.yaml
+++ b/charts/thanos/templates/compactor/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.compactor.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+  name: {{ include "thanos.compName" (list . "compactor") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "compactor") | nindent 10 }}
           resources:
             {{- toYaml .Values.compactor.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "compactor" "port" .Values.compactor.service.port) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "compactor" "port" "http") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "compactor" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "compactor") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "compactor" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "queryFrontend") | nindent 10 }}
           resources:
             {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "queryFrontend" "port" .Values.queryFrontend.service.port) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "queryFrontend" "port" "http") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "queryFrontend" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "queryFrontend" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/ingress.yaml
+++ b/charts/thanos/templates/query-frontend/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "query-frontend") }}
                 port:
-                  number: {{ $.Values.queryFrontend.service.port }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/query-frontend/networkpolicy.yaml
+++ b/charts/thanos/templates/query-frontend/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.queryFrontend.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+  name: {{ include "thanos.compName" (list . "query-frontend") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "query") | nindent 10 }}
           resources:
             {{- toYaml .Values.query.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "query" "port" .Values.query.service.httpPort) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "query" "port" "http") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "query" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "query") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "query" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/query/ingress.yaml
+++ b/charts/thanos/templates/query/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "query") }}
                 port:
-                  number: {{ $.Values.query.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/query/networkpolicy.yaml
+++ b/charts/thanos/templates/query/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.query.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
+  name: {{ include "thanos.compName" (list . "query") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/receive/ingress.yaml
+++ b/charts/thanos/templates/receive/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "receive") }}
                 port:
-                  number: {{ $.Values.receive.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/receive/networkpolicy.yaml
+++ b/charts/thanos/templates/receive/networkpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.receive.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
+  name: {{ include "thanos.compName" (list . "receive") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+        - port: remote-write
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: receive
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "receive") | nindent 10 }}
           resources:
             {{- toYaml (.Values.receive.resources | default dict) | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "receive" "port" (default 10902 .Values.receive.service.httpPort)) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "receive" "port" "http") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "receive") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/ruler/ingress.yaml
+++ b/charts/thanos/templates/ruler/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "ruler") }}
                 port:
-                  number: {{ $.Values.ruler.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/ruler/networkpolicy.yaml
+++ b/charts/thanos/templates/ruler/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.ruler.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+  name: {{ include "thanos.compName" (list . "ruler") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "ruler") | nindent 10 }}
           resources:
             {{- toYaml .Values.ruler.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "ruler" "port" .Values.ruler.service.httpPort) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "ruler" "port" "http") | nindent 10 }}
 
         {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
         - name: prometheus-rule-importer

--- a/charts/thanos/templates/storegateway/ingress.yaml
+++ b/charts/thanos/templates/storegateway/ingress.yaml
@@ -24,7 +24,7 @@ spec:
               service:
                 name: {{ include "thanos.compName" (list $ "storegateway") }}
                 port:
-                  number: {{ $.Values.storegateway.service.httpPort }}
+                  name: http
         {{- end }}
   {{- end }}
   tls:

--- a/charts/thanos/templates/storegateway/networkpolicy.yaml
+++ b/charts/thanos/templates/storegateway/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.storegateway.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+  name: {{ include "thanos.compName" (list . "storegateway") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: storegateway
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "storegateway") | nindent 10 }}
           resources:
             {{- toYaml .Values.storegateway.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "storegateway" "port" .Values.storegateway.service.httpPort) | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "storegateway" "port" "http") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "storegateway" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "storegateway" "root" .) | nindent 6 }}

--- a/charts/thanos/tests/bucketweb_test.yaml
+++ b/charts/thanos/tests/bucketweb_test.yaml
@@ -889,3 +889,51 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: bucket/networkpolicy.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when bucket is disabled
+    template: bucket/networkpolicy.yaml
+    set:
+      bucket.enabled: false
+      bucket.bucketweb.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when bucketweb is disabled
+    template: bucket/networkpolicy.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when bucket, bucketweb, and networkPolicies are enabled
+    template: bucket/networkpolicy.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-bucketweb

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -708,3 +708,38 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: compactor/networkpolicy.yaml
+    set:
+      compactor.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when compactor is disabled
+    template: compactor/networkpolicy.yaml
+    set:
+      compactor.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when compactor and networkPolicies are enabled
+    template: compactor/networkpolicy.yaml
+    set:
+      compactor.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-compactor

--- a/charts/thanos/tests/query_frontend_test.yaml
+++ b/charts/thanos/tests/query_frontend_test.yaml
@@ -833,3 +833,38 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: query-frontend/networkpolicy.yaml
+    set:
+      queryFrontend.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when queryFrontend is disabled
+    template: query-frontend/networkpolicy.yaml
+    set:
+      queryFrontend.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when queryFrontend and networkPolicies are enabled
+    template: query-frontend/networkpolicy.yaml
+    set:
+      queryFrontend.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-query-frontend

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -813,3 +813,38 @@ tests:
               target:
                 type: Utilization
                 averageUtilization: 75
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: query/networkpolicy.yaml
+    set:
+      query.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when query is disabled
+    template: query/networkpolicy.yaml
+    set:
+      query.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when query and networkPolicies are enabled
+    template: query/networkpolicy.yaml
+    set:
+      query.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-query

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -759,3 +759,38 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: receive/networkpolicy.yaml
+    set:
+      receive.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when receive is disabled
+    template: receive/networkpolicy.yaml
+    set:
+      receive.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when receive and networkPolicies are enabled
+    template: receive/networkpolicy.yaml
+    set:
+      receive.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -936,3 +936,38 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: ruler/networkpolicy.yaml
+    set:
+      ruler.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when ruler is disabled
+    template: ruler/networkpolicy.yaml
+    set:
+      ruler.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when ruler and networkPolicies are enabled
+    template: ruler/networkpolicy.yaml
+    set:
+      ruler.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-ruler

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -827,3 +827,38 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # -- NetworkPolicy -------------------------------------------------------
+
+  - it: does not render networkpolicy when networkPolicies is disabled
+    template: storegateway/networkpolicy.yaml
+    set:
+      storegateway.enabled: true
+      global.networkPolicies: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render networkpolicy when storegateway is disabled
+    template: storegateway/networkpolicy.yaml
+    set:
+      storegateway.enabled: false
+      global.networkPolicies: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders networkpolicy when storegateway and networkPolicies are enabled
+    template: storegateway/networkpolicy.yaml
+    set:
+      storegateway.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-storegateway

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -430,11 +430,18 @@
                       "type": "integer"
                     },
                     "port": {
-                      "default": 10902,
+                      "default": "http",
                       "description": "Port checked by the liveness probe.",
                       "required": [],
                       "title": "port",
-                      "type": "integer"
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "successThreshold": {
                       "default": 1,
@@ -504,11 +511,18 @@
                       "type": "integer"
                     },
                     "port": {
-                      "default": 10902,
+                      "default": "http",
                       "description": "Port checked by the readiness probe.",
                       "required": [],
                       "title": "port",
-                      "type": "integer"
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "successThreshold": {
                       "default": 1,
@@ -578,11 +592,18 @@
                       "type": "integer"
                     },
                     "port": {
-                      "default": 10902,
+                      "default": "http",
                       "description": "Port checked by the startup probe.",
                       "required": [],
                       "title": "port",
-                      "type": "integer"
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "successThreshold": {
                       "default": 1,
@@ -1291,11 +1312,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Compactor liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -1365,11 +1393,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Compactor readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -1439,11 +1474,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Compactor startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -2396,6 +2438,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "networkPolicies": {
+          "default": false,
+          "description": "Create a NetworkPolicy for every enabled component. When true each component gets a NetworkPolicy that allows ingress on its service ports from within the namespace and permits all egress.",
+          "required": [],
+          "title": "networkPolicies",
+          "type": "boolean"
         }
       },
       "required": [
@@ -2411,6 +2460,7 @@
         "extraVolumeMounts",
         "resources",
         "nodeSelector",
+        "networkPolicies",
         "tolerations",
         "affinity",
         "topologySpreadConstraints",
@@ -2916,11 +2966,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -2990,11 +3047,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3064,11 +3128,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3773,11 +3844,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query Frontend liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3847,11 +3925,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query Frontend readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -3921,11 +4006,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 9090,
+                  "default": "http",
                   "description": "Port checked by the Query Frontend startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -4691,11 +4783,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Receive liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -4765,11 +4864,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Receive readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -4839,11 +4945,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Receive startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5752,11 +5865,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Ruler liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5826,11 +5946,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Ruler readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -5900,11 +6027,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Ruler startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -6816,11 +6950,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Store Gateway liveness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -6890,11 +7031,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Store Gateway readiness probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,
@@ -6964,11 +7112,18 @@
                   "type": "integer"
                 },
                 "port": {
-                  "default": 10902,
+                  "default": "http",
                   "description": "Port checked by the Store Gateway startup probe.",
                   "required": [],
                   "title": "port",
-                  "type": "integer"
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
                 },
                 "successThreshold": {
                   "default": 1,

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -111,6 +111,11 @@ global:
   # @default -- []
   extraContainers: []
 
+  # -- Create a NetworkPolicy for every enabled component. When true each
+  # component gets a NetworkPolicy that allows ingress on its service ports
+  # from within the namespace and permits all egress.
+  networkPolicies: false
+
   # Object store configuration shared by all components that read or write
   # blocks (Receive, Store Gateway, Compactor, Ruler).
   # Object store configuration block shared by all Thanos components.
@@ -384,8 +389,8 @@ bucket:
         enabled: true
         # -- HTTP path checked by the readiness probe.
         path: /-/ready
-        # -- Port checked by the readiness probe.
-        port: 10902
+        # -- (int or string) Port checked by the readiness probe.
+        port: http
         # -- Seconds to wait before starting the readiness probe.
         initialDelaySeconds: 5
         # -- How often (seconds) to run the readiness probe.
@@ -402,8 +407,8 @@ bucket:
         enabled: true
         # -- HTTP path checked by the liveness probe.
         path: /-/healthy
-        # -- Port checked by the liveness probe.
-        port: 10902
+        # -- (int or string) Port checked by the liveness probe.
+        port: http
         # -- Seconds to wait before starting the liveness probe.
         initialDelaySeconds: 30
         # -- How often (seconds) to run the liveness probe.
@@ -420,8 +425,8 @@ bucket:
         enabled: true
         # -- HTTP path checked by the startup probe.
         path: /-/ready
-        # -- Port checked by the startup probe.
-        port: 10902
+        # -- (int or string) Port checked by the startup probe.
+        port: http
         # -- Seconds to wait before starting the startup probe.
         initialDelaySeconds: 0
         # -- How often (seconds) to run the startup probe.
@@ -649,8 +654,8 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor readiness probe.
       path: /-/ready
-      # -- Port checked by the Compactor readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Compactor readiness probe.
+      port: http
       # -- Seconds to wait before starting the Compactor readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Compactor readiness probe.
@@ -667,8 +672,8 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor liveness probe.
       path: /-/healthy
-      # -- Port checked by the Compactor liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Compactor liveness probe.
+      port: http
       # -- Seconds to wait before starting the Compactor liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Compactor liveness probe.
@@ -685,8 +690,8 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor startup probe.
       path: /-/ready
-      # -- Port checked by the Compactor startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Compactor startup probe.
+      port: http
       # -- Seconds to wait before starting the Compactor startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Compactor startup probe.
@@ -920,8 +925,8 @@ query:
       enabled: true
       # -- HTTP path checked by the Query readiness probe.
       path: /-/ready
-      # -- Port checked by the Query readiness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query readiness probe.
+      port: http
       # -- Seconds to wait before starting the Query readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Query readiness probe.
@@ -938,8 +943,8 @@ query:
       enabled: true
       # -- HTTP path checked by the Query liveness probe.
       path: /-/healthy
-      # -- Port checked by the Query liveness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query liveness probe.
+      port: http
       # -- Seconds to wait before starting the Query liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Query liveness probe.
@@ -956,8 +961,8 @@ query:
       enabled: true
       # -- HTTP path checked by the Query startup probe.
       path: /-/ready
-      # -- Port checked by the Query startup probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query startup probe.
+      port: http
       # -- Seconds to wait before starting the Query startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Query startup probe.
@@ -1163,8 +1168,8 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend readiness probe.
       path: /-/ready
-      # -- Port checked by the Query Frontend readiness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query Frontend readiness probe.
+      port: http
       # -- Seconds to wait before starting the Query Frontend readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Query Frontend readiness probe.
@@ -1181,8 +1186,8 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend liveness probe.
       path: /-/healthy
-      # -- Port checked by the Query Frontend liveness probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query Frontend liveness probe.
+      port: http
       # -- Seconds to wait before starting the Query Frontend liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Query Frontend liveness probe.
@@ -1199,8 +1204,8 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend startup probe.
       path: /-/ready
-      # -- Port checked by the Query Frontend startup probe.
-      port: 9090
+      # -- (int or string) Port checked by the Query Frontend startup probe.
+      port: http
       # -- Seconds to wait before starting the Query Frontend startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Query Frontend startup probe.
@@ -1433,8 +1438,8 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway readiness probe.
       path: /-/ready
-      # -- Port checked by the Store Gateway readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Store Gateway readiness probe.
+      port: http
       # -- Seconds to wait before starting the Store Gateway readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Store Gateway readiness probe.
@@ -1451,8 +1456,8 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway liveness probe.
       path: /-/healthy
-      # -- Port checked by the Store Gateway liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Store Gateway liveness probe.
+      port: http
       # -- Seconds to wait before starting the Store Gateway liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Store Gateway liveness probe.
@@ -1469,8 +1474,8 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway startup probe.
       path: /-/ready
-      # -- Port checked by the Store Gateway startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Store Gateway startup probe.
+      port: http
       # -- Seconds to wait before starting the Store Gateway startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Store Gateway startup probe.
@@ -1742,8 +1747,8 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive readiness probe.
       path: /-/ready
-      # -- Port checked by the Receive readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Receive readiness probe.
+      port: http
       # -- Seconds to wait before starting the Receive readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Receive readiness probe.
@@ -1760,8 +1765,8 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive liveness probe.
       path: /-/healthy
-      # -- Port checked by the Receive liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Receive liveness probe.
+      port: http
       # -- Seconds to wait before starting the Receive liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Receive liveness probe.
@@ -1778,8 +1783,8 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive startup probe.
       path: /-/ready
-      # -- Port checked by the Receive startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Receive startup probe.
+      port: http
       # -- Seconds to wait before starting the Receive startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Receive startup probe.
@@ -2034,8 +2039,8 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler readiness probe.
       path: /-/ready
-      # -- Port checked by the Ruler readiness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Ruler readiness probe.
+      port: http
       # -- Seconds to wait before starting the Ruler readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Ruler readiness probe.
@@ -2052,8 +2057,8 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler liveness probe.
       path: /-/healthy
-      # -- Port checked by the Ruler liveness probe.
-      port: 10902
+      # -- (int or string) Port checked by the Ruler liveness probe.
+      port: http
       # -- Seconds to wait before starting the Ruler liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Ruler liveness probe.
@@ -2070,8 +2075,8 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler startup probe.
       path: /-/ready
-      # -- Port checked by the Ruler startup probe.
-      port: 10902
+      # -- (int or string) Port checked by the Ruler startup probe.
+      port: http
       # -- Seconds to wait before starting the Ruler startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Ruler startup probe.


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add network policies for each of the components that will be created if the new global.networkPolicies value is set to true.

Add unittests for handling when the new network policies are created or not.

Use port names instead of numbers for the probes and update the validation schema to accept both integers and strings for the ports.

Use port names instead of numbers for the Ingress resources.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
