### PR TITLE
fix(ruler): incorrectly formatted ConfigMap for Prometheus Rule auto-import

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -459,3 +459,16 @@ spec:
         - name: {{ include "thanos.compName" (list $root $comp) }}
           port: {{ $port }}
 {{- end -}}
+
+{{/*
+Render .Values.ruler.autoImportPrometheusRules.labelSelector (a map) as a
+comma-separated "key=value" string suitable for `kubectl get -l`.
+An empty map renders as the empty string.
+*/}}
+{{- define "thanos.ruler.autoImportPrometheusRules.labelSelector" -}}
+{{- $parts := list -}}
+{{- range $k, $v := .Values.ruler.autoImportPrometheusRules.labelSelector -}}
+{{- $parts = append $parts (printf "%s=%s" $k $v) -}}
+{{- end -}}
+{{- join "," $parts -}}
+{{- end -}}

--- a/charts/thanos/templates/ruler/configmap-auto-import-prometheus-rules.yaml
+++ b/charts/thanos/templates/ruler/configmap-auto-import-prometheus-rules.yaml
@@ -7,15 +7,17 @@ data:
   import.sh: |
     set -e
 
-    SELECTOR="{{ .Values.ruler.autoImportPrometheusRules.labelSelector }}"
+    SELECTOR="{{ include "thanos.ruler.autoImportPrometheusRules.labelSelector" . }}"
 
-    if [ -z "$SELECTOR" ] || [ "$SELECTOR" = "{}" ]; then
+    if [ -z "$SELECTOR" ]; then
       echo "No label selector provided, importing ALL PrometheusRules"
       SELECTOR_ARG=""
     else
       echo "Using label selector: $SELECTOR"
       SELECTOR_ARG="-l $SELECTOR"
     fi
+
+    PREV_SUM=""
 
     while true; do
       echo "Syncing PrometheusRules"
@@ -30,9 +32,19 @@ data:
 
         echo "Processing $ns/$name"
 
-        kubectl get prometheusrule "$name" -n "$ns" -o yaml | \
-          yq -y '{groups: .spec.groups}' > "/generated/${ns}-${name}.yaml"
+        kubectl get prometheusrule "$name" -n "$ns" -o jsonpath='{.spec}' \
+          > "/generated/${ns}-${name}.yaml"
       done
+
+      CURRENT_SUM=$(find /generated -type f -name '*.yaml' -exec cat {} + 2>/dev/null | md5sum | cut -d' ' -f1)
+      if [ "$CURRENT_SUM" != "$PREV_SUM" ]; then
+        echo "Rule files changed, triggering Thanos Ruler reload"
+        if curl -sf -X POST http://localhost:10902/-/reload; then
+          PREV_SUM="$CURRENT_SUM"
+        else
+          echo "Failed to reload Thanos Ruler, will retry next cycle"
+        fi
+      fi
 
       sleep 60
     done

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -936,3 +936,39 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: renders empty SELECTOR when labelSelector is empty (imports ALL PrometheusRules)
+    template: ruler/configmap-auto-import-prometheus-rules.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      ruler.autoImportPrometheusRules.labelSelector: {}
+    asserts:
+      - matchRegex:
+          path: data["import.sh"]
+          pattern: 'SELECTOR=""'
+
+  - it: renders SELECTOR as comma-separated key=value list when labelSelector is set
+    template: ruler/configmap-auto-import-prometheus-rules.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      ruler.autoImportPrometheusRules.labelSelector:
+        role: alert-rules
+    asserts:
+      - matchRegex:
+          path: data["import.sh"]
+          pattern: 'SELECTOR="role=alert-rules"'
+
+  - it: joins multiple labelSelector entries with commas
+    template: ruler/configmap-auto-import-prometheus-rules.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      ruler.autoImportPrometheusRules.labelSelector:
+        role: alert-rules
+        team: observability
+    asserts:
+      - matchRegex:
+          path: data["import.sh"]
+          pattern: 'SELECTOR="role=alert-rules,team=observability"'


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fixes the formatting/syntax of the produced ConfigMap/script for PrometheusRules auto-reloading, with the suffix `-rule-importer` (e.g.: `thanos-RELEASE-NAME-ruler-rule-importer`). This should allow Thanos Ruler pods to import PrometheusRules properly, when no label selector is specified (the default behaviour).

#### Which issue this PR fixes

- fixes #68


#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
