### PR TITLE
Ci/pin gha versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Thanos Community (Slack)
     url: https://cloud-native.slack.com/archives/CL25937SP
-    about: For questions and general discussion, join #thanos in the CNCF Slack workspace.
+    about: "For questions and general discussion, join #thanos in the CNCF Slack workspace."
   - name: Thanos Discussions (GitHub)
     url: https://github.com/thanos-io/thanos/discussions
     about: Use GitHub Discussions for async support questions about Thanos itself.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Lint Bash scripts
         run: find .github -name '*.sh' -type f -print0 | xargs -0 shellcheck
 
@@ -27,13 +27,13 @@ jobs:
     needs: lint-bash-scripts
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
@@ -42,11 +42,11 @@ jobs:
     needs: lint-chart
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
       - name: Add Helm repos
@@ -88,18 +88,18 @@ jobs:
           - v1.35.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
           config: .github/kind-config.yaml
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
       - name: Add Helm repos and update chart dependencies
         run: |
           helm repo add thanos-community https://thanos-community.github.io/helm-charts

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check documentation formatting (markdownlint)
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9  # v23.0.0
         with:
           globs: |
             **/*.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,15 +16,15 @@ on:
 
 permissions:
   contents: write
-  id-token: write # required for cosign OIDC keyless signing
-  packages: write # required for ghcr.io OCI publishing
+  id-token: write  # required for cosign OIDC keyless signing
+  packages: write  # required for ghcr.io OCI publishing
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -34,10 +34,10 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
 
       - name: Install helm-sigstore plugin
         run: helm plugin install --verify=false https://github.com/sigstore/helm-sigstore
@@ -70,7 +70,7 @@ jobs:
           GPG_KEY_PATH: "${{ runner.temp }}/private.key"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -133,7 +133,7 @@ jobs:
           done
 
       - name: Release charts (GitHub Releases + gh-pages Helm repo)
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         with:
           skip_packaging: true
           config: .cr.yaml

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,16 +13,13 @@ permissions:
 jobs:
   renovate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     env:
       RENOVATE_REPOSITORIES: ${{ github.repository }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Renovate
-        uses: renovatebot/github-action@v46.1.9
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74  # v46.1.9
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,16 @@ repos:
           - '.github/lintconf.yaml'
         exclude: ^charts/.*/templates/
 
+  # Pin GitHub Actions to SHA digests
+  - repo: local
+    hooks:
+      - id: pinact
+        name: Pin GitHub Actions to SHA digests
+        entry: pinact run
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true
+
   # Helm chart linting
   - repo: local
     hooks:

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/tests/bucketweb_test.yaml
+++ b/charts/thanos/tests/bucketweb_test.yaml
@@ -720,6 +720,142 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: does not render HPA when bucket component is disabled
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: false
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render HPA when bucketweb is disabled
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: false
+      bucket.bucketweb.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA scaleTargetRef targets bucketweb Deployment by default
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-thanos-bucketweb
+
+  - it: HPA scaleTargetRef uses custom targetKind
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+      bucket.bucketweb.autoscaling.targetKind: StatefulSet
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+
+  - it: HPA renders CPU metric with correct averageUtilization
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+      bucket.bucketweb.autoscaling.targetCPUUtilizationPercentage: 60
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+
+  - it: HPA renders memory metric when targetMemoryUtilizationPercentage is set
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+      bucket.bucketweb.autoscaling.targetCPUUtilizationPercentage: 80
+      bucket.bucketweb.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders both CPU and memory metrics when both are set
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+      bucket.bucketweb.autoscaling.targetCPUUtilizationPercentage: 80
+      bucket.bucketweb.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders memory-only metric when CPU is not set
+    template: bucket/hpa.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.autoscaling.enabled: true
+      bucket.bucketweb.autoscaling.targetCPUUtilizationPercentage: null
+      bucket.bucketweb.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
   # -- Secret objstore ---------------------------------------------------
 
   - it: renders objstore secret when createSecret is true

