### PR TITLE
feat(tls-endpoints): Query TLS enabled endpoints

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -55,6 +55,7 @@ The chart deploys each Thanos component as an independent workload. Enable only 
 | Component | Enabled by Default | Workload | Purpose |
 |-----------|--------------------|----------|---------|
 | **query** | Yes | Deployment | Fan-out query engine. Queries multiple Store API endpoints and deduplicates results. This is the Prometheus-compatible query entrypoint. |
+| **query-tls** | No | Deployment | Fan-out query engine for TLS endpoints. Queries multiple Store API endpoints that are TLS enabled and deduplicates results. The `query` component adds this to its list of endpoints automatically. |
 | **receive** | Yes | StatefulSet | Remote-write endpoint. Accepts Prometheus `remote_write` traffic, stores samples locally, and ships blocks to the object store. |
 | **storegateway** | Yes | StatefulSet | Serves historical blocks from the object store over the Store API. Required for querying data older than what Prometheus/Receive holds locally. |
 | **compactor** | Yes | StatefulSet | Compacts and downsamples blocks in the object store. Runs as a singleton — do not scale above 1 replica. |
@@ -250,6 +251,31 @@ query:
         paths:
           - path: /
             pathType: Prefix
+```
+
+### Query TLS (optional)
+
+The Query TLS component that fans out to TLS registered Store API endpoints and deduplicates results using replica labels.
+It exists because the `thanos query` command does not support a mix of TLS and non-TLS endpoints, so this provides a way
+to add TLS endpoints as well.
+The Query component above automatically includes Query TLS as one of its endpoints so that the results collected by this
+are available to the Query component.
+
+```yaml
+queryTls:
+  enabled: true
+  replicaCount: 2
+
+  # Labels that identify replica identity — used for deduplication
+  replicaLabels:
+    - prometheus_replica
+
+  # gRPC endpoints to query.
+  # Add external Prometheus sidecars or remote store gateways that are TLS enabled here.
+  stores: []
+  # Example:
+  # stores:
+  #   - thanos-gateway.mydomain.com:443
 ```
 
 ### Receive
@@ -738,7 +764,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.serviceMonitor.scheme | string | `""` | Scrape scheme for Query (http or https). |
 | query.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query. Empty uses the Prometheus operator default. |
 | query.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query scraping. |
-| query.stores | list | [] | List of gRPC Store API endpoints that Query should connect to. In-chart components (Receive, Store Gateway, Ruler) are wired automatically. Add external Prometheus sidecars or remote store gateways here. |
+| query.stores | list | [] | List of gRPC Store API endpoints that Query should connect to. In-chart components (Receive, Store Gateway, Ruler) are wired automatically. Add external Prometheus sidecars or remote store gateways that are not TLS enabled here. |
 | query.tolerations | list | [] | Tolerations for Query pod scheduling. |
 | query.topologySpreadConstraints | list | [] | Topology spread constraints for Query pods. |
 | queryFrontend.affinity | object | {} | Affinity rules for Query Frontend pod scheduling. |
@@ -819,6 +845,77 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query Frontend scraping. |
 | queryFrontend.tolerations | list | [] | Tolerations for Query Frontend pod scheduling. |
 | queryFrontend.topologySpreadConstraints | list | [] | Topology spread constraints for Query Frontend pods. |
+| queryTls.affinity | object | {} | Affinity rules for Query TLS pod scheduling. |
+| queryTls.annotations | object | {} | Extra annotations applied to Query TLS resources. |
+| queryTls.autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler for Query TLS. |
+| queryTls.autoscaling.maxReplicas | int | `5` | Maximum number of Query TLS replicas. |
+| queryTls.autoscaling.minReplicas | int | `2` | Minimum number of Query TLS replicas. |
+| queryTls.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilisation percentage for Query TLS autoscaling. |
+| queryTls.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilisation percentage for Query TLS autoscaling. Null disables memory-based scaling. |
+| queryTls.containerSecurityContext | object | {} | Container security context for Query TLS. Overrides global.containerSecurityContext. |
+| queryTls.dnsConfig | object | {} | DNS configuration for Query TLS pods. Overrides global.dnsConfig. |
+| queryTls.enabled | bool | `false` | Enable the Query TLS Deployment. When enabled, the plain Query automatically adds Query TLS as an endpoint. |
+| queryTls.extraArgs[0] | string | `"--log.level=info"` |  |
+| queryTls.extraContainers | list | [] | Extra sidecar containers for Query TLS pods. |
+| queryTls.extraEnv | list | [] | Extra environment variables injected into the Query TLS container. |
+| queryTls.extraEnvFrom | list | [] | Extra environment variable sources for the Query TLS container. |
+| queryTls.extraInitContainers | list | [] | Extra init containers for Query TLS pods. |
+| queryTls.extraVolumeMounts | list | [] | Extra volume mounts for the Query TLS container. |
+| queryTls.extraVolumes | list | [] | Extra volumes for Query TLS pods. |
+| queryTls.labels | object | {} | Extra labels applied to Query TLS resources. |
+| queryTls.nodeSelector | object | {} | Node selector for Query TLS pod scheduling. |
+| queryTls.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Query TLS. |
+| queryTls.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Query TLS pods during a disruption. |
+| queryTls.pdb.minAvailable | int or string | `""` | Minimum available Query TLS pods during a disruption. |
+| queryTls.podSecurityContext | object | {} | Pod security context for Query TLS pods. Overrides global.podSecurityContext. |
+| queryTls.priorityClassName | string | `""` | Priority class name for Query TLS pods. |
+| queryTls.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Query TLS. |
+| queryTls.probes.liveness.failureThreshold | int | `6` | Consecutive failures before the Query TLS container is restarted. |
+| queryTls.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query TLS liveness probe. |
+| queryTls.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query TLS liveness probe. |
+| queryTls.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query TLS liveness probe. |
+| queryTls.probes.liveness.port | int or string | `"http"` | Port checked by the Query TLS liveness probe. |
+| queryTls.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query TLS container is considered live. |
+| queryTls.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query TLS liveness probe times out. |
+| queryTls.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query TLS. |
+| queryTls.probes.readiness.failureThreshold | int | `6` | Consecutive failures before the Query TLS pod is marked not-ready. |
+| queryTls.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query TLS readiness probe. |
+| queryTls.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query TLS readiness probe. |
+| queryTls.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query TLS readiness probe. |
+| queryTls.probes.readiness.port | int or string | `"http"` | Port checked by the Query TLS readiness probe. |
+| queryTls.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query TLS pod is marked ready. |
+| queryTls.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query TLS readiness probe times out. |
+| queryTls.probes.startup.enabled | bool | `true` | Enable the startup probe for Query TLS. |
+| queryTls.probes.startup.failureThreshold | int | `60` | Consecutive failures during Query TLS startup before the container is killed. |
+| queryTls.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query TLS startup probe. |
+| queryTls.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query TLS startup probe. |
+| queryTls.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query TLS startup probe. |
+| queryTls.probes.startup.port | int or string | `"http"` | Port checked by the Query TLS startup probe. |
+| queryTls.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query TLS startup probe is considered passed. |
+| queryTls.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query TLS startup probe times out. |
+| queryTls.replicaCount | int | `2` | Number of Query TLS pod replicas. |
+| queryTls.replicaLabels | list | `["prometheus_replica"]` | Label names that identify replica identity for result deduplication. |
+| queryTls.resources | object | {} | Resource requests and limits for the Query TLS container. |
+| queryTls.service.annotations | object | {} | Extra annotations for the Query TLS Service. |
+| queryTls.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Query TLS Service. |
+| queryTls.service.httpPort | int | `9090` | HTTP/PromQL port exposed by the Query TLS Service. |
+| queryTls.service.labels | object | {} | Extra labels for the Query TLS Service. |
+| queryTls.service.type | string | `"ClusterIP"` | Kubernetes Service type for Query TLS. |
+| queryTls.serviceMonitor.annotations | object | {} | Extra annotations for the Query TLS ServiceMonitor. |
+| queryTls.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Query TLS. |
+| queryTls.serviceMonitor.interval | string | `""` | Scrape interval for Query TLS. Empty uses the Prometheus operator default. |
+| queryTls.serviceMonitor.labels | object | {} | Extra labels for the Query TLS ServiceMonitor. |
+| queryTls.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Query TLS metrics are ingested. |
+| queryTls.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Query TLS metrics are ingested. |
+| queryTls.serviceMonitor.scheme | string | `""` | Scrape scheme for Query TLS (http or https). |
+| queryTls.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query TLS. Empty uses the Prometheus operator default. |
+| queryTls.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query TLS scraping. |
+| queryTls.stores | list | [] | List of remote gRPC Store API endpoints that require TLS. Add external Prometheus sidecars or remote store gateways that are TLS enabled here. |
+| queryTls.tls.ca | string | `""` | Path to the CA certificate file used to verify the remote endpoint. Leave empty to use the system trust store. |
+| queryTls.tls.cert | string | `""` | Path to the TLS client certificate file (PEM). Leave empty when the remote endpoint uses a publicly trusted CA. |
+| queryTls.tls.key | string | `""` | Path to the TLS client private key file (PEM). |
+| queryTls.tolerations | list | [] | Tolerations for Query TLS pod scheduling. |
+| queryTls.topologySpreadConstraints | list | [] | Topology spread constraints for Query TLS pods. |
 | receive.affinity | object | {} | Affinity rules for Receive pod scheduling. |
 | receive.annotations | object | {} | Extra annotations applied to Receive resources. |
 | receive.containerSecurityContext | object | {} | Container security context for Receive. Overrides global.containerSecurityContext. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -43,6 +43,7 @@ The chart deploys each Thanos component as an independent workload. Enable only 
 | Component | Enabled by Default | Workload | Purpose |
 |-----------|--------------------|----------|---------|
 | **query** | Yes | Deployment | Fan-out query engine. Queries multiple Store API endpoints and deduplicates results. This is the Prometheus-compatible query entrypoint. |
+| **query-tls** | No | Deployment | Fan-out query engine for TLS endpoints. Queries multiple Store API endpoints that are TLS enabled and deduplicates results. The `query` component adds this to its list of endpoints automatically. |
 | **receive** | Yes | StatefulSet | Remote-write endpoint. Accepts Prometheus `remote_write` traffic, stores samples locally, and ships blocks to the object store. |
 | **storegateway** | Yes | StatefulSet | Serves historical blocks from the object store over the Store API. Required for querying data older than what Prometheus/Receive holds locally. |
 | **compactor** | Yes | StatefulSet | Compacts and downsamples blocks in the object store. Runs as a singleton — do not scale above 1 replica. |
@@ -238,6 +239,31 @@ query:
         paths:
           - path: /
             pathType: Prefix
+```
+
+### Query TLS (optional)
+
+The Query TLS component that fans out to TLS registered Store API endpoints and deduplicates results using replica labels.
+It exists because the `thanos query` command does not support a mix of TLS and non-TLS endpoints, so this provides a way
+to add TLS endpoints as well.
+The Query component above automatically includes Query TLS as one of its endpoints so that the results collected by this
+are available to the Query component.
+
+```yaml
+queryTls:
+  enabled: true
+  replicaCount: 2
+
+  # Labels that identify replica identity — used for deduplication
+  replicaLabels:
+    - prometheus_replica
+
+  # gRPC endpoints to query.
+  # Add external Prometheus sidecars or remote store gateways that are TLS enabled here.
+  stores: []
+  # Example:
+  # stores:
+  #   - thanos-gateway.mydomain.com:443
 ```
 
 ### Receive

