### PR TITLE
fix(ruler): incorrectly formatted ConfigMap for prometheus rules

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.3.4
+version: 0.4.3
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/ruler/configmaprules.yaml
+++ b/charts/thanos/templates/ruler/configmaprules.yaml
@@ -10,6 +10,6 @@ metadata:
 data:
 {{- range $fname, $content := .Values.ruler.rules }}
   {{ $fname }}: |
-    {{- toYaml (tpl $content $) | nindent 4 }}
+    {{- tpl $content $ | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -623,6 +623,81 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: renders rules configmap data as valid Thanos rules.configGroups with default values
+    template: ruler/configmaprules.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: data["example-alerts.yaml"]
+          value: |
+            groups:
+              - name: thanos-example
+                rules:
+                  - alert: ExampleAlwaysFiring
+                    expr: vector(1)
+                    for: 1m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: Example alert firing
+
+  - it: renders multiple rule files with user-provided content
+    template: ruler/configmaprules.yaml
+    set:
+      ruler.enabled: true
+      ruler.rules:
+        alerts.yaml: |
+          groups:
+            - name: custom
+              rules:
+                - alert: MyAlert
+                  expr: up == 0
+        recording.yaml: |
+          groups:
+            - name: recording
+              rules:
+                - record: job:up
+                  expr: up
+    asserts:
+      - equal:
+          path: data["alerts.yaml"]
+          value: |
+            groups:
+              - name: custom
+                rules:
+                  - alert: MyAlert
+                    expr: up == 0
+      - equal:
+          path: data["recording.yaml"]
+          value: |
+            groups:
+              - name: recording
+                rules:
+                  - record: job:up
+                    expr: up
+
+  - it: renders rules with templated values via tpl
+    template: ruler/configmaprules.yaml
+    set:
+      ruler.enabled: true
+      ruler.rules:
+        alerts.yaml: |
+          groups:
+            - name: {{ .Release.Name }}-alerts
+              rules:
+                - alert: Dummy
+                  expr: vector(1)
+    asserts:
+      - equal:
+          path: data["alerts.yaml"]
+          value: |
+            groups:
+              - name: RELEASE-NAME-alerts
+                rules:
+                  - alert: Dummy
+                    expr: vector(1)
+
   # -- ConfigMap alertmanagers -------------------------------------------
 
   - it: renders alertmanagers configmap when ruler is enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the formatting of the produced ConfigMap for PrometheusRules, with the suffix `-rules` (e.g.: `thanos-RELEASE-NAME-ruler-rules`). This should allow Thanos Ruler pods to start without the errors:

```
...
ts=2026-04-14T16:55:37.598214466Z caller=rule.go:895 level=info component=rules msg="starting rule node"
ts=2026-04-14T16:55:37.598426995Z caller=rule.go:1060 level=info component=rules msg="reload rule files" numFiles=2
ts=2026-04-14T16:55:37.598555858Z caller=intrumentation.go:56 level=info component=rules msg="changing probe status" status=ready
ts=2026-04-14T16:55:37.598739146Z caller=rule.go:705 level=error component=rules msg="initialize rules failed" err="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.598820508Z caller=handler.go:87 level=info caller=manager.go:204 time=2026-04-14T16:55:37.598812531Z msg="Stopping rule manager..."
ts=2026-04-14T16:55:37.598866579Z caller=handler.go:87 level=info caller=manager.go:220 time=2026-04-14T16:55:37.598863228Z msg="Rule manager stopped"
ts=2026-04-14T16:55:37.598927314Z caller=handler.go:87 level=info caller=manager.go:204 time=2026-04-14T16:55:37.598924478Z msg="Stopping rule manager..."
ts=2026-04-14T16:55:37.598986381Z caller=handler.go:87 level=info caller=manager.go:220 time=2026-04-14T16:55:37.598982466Z msg="Rule manager stopped"
ts=2026-04-14T16:55:37.598869395Z caller=grpc.go:158 level=info component=rules service=gRPC/server component=rule msg="listening for serving gRPC" address=0.0.0.0:10901
ts=2026-04-14T16:55:37.599102557Z caller=handler.go:87 level=info caller=manager.go:190 time=2026-04-14T16:55:37.599098195Z msg="Starting rule manager..."
ts=2026-04-14T16:55:37.599162497Z caller=handler.go:87 level=info caller=manager.go:190 time=2026-04-14T16:55:37.599159849Z msg="Starting rule manager..."
ts=2026-04-14T16:55:37.59891246Z caller=intrumentation.go:75 level=info component=rules msg="changing probe status" status=healthy
ts=2026-04-14T16:55:37.599203744Z caller=http.go:72 level=info component=rules service=http/server component=rule msg="listening for requests and metrics" address=0.0.0.0:10902
ts=2026-04-14T16:55:37.599267165Z caller=handler.go:87 level=info component=rules service=http/server component=rule caller=tls_config.go:354 time=2026-04-14T16:55:37.599256006Z msg="Listening on" address=[::]:10902
ts=2026-04-14T16:55:37.599279613Z caller=handler.go:87 level=info component=rules service=http/server component=rule caller=tls_config.go:357 time=2026-04-14T16:55:37.599275813Z msg="TLS is disabled." http2=false address=[::]:10902
ts=2026-04-14T16:55:37.599337482Z caller=intrumentation.go:67 level=warn component=rules msg="changing probe status" status=not-ready reason="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.599368243Z caller=grpc.go:172 level=info component=rules service=gRPC/server component=rule msg="internal server is shutting down" err="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.599411092Z caller=grpc.go:185 level=info component=rules service=gRPC/server component=rule msg="gracefully stopping internal server"
ts=2026-04-14T16:55:37.599496752Z caller=grpc.go:198 level=info component=rules service=gRPC/server component=rule msg="internal server is shutdown gracefully" err="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.599529474Z caller=http.go:90 level=info component=rules service=http/server component=rule msg="internal server is shutting down" err="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.599590822Z caller=http.go:109 level=info component=rules service=http/server component=rule msg="internal server is shutdown gracefully" err="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.599624381Z caller=intrumentation.go:81 level=info component=rules msg="changing probe status" status=not-healthy reason="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups"
ts=2026-04-14T16:55:37.602489495Z caller=main.go:177 level=error err="reloading rules failed: 2 errors: /etc/thanos/rules/example-alerts.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `groups:...` into rules.configGroups; /etc/thanos/rules/rules.yaml: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `` into rules.configGroups\nrule command failed\nmain.main\n\t/app/cmd/thanos/main.go:177\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1268"
```

#### Which issue this PR fixes

- fixes #51

#### Special notes for your reviewer:
@hamdikh Similarly to PR #56 and #57, I bumped the Chart version to `0.4.3`, because I noticed you suggested it be updated to `0.4.0` in [this other PR comment](https://github.com/thanos-community/helm-charts/pull/55#discussion_r3086294957).
Let me know if you want me to change the version to something else, thanks.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