--- a/charts/thanos/tests/query_frontend_test.yaml
+++ b/charts/thanos/tests/query_frontend_test.yaml
@@ -689,6 +689,125 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: does not render HPA when queryFrontend component is disabled
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: false
+      queryFrontend.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA scaleTargetRef targets query-frontend Deployment by default
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-thanos-query-frontend
+
+  - it: HPA scaleTargetRef uses custom targetKind
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.autoscaling.enabled: true
+      queryFrontend.autoscaling.targetKind: StatefulSet
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+
+  - it: HPA renders CPU metric with correct averageUtilization
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.autoscaling.enabled: true
+      queryFrontend.autoscaling.targetCPUUtilizationPercentage: 60
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+
+  - it: HPA renders memory metric when targetMemoryUtilizationPercentage is set
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.autoscaling.enabled: true
+      queryFrontend.autoscaling.targetCPUUtilizationPercentage: 80
+      queryFrontend.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders both CPU and memory metrics when both are set
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.autoscaling.enabled: true
+      queryFrontend.autoscaling.targetCPUUtilizationPercentage: 80
+      queryFrontend.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders memory-only metric when CPU is not set
+    template: query-frontend/hpa.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.autoscaling.enabled: true
+      queryFrontend.autoscaling.targetCPUUtilizationPercentage: null
+      queryFrontend.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
   # -- ConfigMap cache ---------------------------------------------------
 
   - it: renders cache configmap when cacheConfig is set

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -694,3 +694,122 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: does not render HPA when query component is disabled
+    template: query/hpa.yaml
+    set:
+      query.enabled: false
+      query.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA scaleTargetRef targets query Deployment by default
+    template: query/hpa.yaml
+    set:
+      query.enabled: true
+      query.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-thanos-query
+
+  - it: HPA scaleTargetRef uses custom targetKind
+    template: query/hpa.yaml
+    set:
+      query.enabled: true
+      query.autoscaling.enabled: true
+      query.autoscaling.targetKind: StatefulSet
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+
+  - it: HPA renders CPU metric with correct averageUtilization
+    template: query/hpa.yaml
+    set:
+      query.enabled: true
+      query.autoscaling.enabled: true
+      query.autoscaling.targetCPUUtilizationPercentage: 60
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+
+  - it: HPA renders memory metric when targetMemoryUtilizationPercentage is set
+    template: query/hpa.yaml
+    set:
+      query.enabled: true
+      query.autoscaling.enabled: true
+      query.autoscaling.targetCPUUtilizationPercentage: 80
+      query.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders both CPU and memory metrics when both are set
+    template: query/hpa.yaml
+    set:
+      query.enabled: true
+      query.autoscaling.enabled: true
+      query.autoscaling.targetCPUUtilizationPercentage: 80
+      query.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders memory-only metric when CPU is not set
+    template: query/hpa.yaml
+    set:
+      query.enabled: true
+      query.autoscaling.enabled: true
+      query.autoscaling.targetCPUUtilizationPercentage: null
+      query.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -682,6 +682,125 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: does not render HPA when storegateway component is disabled
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: false
+      storegateway.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA scaleTargetRef targets storegateway StatefulSet by default
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-thanos-storegateway
+
+  - it: HPA scaleTargetRef uses custom targetKind
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.autoscaling.enabled: true
+      storegateway.autoscaling.targetKind: Deployment
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+
+  - it: HPA renders CPU metric with correct averageUtilization
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.autoscaling.enabled: true
+      storegateway.autoscaling.targetCPUUtilizationPercentage: 60
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+
+  - it: HPA renders memory metric when targetMemoryUtilizationPercentage is set
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.autoscaling.enabled: true
+      storegateway.autoscaling.targetCPUUtilizationPercentage: 80
+      storegateway.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders both CPU and memory metrics when both are set
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.autoscaling.enabled: true
+      storegateway.autoscaling.targetCPUUtilizationPercentage: 80
+      storegateway.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders memory-only metric when CPU is not set
+    template: storegateway/hpa.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.autoscaling.enabled: true
+      storegateway.autoscaling.targetCPUUtilizationPercentage: null
+      storegateway.autoscaling.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
   # -- ConfigMap caching bucket ------------------------------------------
 
   - it: renders caching bucket configmap when cachingBucketConfig is set

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -61,18 +61,20 @@
                   "description": "Target memory utilisation percentage. Null disables memory-based scaling.",
                   "required": [],
                   "title": "targetMemoryUtilizationPercentage",