--- a/charts/thanos/templates/NOTES.txt
+++ b/charts/thanos/templates/NOTES.txt
@@ -5,6 +5,7 @@ Components enabled:
 - compactor: {{ .Values.compactor.enabled }}
 - query: {{ .Values.query.enabled }}
 - query-frontend: {{ .Values.queryFrontend.enabled }}
+- query-tls: {{ .Values.queryTls.enabled }}
 - receive: {{ .Values.receive.enabled }}
 - ruler: {{ .Values.ruler.enabled }}
 - storegateway: {{ .Values.storegateway.enabled }}

--- a/charts/thanos/templates/query-tls/deployment.yaml
+++ b/charts/thanos/templates/query-tls/deployment.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.queryTls.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+    {{- with .Values.queryTls.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.queryTls.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  replicas: {{ .Values.queryTls.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+      labels:
+        app.kubernetes.io/component: query-tls
+        {{- include "thanos.labels" . | nindent 8 }}
+    spec:
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      containers:
+        - args:
+            - query
+            {{- range .Values.queryTls.stores }}
+            - --endpoint={{ . }}
+            {{- end }}
+            - --grpc-address=0.0.0.0:{{ .Values.queryTls.service.grpcPort }}
+            {{- if .Values.queryTls.tls.ca }}
+            - --grpc-client-tls-ca={{ .Values.queryTls.tls.ca }}
+            {{- end }}
+            {{- if .Values.queryTls.tls.cert }}
+            - --grpc-client-tls-cert={{ .Values.queryTls.tls.cert }}
+            {{- end }}
+            {{- if .Values.queryTls.tls.key }}
+            - --grpc-client-tls-key={{ .Values.queryTls.tls.key }}
+            {{- end }}
+            - --grpc-client-tls-secure
+            - --http-address=0.0.0.0:{{ .Values.queryTls.service.httpPort }}
+            {{- range .Values.queryTls.replicaLabels }}
+            - --query.replica-label={{ . }}
+            {{- end }}
+            {{- range .Values.queryTls.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "queryTls") | nindent 10 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "queryTls") | nindent 10 }}
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          name: query-tls
+          ports:
+            - containerPort: {{ .Values.queryTls.service.grpcPort }}
+              name: grpc
+            - containerPort: {{ .Values.queryTls.service.httpPort }}
+              name: http
+          {{- include "thanos.extraMountsBlock" (dict "root" . "key" "queryTls") | nindent 10 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "queryTls") | nindent 10 }}
+          resources:
+            {{- toYaml .Values.queryTls.resources | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "queryTls" "port" "http") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "queryTls" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "queryTls" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "queryTls") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "queryTls") | nindent 6 }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      {{- include "thanos.extraVolumesBlock" (dict "root" . "key" "queryTls") | nindent 6 }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/hpa.yaml
+++ b/charts/thanos/templates/query-tls/hpa.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.queryTls.enabled .Values.queryTls.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  maxReplicas: {{ .Values.queryTls.autoscaling.maxReplicas }}
+  metrics:
+    {{- $cpu := .Values.queryTls.autoscaling.targetCPUUtilizationPercentage }}
+    {{- $mem := .Values.queryTls.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if or $cpu $mem }}
+    {{- if $cpu }}
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: {{ $cpu }}
+          type: Utilization
+      type: Resource
+    {{- end }}
+    {{- if $mem }}
+    - resource:
+        name: memory
+        target:
+          averageUtilization: {{ $mem }}
+          type: Utilization
+      type: Resource
+    {{- end }}
+    {{- else }}
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    {{- end }}
+  minReplicas: {{ .Values.queryTls.autoscaling.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.queryTls.autoscaling.targetKind | default "Deployment" }}
+    name: {{ include "thanos.compName" (list . "query-tls") }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/networkpolicy.yaml
+++ b/charts/thanos/templates/query-tls/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.queryTls.enabled .Values.global.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: query-tls
+    {{- include "thanos.labels" . | nindent 4 }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: grpc
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress
+{{- end }}

--- a/charts/thanos/templates/query-tls/pdb.yaml
+++ b/charts/thanos/templates/query-tls/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.queryTls.enabled (or .Values.queryTls.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $maxUnavail := .Values.queryTls.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
+{{- $minAvail := .Values.queryTls.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  {{- if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
+  {{- else if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/service.yaml
+++ b/charts/thanos/templates/query-tls/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.queryTls.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+    {{- with .Values.queryTls.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.queryTls.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  ports:
+    - name: grpc
+      port: {{ .Values.queryTls.service.grpcPort }}
+      targetPort: grpc
+    - name: http
+      port: {{ .Values.queryTls.service.httpPort }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: query-tls
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  type: {{ .Values.queryTls.service.type }}
+{{- end }}

--- a/charts/thanos/templates/query-tls/servicemonitor.yaml
+++ b/charts/thanos/templates/query-tls/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.queryTls.enabled (or .Values.queryTls.serviceMonitor.enabled .Values.global.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "queryTls") | nindent 4 }}
+  labels:
+    {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
+    {{- if .Values.queryTls.serviceMonitor.labels }}{{ toYaml .Values.queryTls.serviceMonitor.labels | nindent 4 }}{{- end }}
+  name: {{ include "thanos.compName" (list . "query-tls") }}
+spec:
+  endpoints:
+    - interval: {{ default .Values.global.serviceMonitor.interval .Values.queryTls.serviceMonitor.interval | quote }}
+      {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.queryTls.serviceMonitor.metricRelabelings) }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      path: /metrics
+      port: http
+      {{- with (default .Values.global.serviceMonitor.relabelings .Values.queryTls.serviceMonitor.relabelings) }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.queryTls.serviceMonitor.scrapeTimeout | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tls
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: thanos
+{{- end }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - query
             - --http-address=0.0.0.0:{{ .Values.query.service.httpPort }}
             - --grpc-address=0.0.0.0:{{ .Values.query.service.grpcPort }}
+          {{- if .Values.queryTls.enabled }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "query-tls") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+          {{- end }}
           {{- if .Values.storegateway.enabled }}
             # - --endpoint={{ include "thanos.compName" (list . "storegateway") }}:{{ .Values.storegateway.service.grpcPort }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}

--- a/charts/thanos/tests/query_tls_test.yaml
+++ b/charts/thanos/tests/query_tls_test.yaml
@@ -1,41 +1,41 @@
-suite: query component
+suite: query-tls component
 
 tests:
   # -- Deployment basics ----------------------------------------------
 
-  - it: renders deployment when query is enabled
-    template: query/deployment.yaml
+  - it: renders deployment when query-tls is enabled
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
     asserts:
       - isKind:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-thanos-query
+          value: RELEASE-NAME-thanos-query-tls
 
-  - it: does not render when query is disabled
-    template: query/deployment.yaml
+  - it: does not render when query-tls is disabled
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: false
+      queryTls.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
   - it: sets the correct replica count
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.replicaCount: 3
+      queryTls.enabled: true
+      queryTls.replicaCount: 3
     asserts:
       - equal:
           path: spec.replicas
           value: 3
 
   - it: uses the global image repository and tag
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.image.repository: quay.io/thanos/thanos
       global.image.tag: v0.40.0
     asserts:
@@ -44,10 +44,10 @@ tests:
           value: quay.io/thanos/thanos:v0.40.0
 
   - it: passes replica labels as CLI args
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.replicaLabels:
+      queryTls.enabled: true
+      queryTls.replicaLabels:
         - prometheus_replica
         - thanos_replica
     asserts:
@@ -58,33 +58,11 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --query.replica-label=thanos_replica
 
-  - it: adds store endpoints for storegateway when enabled
-    template: query/deployment.yaml
-    set:
-      query.enabled: true
-      storegateway.enabled: true
-      receive.enabled: false
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[3]
-          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*storegateway\\..*"
-
-  - it: adds store endpoint for query-tls when enabled
-    template: query/deployment.yaml
-    set:
-      query.enabled: true
-      queryTls.enabled: true
-      receive.enabled: false
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[3]
-          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*query-tls\\..*"
-
   - it: passes extra CLI args
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.extraArgs:
+      queryTls.enabled: true
+      queryTls.extraArgs:
         - --log.level=debug
     asserts:
       - contains:
@@ -94,10 +72,10 @@ tests:
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.annotations:
+      queryTls.enabled: true
+      queryTls.annotations:
         custom-annotation: my-value
     asserts:
       - equal:
@@ -105,10 +83,10 @@ tests:
           value: my-value
 
   - it: applies component labels
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.labels:
+      queryTls.enabled: true
+      queryTls.labels:
         custom-label: my-value
     asserts:
       - equal:
@@ -118,10 +96,10 @@ tests:
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.extraEnv:
+      queryTls.enabled: true
+      queryTls.extraEnv:
         - name: LOG_FORMAT
           value: json
     asserts:
@@ -132,15 +110,15 @@ tests:
             value: json
 
   - it: merges global and component extraEnv with component winning
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.extraEnv:
         - name: LOG_FORMAT
           value: json
         - name: SHARED_VAR
           value: global-value
-      query.extraEnv:
+      queryTls.extraEnv:
         - name: SHARED_VAR
           value: component-value
     asserts:
@@ -158,15 +136,15 @@ tests:
   # -- Extra envFrom vars -----------------------------------------------
 
   - it: merges global and component extraEnvFrom with component winning
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.extraEnvFrom:
         - name: GLOBAL_FROM
           value: global-value
         - name: SHARED_FROM
           value: global-value
-      query.extraEnvFrom:
+      queryTls.extraEnvFrom:
         - name: SHARED_FROM
           value: component-value
     asserts:
@@ -184,9 +162,9 @@ tests:
   # -- Security contexts ----------------------------------------------
 
   - it: applies global container security context
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.containerSecurityContext:
         readOnlyRootFilesystem: true
         runAsNonRoot: true
@@ -199,12 +177,12 @@ tests:
           value: true
 
   - it: applies component container security context overriding global
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.containerSecurityContext:
         runAsNonRoot: true
-      query.containerSecurityContext:
+      queryTls.containerSecurityContext:
         runAsNonRoot: false
         runAsUser: 1001
     asserts:
@@ -216,10 +194,10 @@ tests:
           value: 1001
 
   - it: applies pod security context
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.podSecurityContext:
+      queryTls.enabled: true
+      queryTls.podSecurityContext:
         fsGroup: 1001
     asserts:
       - equal:
@@ -229,9 +207,9 @@ tests:
   # -- DNS configuration -----------------------------------------------
 
   - it: applies global dnsConfig as fallback
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.dnsConfig:
         options:
           - name: ndots
@@ -245,14 +223,14 @@ tests:
           value: "1"
 
   - it: applies component dnsConfig overriding global
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.dnsConfig:
         options:
           - name: ndots
             value: "5"
-      query.dnsConfig:
+      queryTls.dnsConfig:
         options:
           - name: ndots
             value: "1"
@@ -265,9 +243,9 @@ tests:
           value: "1"
 
   - it: does not render dnsConfig when not set
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
     asserts:
       - isNull:
           path: spec.template.spec.dnsConfig
@@ -275,9 +253,9 @@ tests:
   # -- Scheduling and placement ---------------------------------------
 
   - it: applies component affinity overriding global
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -287,7 +265,7 @@ tests:
                     operator: In
                     values:
                       - ap-southeast-2a
-      query.affinity:
+      queryTls.affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -303,9 +281,9 @@ tests:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -320,12 +298,12 @@ tests:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies component nodeSelector overriding global
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.nodeSelector:
         node-role: node
-      query.nodeSelector:
+      queryTls.nodeSelector:
         node-role: thanos
     asserts:
       - equal:
@@ -333,9 +311,9 @@ tests:
           value: thanos
 
   - it: applies global nodeSelector as fallback
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.nodeSelector:
         node-role: thanos
     asserts:
@@ -344,10 +322,10 @@ tests:
           value: thanos
 
   - it: applies component tolerations
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
-      query.tolerations:
+      queryTls.enabled: true
+      queryTls.tolerations:
         - key: dedicated
           operator: Equal
           value: thanos
@@ -362,9 +340,9 @@ tests:
             effect: NoSchedule
 
   - it: applies global tolerations as fallback
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.tolerations:
         - key: dedicated
           operator: Equal
@@ -380,9 +358,9 @@ tests:
             effect: NoSchedule
 
   - it: applies component topologySpreadConstraints overriding global
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -390,7 +368,7 @@ tests:
           labelSelector:
             matchLabels:
               app: thanos
-      query.topologySpreadConstraints:
+      queryTls.topologySpreadConstraints:
         - maxSkew: 2
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
@@ -409,9 +387,9 @@ tests:
                 app: thanos
 
   - it: applies global topologySpreadConstraints as fallback
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -431,20 +409,20 @@ tests:
                 app: thanos
 
   - it: applies component priorityClassName overriding global
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.priorityClassName: high-priority
-      query.priorityClassName: critical
+      queryTls.priorityClassName: critical
     asserts:
       - equal:
           path: spec.template.spec.priorityClassName
           value: critical
 
   - it: applies global priorityClassName as fallback
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.priorityClassName: high-priority
     asserts:
       - equal:
@@ -454,14 +432,14 @@ tests:
   # -- Extra init and sidecar containers ------------------------------
 
   - it: merges global and component extraInitContainers
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.extraInitContainers:
         - name: global-init
           image: busybox:latest
           command: ["echo", "global"]
-      query.extraInitContainers:
+      queryTls.extraInitContainers:
         - name: component-init
           image: busybox:latest
           command: ["echo", "component"]
@@ -480,14 +458,14 @@ tests:
             command: ["echo", "component"]
 
   - it: merges global and component extraContainers
-    template: query/deployment.yaml
+    template: query-tls/deployment.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.extraContainers:
         - name: global-init
           image: busybox:latest
           command: ["echo", "global"]
-      query.extraContainers:
+      queryTls.extraContainers:
         - name: component-init
           image: busybox:latest
           command: ["echo", "component"]
@@ -508,10 +486,10 @@ tests:
   # -- Service --------------------------------------------------------
 
   - it: applies service annotations
-    template: query/service.yaml
+    template: query-tls/service.yaml
     set:
-      query.enabled: true
-      query.service.annotations:
+      queryTls.enabled: true
+      queryTls.service.annotations:
         custom-annotation: my-value
     asserts:
       - equal:
@@ -519,10 +497,10 @@ tests:
           value: my-value
 
   - it: applies service labels
-    template: query/service.yaml
+    template: query-tls/service.yaml
     set:
-      query.enabled: true
-      query.service.labels:
+      queryTls.enabled: true
+      queryTls.service.labels:
         monitoring: "true"
     asserts:
       - equal:
@@ -532,11 +510,11 @@ tests:
   # -- PodDisruptionBudget --------------------------------------------
 
   - it: renders PDB when component pdb is enabled
-    template: query/pdb.yaml
+    template: query-tls/pdb.yaml
     set:
-      query.enabled: true
-      query.pdb.enabled: true
-      query.pdb.maxUnavailable: "1"
+      queryTls.enabled: true
+      queryTls.pdb.enabled: true
+      queryTls.pdb.maxUnavailable: "1"
     asserts:
       - isKind:
           of: PodDisruptionBudget
@@ -545,9 +523,9 @@ tests:
           value: 1
 
   - it: renders PDB via global pdb.enabled fallback
-    template: query/pdb.yaml
+    template: query-tls/pdb.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.pdb.enabled: true
       global.pdb.minAvailable: "1"
     asserts:
@@ -558,117 +536,55 @@ tests:
           value: 1
 
   - it: component PDB values override global
-    template: query/pdb.yaml
+    template: query-tls/pdb.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.pdb.enabled: true
       global.pdb.minAvailable: "1"
-      query.pdb.minAvailable: "3"
+      queryTls.pdb.minAvailable: "3"
     asserts:
       - equal:
           path: spec.minAvailable
           value: 3
 
   - it: does not render PDB when both component and global pdb are disabled
-    template: query/pdb.yaml
+    template: query-tls/pdb.yaml
     set:
-      query.enabled: true
-      query.pdb.enabled: false
+      queryTls.enabled: true
+      queryTls.pdb.enabled: false
       global.pdb.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  # -- Ingress -----------------------------------------------------------
-
-  - it: renders ingress when enabled
-    template: query/ingress.yaml
-    set:
-      query.enabled: true
-      query.ingress.enabled: true
-      query.ingress.hosts:
-        - host: thanos.example.com
-          paths:
-            - path: /
-              pathType: Prefix
-    asserts:
-      - isKind:
-          of: Ingress
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-thanos-query
-
-  - it: does not render ingress when disabled
-    template: query/ingress.yaml
-    set:
-      query.enabled: true
-      query.ingress.enabled: false
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: sets ingress class name
-    template: query/ingress.yaml
-    set:
-      query.enabled: true
-      query.ingress.enabled: true
-      query.ingress.className: nginx
-      query.ingress.hosts:
-        - host: thanos.example.com
-          paths:
-            - path: /
-              pathType: Prefix
-    asserts:
-      - equal:
-          path: spec.ingressClassName
-          value: nginx
-
-  - it: sets ingress host and path
-    template: query/ingress.yaml
-    set:
-      query.enabled: true
-      query.ingress.enabled: true
-      query.ingress.hosts:
-        - host: thanos.example.com
-          paths:
-            - path: /
-              pathType: Prefix
-    asserts:
-      - equal:
-          path: spec.rules[0].host
-          value: thanos.example.com
-      - equal:
-          path: spec.rules[0].http.paths[0].path
-          value: /
-
   # -- ServiceMonitor ----------------------------------------------------
 
   - it: renders servicemonitor when component enabled
-    template: query/servicemonitor.yaml
+    template: query-tls/servicemonitor.yaml
     set:
-      query.enabled: true
-      query.serviceMonitor.enabled: true
+      queryTls.enabled: true
+      queryTls.serviceMonitor.enabled: true
     asserts:
       - isKind:
           of: ServiceMonitor
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-thanos-query
+          value: RELEASE-NAME-thanos-query-tls
 
   - it: renders servicemonitor via global fallback
-    template: query/servicemonitor.yaml
+    template: query-tls/servicemonitor.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.serviceMonitor.enabled: true
     asserts:
       - isKind:
           of: ServiceMonitor
 
   - it: does not render servicemonitor when disabled
-    template: query/servicemonitor.yaml
+    template: query-tls/servicemonitor.yaml
     set:
-      query.enabled: true
-      query.serviceMonitor.enabled: false
+      queryTls.enabled: true
+      queryTls.serviceMonitor.enabled: false
       global.serviceMonitor.enabled: false
     asserts:
       - hasDocuments:
@@ -677,19 +593,19 @@ tests:
   # -- HorizontalPodAutoscaler ------------------------------------------
 
   - it: renders HPA when autoscaling is enabled
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
-      query.autoscaling.minReplicas: 1
-      query.autoscaling.maxReplicas: 3
-      query.autoscaling.targetCPUUtilizationPercentage: 80
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
+      queryTls.autoscaling.minReplicas: 1
+      queryTls.autoscaling.maxReplicas: 3
+      queryTls.autoscaling.targetCPUUtilizationPercentage: 80
     asserts:
       - isKind:
           of: HorizontalPodAutoscaler
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-thanos-query
+          value: RELEASE-NAME-thanos-query-tls
       - equal:
           path: spec.minReplicas
           value: 1
@@ -698,53 +614,53 @@ tests:
           value: 3
 
   - it: does not render HPA when autoscaling is disabled
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: false
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: does not render HPA when query component is disabled
-    template: query/hpa.yaml
+  - it: does not render HPA when query-tls component is disabled
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: false
-      query.autoscaling.enabled: true
+      queryTls.enabled: false
+      queryTls.autoscaling.enabled: true
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: HPA scaleTargetRef targets query Deployment by default
-    template: query/hpa.yaml
+  - it: HPA scaleTargetRef targets query-tls Deployment by default
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.scaleTargetRef.kind
           value: Deployment
       - equal:
           path: spec.scaleTargetRef.name
-          value: RELEASE-NAME-thanos-query
+          value: RELEASE-NAME-thanos-query-tls
 
   - it: HPA scaleTargetRef uses custom targetKind
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
-      query.autoscaling.targetKind: StatefulSet
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
+      queryTls.autoscaling.targetKind: StatefulSet
     asserts:
       - equal:
           path: spec.scaleTargetRef.kind
           value: StatefulSet
 
   - it: HPA renders CPU metric with correct averageUtilization
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
-      query.autoscaling.targetCPUUtilizationPercentage: 60
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
+      queryTls.autoscaling.targetCPUUtilizationPercentage: 60
     asserts:
       - contains:
           path: spec.metrics
@@ -757,12 +673,12 @@ tests:
                 averageUtilization: 60
 
   - it: HPA renders memory metric when targetMemoryUtilizationPercentage is set
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
-      query.autoscaling.targetCPUUtilizationPercentage: 80
-      query.autoscaling.targetMemoryUtilizationPercentage: 75
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
+      queryTls.autoscaling.targetCPUUtilizationPercentage: 80
+      queryTls.autoscaling.targetMemoryUtilizationPercentage: 75
     asserts:
       - contains:
           path: spec.metrics
@@ -775,12 +691,12 @@ tests:
                 averageUtilization: 75
 
   - it: HPA renders both CPU and memory metrics when both are set
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
-      query.autoscaling.targetCPUUtilizationPercentage: 80
-      query.autoscaling.targetMemoryUtilizationPercentage: 75
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
+      queryTls.autoscaling.targetCPUUtilizationPercentage: 80
+      queryTls.autoscaling.targetMemoryUtilizationPercentage: 75
     asserts:
       - lengthEqual:
           path: spec.metrics
@@ -805,12 +721,12 @@ tests:
                 averageUtilization: 75
 
   - it: HPA renders memory-only metric when CPU is not set
-    template: query/hpa.yaml
+    template: query-tls/hpa.yaml
     set:
-      query.enabled: true
-      query.autoscaling.enabled: true
-      query.autoscaling.targetCPUUtilizationPercentage: null
-      query.autoscaling.targetMemoryUtilizationPercentage: 75
+      queryTls.enabled: true
+      queryTls.autoscaling.enabled: true
+      queryTls.autoscaling.targetCPUUtilizationPercentage: null
+      queryTls.autoscaling.targetMemoryUtilizationPercentage: 75
     asserts:
       - lengthEqual:
           path: spec.metrics
@@ -828,27 +744,27 @@ tests:
   # -- NetworkPolicy -------------------------------------------------------
 
   - it: does not render networkpolicy when networkPolicies is disabled
-    template: query/networkpolicy.yaml
+    template: query-tls/networkpolicy.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.networkPolicies: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: does not render networkpolicy when query is disabled
-    template: query/networkpolicy.yaml
+  - it: does not render networkpolicy when query-tls is disabled
+    template: query-tls/networkpolicy.yaml
     set:
-      query.enabled: false
+      queryTls.enabled: false
       global.networkPolicies: true
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: renders networkpolicy when query and networkPolicies are enabled
-    template: query/networkpolicy.yaml
+  - it: renders networkpolicy when query-tls and networkPolicies are enabled
+    template: query-tls/networkpolicy.yaml
     set:
-      query.enabled: true
+      queryTls.enabled: true
       global.networkPolicies: true
     asserts:
       - isKind:
@@ -858,4 +774,4 @@ tests:
           value: networking.k8s.io/v1
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-thanos-query
+          value: RELEASE-NAME-thanos-query-tls

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -7372,6 +7372,758 @@
       ],
       "title": "storegateway",
       "type": "object"
+    },
+    "queryTls": {
+      "additionalProperties": true,
+      "description": "Query TLS component — TLS-enabled Query for reaching remote gRPC Store API endpoints.",
+      "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "description": "Affinity rules for Query pod scheduling.",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Extra annotations applied to Query resources.",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "autoscaling": {
+          "additionalProperties": true,
+          "description": "HorizontalPodAutoscaler configuration for the Query component.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable HorizontalPodAutoscaler for the Query component.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxReplicas": {
+              "default": 5,
+              "description": "Maximum number of Query replicas.",
+              "required": [],
+              "title": "maxReplicas",
+              "type": "integer"
+            },
+            "minReplicas": {
+              "default": 2,
+              "description": "Minimum number of Query replicas.",
+              "required": [],
+              "title": "minReplicas",
+              "type": "integer"
+            },
+            "targetCPUUtilizationPercentage": {
+              "default": 80,
+              "description": "Target CPU utilisation percentage for Query autoscaling.",
+              "required": [],
+              "title": "targetCPUUtilizationPercentage",
+              "type": "integer"
+            },
+            "targetMemoryUtilizationPercentage": {
+              "default": "null",
+              "description": "Target memory utilisation percentage for Query autoscaling. Null disables memory-based scaling.",
+              "required": [],
+              "title": "targetMemoryUtilizationPercentage",
+              "type": ["integer", "null"]
+            }
+          },
+          "required": [
+            "enabled",
+            "minReplicas",
+            "maxReplicas"
+          ],
+          "title": "autoscaling",
+          "type": "object",
+          "anyOf": [
+            {"required": ["targetCPUUtilizationPercentage"]},
+            {"required": ["targetMemoryUtilizationPercentage"]}
+          ]
+        },
+        "containerSecurityContext": {
+          "additionalProperties": true,
+          "description": "Container security context for Query. Overrides global.containerSecurityContext.",
+          "required": [],
+          "title": "containerSecurityContext",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable the Query Deployment.",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "extraArgs": {
+          "description": "Additional CLI arguments appended to the `thanos query` command.",
+          "items": {
+            "anyOf": [
+              {
+                "required": [],
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "required": [],
+          "title": "extraArgs",
+          "type": "array"
+        },
+        "extraContainers": {
+          "description": "Extra sidecar containers for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraContainers",
+          "type": "array"
+        },
+        "extraEnv": {
+          "description": "Extra environment variables injected into the Query container.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraEnv",
+          "type": "array"
+        },
+        "extraEnvFrom": {
+          "description": "Extra environment variable sources for the Query container.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraEnvFrom",
+          "type": "array"
+        },
+        "extraInitContainers": {
+          "description": "Extra init containers for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraInitContainers",
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "description": "Extra volume mounts for the Query container.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraVolumeMounts",
+          "type": "array"
+        },
+        "extraVolumes": {
+          "description": "Extra volumes for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraVolumes",
+          "type": "array"
+        },
+        "labels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Query resources.",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "nodeSelector": {
+          "additionalProperties": true,
+          "description": "Node selector for Query pod scheduling.",
+          "required": [],
+          "title": "nodeSelector",
+          "type": "object"
+        },
+        "pdb": {
+          "additionalProperties": true,
+          "description": "PodDisruptionBudget configuration for the Query component.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable a PodDisruptionBudget for Query.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "default": "",
+              "description": "Maximum unavailable Query pods during a disruption.",
+              "required": [],
+              "title": "maxUnavailable",
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "minAvailable": {
+              "default": "",
+              "description": "Minimum available Query pods during a disruption.",
+              "required": [],
+              "title": "minAvailable",
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "enabled",
+            "minAvailable",
+            "maxUnavailable"
+          ],
+          "title": "pdb",
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "additionalProperties": true,
+          "description": "Pod security context for Query pods. Overrides global.podSecurityContext.",
+          "required": [],
+          "title": "podSecurityContext",
+          "type": "object"
+        },
+        "priorityClassName": {
+          "default": "",
+          "description": "Priority class name for Query pods.",
+          "required": [],
+          "title": "priorityClassName",
+          "type": "string"
+        },
+        "probes": {
+          "additionalProperties": true,
+          "description": "Health and readiness probe configuration for the Query component.",
+          "properties": {
+            "liveness": {
+              "additionalProperties": true,
+              "description": "Liveness probe for the Query component.",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Enable the liveness probe for Query.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "default": 6,
+                  "description": "Consecutive failures before the Query container is restarted.",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "default": 30,
+                  "description": "Seconds to wait before starting the Query liveness probe.",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/-/healthy",
+                  "description": "HTTP path checked by the Query liveness probe.",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 10,
+                  "description": "How often (seconds) to run the Query liveness probe.",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "port": {
+                  "default": "http",
+                  "description": "Port checked by the Query liveness probe.",
+                  "required": [],
+                  "title": "port",
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Consecutive successes before the Query container is considered live.",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "default": 5,
+                  "description": "Seconds after which the Query liveness probe times out.",
+                  "required": [],
+                  "title": "timeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled",
+                "path",
+                "port",
+                "initialDelaySeconds",
+                "periodSeconds",
+                "timeoutSeconds",
+                "failureThreshold",
+                "successThreshold"
+              ],
+              "title": "liveness",
+              "type": "object"
+            },
+            "readiness": {
+              "additionalProperties": true,
+              "description": "Readiness probe for the Query component.",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Enable the readiness probe for Query.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "default": 6,
+                  "description": "Consecutive failures before the Query pod is marked not-ready.",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "default": 5,
+                  "description": "Seconds to wait before starting the Query readiness probe.",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/-/ready",
+                  "description": "HTTP path checked by the Query readiness probe.",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 10,
+                  "description": "How often (seconds) to run the Query readiness probe.",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "port": {
+                  "default": "http",
+                  "description": "Port checked by the Query readiness probe.",
+                  "required": [],
+                  "title": "port",
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Consecutive successes before the Query pod is marked ready.",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "default": 5,
+                  "description": "Seconds after which the Query readiness probe times out.",
+                  "required": [],
+                  "title": "timeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled",
+                "path",
+                "port",
+                "initialDelaySeconds",
+                "periodSeconds",
+                "timeoutSeconds",
+                "failureThreshold",
+                "successThreshold"
+              ],
+              "title": "readiness",
+              "type": "object"
+            },
+            "startup": {
+              "additionalProperties": true,
+              "description": "Startup probe for the Query component.",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Enable the startup probe for Query.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "default": 60,
+                  "description": "Consecutive failures during Query startup before the container is killed.",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "default": 0,
+                  "description": "Seconds to wait before starting the Query startup probe.",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/-/ready",
+                  "description": "HTTP path checked by the Query startup probe.",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 5,
+                  "description": "How often (seconds) to run the Query startup probe.",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "port": {
+                  "default": "http",
+                  "description": "Port checked by the Query startup probe.",
+                  "required": [],
+                  "title": "port",
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Consecutive successes before the Query startup probe is considered passed.",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "default": 5,
+                  "description": "Seconds after which the Query startup probe times out.",
+                  "required": [],
+                  "title": "timeoutSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled",
+                "path",
+                "port",
+                "initialDelaySeconds",
+                "periodSeconds",
+                "timeoutSeconds",
+                "failureThreshold",
+                "successThreshold"
+              ],
+              "title": "startup",
+              "type": "object"
+            }
+          },
+          "required": [
+            "readiness",
+            "liveness",
+            "startup"
+          ],
+          "title": "probes",
+          "type": "object"
+        },
+        "replicaCount": {
+          "default": 2,
+          "description": "Number of Query pod replicas. Two or more is recommended for HA.",
+          "required": [],
+          "title": "replicaCount",
+          "type": "integer"
+        },
+        "replicaLabels": {
+          "description": "Label names that identify replica identity for result deduplication.",
+          "items": {
+            "anyOf": [
+              {
+                "required": [],
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "required": [],
+          "title": "replicaLabels",
+          "type": "array"
+        },
+        "resources": {
+          "additionalProperties": true,
+          "description": "Resource requests and limits for the Query container.",
+          "required": [],
+          "title": "resources",
+          "type": "object"
+        },
+        "service": {
+          "additionalProperties": true,
+          "description": "Kubernetes Service configuration for the Query component.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Query Service.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "grpcPort": {
+              "default": 10901,
+              "description": "gRPC Store API port exposed by the Query Service.",
+              "required": [],
+              "title": "grpcPort",
+              "type": "integer"
+            },
+            "httpPort": {
+              "default": 9090,
+              "description": "HTTP/PromQL port exposed by the Query Service.",
+              "required": [],
+              "title": "httpPort",
+              "type": "integer"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Extra labels for the Query Service.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "type": {
+              "default": "ClusterIP",
+              "description": "Kubernetes Service type for the Query component.",
+              "required": [],
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "httpPort",
+            "grpcPort",
+            "annotations",
+            "labels"
+          ],
+          "title": "service",
+          "type": "object"
+        },
+        "serviceMonitor": {
+          "additionalProperties": true,
+          "description": "Prometheus Operator ServiceMonitor configuration for the Query component.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Query ServiceMonitor.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Enable a Prometheus Operator ServiceMonitor for Query.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "interval": {
+              "default": "",
+              "description": "Scrape interval for Query. Empty uses the Prometheus operator default.",
+              "required": [],
+              "title": "interval",
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Extra labels for the Query ServiceMonitor.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "metricRelabelings": {
+              "description": "Metric relabeling rules applied after Query metrics are ingested.",
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "metricRelabelings",
+              "type": "array"
+            },
+            "relabelings": {
+              "description": "Relabeling rules applied before Query metrics are ingested.",
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "relabelings",
+              "type": "array"
+            },
+            "scheme": {
+              "default": "",
+              "description": "Scrape scheme for Query (http or https).",
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "default": "",
+              "description": "Scrape timeout for Query. Empty uses the Prometheus operator default.",
+              "required": [],
+              "title": "scrapeTimeout",
+              "type": "string"
+            },
+            "tlsConfig": {
+              "additionalProperties": true,
+              "description": "TLS configuration for Query scraping.",
+              "required": [],
+              "title": "tlsConfig",
+              "type": "object"
+            }
+          },
+          "required": [
+            "enabled",
+            "labels",
+            "annotations",
+            "interval",
+            "scrapeTimeout",
+            "scheme",
+            "tlsConfig",
+            "relabelings",
+            "metricRelabelings"
+          ],
+          "title": "serviceMonitor",
+          "type": "object"
+        },
+        "stores": {
+          "description": "List of gRPC Store API endpoints that Query should connect to.\nIn-chart components (Receive, Store Gateway, Ruler) are wired automatically.\nAdd external Prometheus sidecars or remote store gateways here.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "stores",
+          "type": "array"
+        },
+        "tolerations": {
+          "description": "Tolerations for Query pod scheduling.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for Query pods.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "topologySpreadConstraints",
+          "type": "array"
+        },
+        "dnsConfig": {
+          "additionalProperties": true,
+          "description": "DNS configuration for pods. Overrides global.dnsConfig.",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
+        },
+        "tls": {
+          "additionalProperties": true,
+          "description": "TLS client configuration for outbound gRPC connections.",
+          "properties": {
+            "cert": {
+              "default": "",
+              "description": "Path to the TLS client certificate file (PEM).",
+              "required": [],
+              "title": "cert",
+              "type": "string"
+            },
+            "key": {
+              "default": "",
+              "description": "Path to the TLS client private key file (PEM).",
+              "required": [],
+              "title": "key",
+              "type": "string"
+            },
+            "ca": {
+              "default": "",
+              "description": "Path to the CA certificate file used to verify the remote endpoint.",
+              "required": [],
+              "title": "ca",
+              "type": "string"
+            }
+          },
+          "required": [
+            "cert",
+            "key",
+            "ca"
+          ],
+          "title": "tls",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enabled",
+        "replicaCount",
+        "service",
+        "autoscaling",
+        "stores",
+        "replicaLabels",
+        "extraArgs",
+        "resources",
+        "podSecurityContext",
+        "containerSecurityContext",
+        "dnsConfig",
+        "extraEnv",
+        "extraEnvFrom",
+        "extraInitContainers",
+        "extraContainers",
+        "probes",
+        "nodeSelector",
+        "tolerations",
+        "affinity",
+        "topologySpreadConstraints",
+        "priorityClassName",
+        "extraVolumes",
+        "extraVolumeMounts",
+        "annotations",
+        "labels",
+        "serviceMonitor",
+        "pdb",
+        "tls"
+      ],
+      "title": "queryTls",
+      "type": "object"
     }
   },
   "required": [
@@ -7379,6 +8131,7 @@
     "bucket",
     "compactor",
     "query",
+    "queryTls",
     "queryFrontend",
     "storegateway",
     "receive",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -870,7 +870,7 @@ query:
 
   # -- List of gRPC Store API endpoints that Query should connect to.
   # In-chart components (Receive, Store Gateway, Ruler) are wired automatically.
-  # Add external Prometheus sidecars or remote store gateways here.
+  # Add external Prometheus sidecars or remote store gateways that are not TLS enabled here.
   # @default -- []
   stores: []
   # Example:
@@ -1043,6 +1043,237 @@ query:
     minAvailable: ""
     # -- (int or string) Maximum unavailable Query pods during a disruption.
     maxUnavailable: ""
+
+# ======================================================================
+# Query TLS component
+# A second Query tier that connects to remote Store API endpoints
+# over TLS. The plain Query automatically fans out to this component,
+# so users only need to point Grafana at the plain Query.
+# ======================================================================
+# Query TLS component — TLS-enabled Query for reaching remote gRPC Store API endpoints.
+queryTls:
+  # -- Enable the Query TLS Deployment. When enabled, the plain Query
+  # automatically adds Query TLS as an endpoint.
+  enabled: false
+
+  # -- Number of Query TLS pod replicas.
+  replicaCount: 2
+
+  # Kubernetes Service configuration for Query TLS.
+  service:
+    # -- Extra annotations for the Query TLS Service.
+    # @default -- {}
+    annotations: {}
+    # -- gRPC Store API port exposed by the Query TLS Service.
+    grpcPort: 10901
+    # -- HTTP/PromQL port exposed by the Query TLS Service.
+    httpPort: 9090
+    # -- Extra labels for the Query TLS Service.
+    # @default -- {}
+    labels: {}
+    # -- Kubernetes Service type for Query TLS.
+    type: ClusterIP
+
+  # HorizontalPodAutoscaler configuration for Query TLS.
+  autoscaling:
+    # -- Enable HorizontalPodAutoscaler for Query TLS.
+    enabled: false
+    # -- Maximum number of Query TLS replicas.
+    maxReplicas: 5
+    # -- Minimum number of Query TLS replicas.
+    minReplicas: 2
+    # -- Target CPU utilisation percentage for Query TLS autoscaling.
+    targetCPUUtilizationPercentage: 80
+    # -- Target memory utilisation percentage for Query TLS autoscaling. Null disables memory-based scaling.
+    targetMemoryUtilizationPercentage: null
+
+  # -- List of remote gRPC Store API endpoints that require TLS.
+  # Add external Prometheus sidecars or remote store gateways that are TLS enabled here.
+  # @default -- []
+  stores: []
+  # Example:
+  # stores:
+  #   - thanos-gateway.remote-cluster.example.com:443
+  #   - dnssrv+_grpc._tcp.thanos-storegateway.remote.svc.cluster.local
+
+  # -- Label names that identify replica identity for result deduplication.
+  replicaLabels:
+    - prometheus_replica
+
+  # Additional CLI arguments appended to the `thanos query` command.
+  # Note: --grpc-client-tls-secure is always added automatically.
+  extraArgs:
+    - --log.level=info
+
+  # TLS client configuration for outbound gRPC connections.
+  tls:
+    # -- Path to the CA certificate file used to verify the remote endpoint.
+    # Leave empty to use the system trust store.
+    ca: ""
+    # -- Path to the TLS client certificate file (PEM).
+    # Leave empty when the remote endpoint uses a publicly trusted CA.
+    cert: ""
+    # -- Path to the TLS client private key file (PEM).
+    key: ""
+
+  # -- Resource requests and limits for the Query TLS container.
+  # @default -- {}
+  resources: {}
+
+  # -- Pod security context for Query TLS pods. Overrides global.podSecurityContext.
+  # @default -- {}
+  podSecurityContext: {}
+
+  # -- Container security context for Query TLS. Overrides global.containerSecurityContext.
+  # @default -- {}
+  containerSecurityContext: {}
+
+  # -- DNS configuration for Query TLS pods. Overrides global.dnsConfig.
+  # @default -- {}
+  dnsConfig: {}
+
+  # -- Extra environment variables injected into the Query TLS container.
+  # @default -- []
+  extraEnv: []
+
+  # -- Extra environment variable sources for the Query TLS container.
+  # @default -- []
+  extraEnvFrom: []
+
+  # -- Extra init containers for Query TLS pods.
+  # @default -- []
+  extraInitContainers: []
+
+  # -- Extra sidecar containers for Query TLS pods.
+  # @default -- []
+  extraContainers: []
+
+  # Health and readiness probe configuration for the Query TLS component.
+  probes:
+    # Readiness probe for the Query TLS component.
+    readiness:
+      # -- Enable the readiness probe for Query TLS.
+      enabled: true
+      # -- HTTP path checked by the Query TLS readiness probe.
+      path: /-/ready
+      # -- (int or string) Port checked by the Query TLS readiness probe.
+      port: http
+      # -- Seconds to wait before starting the Query TLS readiness probe.
+      initialDelaySeconds: 5
+      # -- How often (seconds) to run the Query TLS readiness probe.
+      periodSeconds: 10
+      # -- Seconds after which the Query TLS readiness probe times out.
+      timeoutSeconds: 5
+      # -- Consecutive failures before the Query TLS pod is marked not-ready.
+      failureThreshold: 6
+      # -- Consecutive successes before the Query TLS pod is marked ready.
+      successThreshold: 1
+    # Liveness probe for the Query TLS component.
+    liveness:
+      # -- Enable the liveness probe for Query TLS.
+      enabled: true
+      # -- HTTP path checked by the Query TLS liveness probe.
+      path: /-/healthy
+      # -- (int or string) Port checked by the Query TLS liveness probe.
+      port: http
+      # -- Seconds to wait before starting the Query TLS liveness probe.
+      initialDelaySeconds: 30
+      # -- How often (seconds) to run the Query TLS liveness probe.
+      periodSeconds: 10
+      # -- Seconds after which the Query TLS liveness probe times out.
+      timeoutSeconds: 5
+      # -- Consecutive failures before the Query TLS container is restarted.
+      failureThreshold: 6
+      # -- Consecutive successes before the Query TLS container is considered live.
+      successThreshold: 1
+    # Startup probe for the Query TLS component.
+    startup:
+      # -- Enable the startup probe for Query TLS.
+      enabled: true
+      # -- HTTP path checked by the Query TLS startup probe.
+      path: /-/ready
+      # -- (int or string) Port checked by the Query TLS startup probe.
+      port: http
+      # -- Seconds to wait before starting the Query TLS startup probe.
+      initialDelaySeconds: 0
+      # -- How often (seconds) to run the Query TLS startup probe.
+      periodSeconds: 5
+      # -- Seconds after which the Query TLS startup probe times out.
+      timeoutSeconds: 5
+      # -- Consecutive failures during Query TLS startup before the container is killed.
+      failureThreshold: 60
+      # -- Consecutive successes before the Query TLS startup probe is considered passed.
+      successThreshold: 1
+
+  # -- Node selector for Query TLS pod scheduling.
+  # @default -- {}
+  nodeSelector: {}
+
+  # -- Tolerations for Query TLS pod scheduling.
+  # @default -- []
+  tolerations: []
+
+  # -- Affinity rules for Query TLS pod scheduling.
+  # @default -- {}
+  affinity: {}
+
+  # -- Topology spread constraints for Query TLS pods.
+  # @default -- []
+  topologySpreadConstraints: []
+
+  # -- Priority class name for Query TLS pods.
+  priorityClassName: ""
+
+  # -- Extra volumes for Query TLS pods.
+  # @default -- []
+  extraVolumes: []
+
+  # -- Extra volume mounts for the Query TLS container.
+  # @default -- []
+  extraVolumeMounts: []
+
+  # -- Extra annotations applied to Query TLS resources.
+  # @default -- {}
+  annotations: {}
+
+  # -- Extra labels applied to Query TLS resources.
+  # @default -- {}
+  labels: {}
+
+  # Prometheus Operator ServiceMonitor configuration for Query TLS.
+  serviceMonitor:
+    # -- Enable a Prometheus Operator ServiceMonitor for Query TLS.
+    enabled: false
+    # -- Extra annotations for the Query TLS ServiceMonitor.
+    # @default -- {}
+    annotations: {}
+    # -- Extra labels for the Query TLS ServiceMonitor.
+    # @default -- {}
+    labels: {}
+    # -- Scrape interval for Query TLS. Empty uses the Prometheus operator default.
+    interval: ""
+    # -- Scrape timeout for Query TLS. Empty uses the Prometheus operator default.
+    scrapeTimeout: ""
+    # -- Scrape scheme for Query TLS (http or https).
+    scheme: ""
+    # -- TLS configuration for Query TLS scraping.
+    # @default -- {}
+    tlsConfig: {}
+    # -- Relabeling rules applied before Query TLS metrics are ingested.
+    # @default -- []
+    relabelings: []
+    # -- Metric relabeling rules applied after Query TLS metrics are ingested.
+    # @default -- []
+    metricRelabelings: []
+
+  # PodDisruptionBudget configuration for Query TLS.
+  pdb:
+    # -- Enable a PodDisruptionBudget for Query TLS.
+    enabled: false
+    # -- (int or string) Maximum unavailable Query TLS pods during a disruption.
+    maxUnavailable: ""
+    # -- (int or string) Minimum available Query TLS pods during a disruption.
+    minAvailable: ""
 
 # ======================================================================
 # Query Frontend component


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Provide a way to query TLS enabled endpoints.

The `thanos query` command cannot accept a mix of TLS and non-TLS enabled endpoints.

The Query component already handles the local non-TLS endpoints by talking directly to the Kubernetes services created by the chart, and optionally any other non-TLS endpoints added by users to the `query.stores[]` value.

Create a new optional query-tls component that has the job of querying TLS enabled endpoints. This is so Thanos components in other remote clusters that are only exposed by TLS enabled Ingress can be queried.

If the query-tls component is enabled, the query component will automatically add it to its list of endpoints.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

I'm not sure if you're happy with the name `query-tls` or if I should have called it something like `query-tls-endpoints` instead to make it clearer what this query deployment is for?

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