-                  "type": "null"
+                  "type": ["integer", "null"]
                 }
               },
               "required": [
                 "enabled",
                 "minReplicas",
-                "maxReplicas",
-                "targetCPUUtilizationPercentage",
-                "targetMemoryUtilizationPercentage"
+                "maxReplicas"
               ],
               "title": "autoscaling",
-              "type": "object"
+              "type": "object",
+              "anyOf": [
+                {"required": ["targetCPUUtilizationPercentage"]},
+                {"required": ["targetMemoryUtilizationPercentage"]}
+              ]
             },
             "containerSecurityContext": {
               "additionalProperties": true,
@@ -2500,18 +2502,20 @@
               "description": "Target memory utilisation percentage for Query autoscaling. Null disables memory-based scaling.",
               "required": [],
               "title": "targetMemoryUtilizationPercentage",
-              "type": "null"
+              "type": ["integer", "null"]
             }
           },
           "required": [
             "enabled",
             "minReplicas",
-            "maxReplicas",
-            "targetCPUUtilizationPercentage",
-            "targetMemoryUtilizationPercentage"
+            "maxReplicas"
           ],
           "title": "autoscaling",
-          "type": "object"
+          "type": "object",
+          "anyOf": [
+            {"required": ["targetCPUUtilizationPercentage"]},
+            {"required": ["targetMemoryUtilizationPercentage"]}
+          ]
         },
         "containerSecurityContext": {
           "additionalProperties": true,
@@ -3393,18 +3397,20 @@
               "description": "Target memory utilisation percentage for Query Frontend autoscaling. Null disables memory-based scaling.",
               "required": [],
               "title": "targetMemoryUtilizationPercentage",
-              "type": "null"
+              "type": ["integer", "null"]
             }
           },
           "required": [
             "enabled",
             "minReplicas",
-            "maxReplicas",
-            "targetCPUUtilizationPercentage",
-            "targetMemoryUtilizationPercentage"
+            "maxReplicas"
           ],
           "title": "autoscaling",
-          "type": "object"
+          "type": "object",
+          "anyOf": [
+            {"required": ["targetCPUUtilizationPercentage"]},
+            {"required": ["targetMemoryUtilizationPercentage"]}
+          ]
         },
         "cacheConfig": {
           "default": "",
@@ -6328,18 +6334,20 @@
               "description": "Target memory utilisation percentage for Store Gateway autoscaling. Null disables memory-based scaling.",
               "required": [],
               "title": "targetMemoryUtilizationPercentage",
-              "type": "null"
+              "type": ["integer", "null"]
             }
           },
           "required": [
             "enabled",
             "minReplicas",
-            "maxReplicas",
-            "targetCPUUtilizationPercentage",
-            "targetMemoryUtilizationPercentage"
+            "maxReplicas"
           ],
           "title": "autoscaling",
-          "type": "object"
+          "type": "object",
+          "anyOf": [
+            {"required": ["targetCPUUtilizationPercentage"]},
+            {"required": ["targetMemoryUtilizationPercentage"]}
+          ]
         },
         "cachingBucketConfig": {
           "default": "",

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
-  "autodiscover": true,
   "labels": [
     "renovate"
   ],
@@ -73,6 +73,7 @@
       "matchManagers": [
         "github-actions"
       ],
+      "pinDigests": true,
       "labels": [
         "renovate",
         "github-actions"


### PR DESCRIPTION
#### What this PR does / why we need it:

- **fix: review schema validation for HPA** — corrected JSON schema validation for HPA fields in `values.schema.json` and added unit tests covering HPA configuration for `bucketweb`, `query`, `query-frontend`, and `storegateway` components
- **chore: pin GitHub Actions versions via pinact/renovate** — all GHA workflow action references are now pinned to specific SHA hashes; renovate is configured to keep them up to date automatically via `pinact`

#### Which issue this PR fixes

- fixes #27 
- fixes #43

#### Special notes for your reviewer:

The HPA schema fix is accompanied by new helm unittest cases that validate both enabled and disabled HPA scenarios across all supported components. The GHA pinning uses `pinact` (configured in `.pre-commit-config.yaml`) to enforce and update pins.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md