### PR TITLE
feat(endpoints): Allow overriding query endpoints

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -235,12 +235,20 @@ query:
   replicaLabels:
     - prometheus_replica
 
-  # gRPC endpoints to query. Auto-discovered components are wired automatically.
-  # Add external Prometheus sidecars or remote store gateways here.
+  # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway) are auto-wired
+  # when autogen.enabled is true. Endpoints defined in static[] are always appended; set
+  # autogen.enabled to false to take full control of what endpoint arguments are passed.
+  endpoints:
+    autogen:
+      enabled: true
+    static: []
+    # Example:
+    # static:
+    #   - thanos-storegateway.cluster1.internal:443
+    #   - thanos-receive.cluster1.internal:443
+
+  # Deprecated. Use query.endpoints.static[] instead.
   stores: []
-  # Example:
-  # stores:
-  #   - dnssrv+_grpc._tcp.thanos-storegateway.monitoring.svc.cluster.local
 
   ingress:
     http:
@@ -669,6 +677,8 @@ The table below documents all available values. Top-level keys group settings by
 | query.containerSecurityContext | object | {} | Container security context for Query. Overrides global.containerSecurityContext. |
 | query.dnsConfig | object | {} | DNS configuration for Query pods. Overrides global.dnsConfig. |
 | query.enabled | bool | `true` | Enable the Query Deployment. |
+| query.endpoints.autogen.enabled | bool | `true` | Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway). These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format. |
+| query.endpoints.static | list | [] | Optional static endpoint arguments. When non-empty will be added as extra endpoints. When `query.endpoints.autogen.enabled` is `false`, these will give you full control over the endpoints. |
 | query.extraArgs[0] | string | `"--log.level=info"` |  |
 | query.extraContainers | list | [] | Extra sidecar containers for Query pods. |
 | query.extraEnv | list | [] | Extra environment variables injected into the Query container. |
@@ -753,7 +763,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.serviceMonitor.scheme | string | `""` | Scrape scheme for Query (http or https). |
 | query.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query. Empty uses the Prometheus operator default. |
 | query.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query scraping. |
-| query.stores | list | [] | List of gRPC Store API endpoints that Query should connect to. In-chart components (Receive, Store Gateway, Ruler) are wired automatically. Add external Prometheus sidecars or remote store gateways here. |
+| query.stores | list | [] | Deprecated. Use `query.endpoints.static[]` instead. |
 | query.tolerations | list | [] | Tolerations for Query pod scheduling. |
 | query.topologySpreadConstraints | list | [] | Topology spread constraints for Query pods. |
 | queryFrontend.affinity | object | {} | Affinity rules for Query Frontend pod scheduling. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -223,12 +223,20 @@ query:
   replicaLabels:
     - prometheus_replica
 
-  # gRPC endpoints to query. Auto-discovered components are wired automatically.
-  # Add external Prometheus sidecars or remote store gateways here.
+  # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway) are auto-wired
+  # when autogen.enabled is true. Endpoints defined in static[] are always appended; set
+  # autogen.enabled to false to take full control of what endpoint arguments are passed.
+  endpoints:
+    autogen:
+      enabled: true
+    static: []
+    # Example:
+    # static:
+    #   - thanos-storegateway.cluster1.internal:443
+    #   - thanos-receive.cluster1.internal:443
+
+  # Deprecated. Use query.endpoints.static[] instead.
   stores: []
-  # Example:
-  # stores:
-  #   - dnssrv+_grpc._tcp.thanos-storegateway.monitoring.svc.cluster.local
 
   ingress:
     http:

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - query
             - --http-address=0.0.0.0:{{ .Values.query.service.httpPort }}
             - --grpc-address=0.0.0.0:{{ .Values.query.service.grpcPort }}
+        {{- if .Values.query.endpoints.autogen.enabled }}
           {{- if .Values.storegateway.enabled }}
             # - --endpoint={{ include "thanos.compName" (list . "storegateway") }}:{{ .Values.storegateway.service.grpcPort }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
@@ -47,11 +48,15 @@ spec:
             # - --endpoint={{ include "thanos.compName" (list . "receive") }}-headless:{{ .Values.receive.service.grpcPort }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "receive") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
-          {{- range .Values.query.replicaLabels }}
-            - --query.replica-label={{ . }}
+        {{- end }}
+          {{- range .Values.query.endpoints.static }}
+            - --endpoint={{ . }}
           {{- end }}
           {{- range .Values.query.stores }}
             - --endpoint={{ . }}
+          {{- end }}
+          {{- range .Values.query.replicaLabels }}
+            - --query.replica-label={{ . }}
           {{- end }}
           {{- range .Values.query.extraArgs }}
             - {{ . | quote }}

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -67,7 +67,88 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[3]
-          pattern: "^--endpoint=dnssrv\\+_grpc._tcp\\..*storegateway.*"
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*storegateway.*"
+
+  - it: renders --endpoint args from query.endpoints.static when autogen disabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      query.endpoints.autogen.enabled: false
+      query.endpoints.static:
+        - sidecar.example.com:10901
+        - store.example.com:10901
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=sidecar.example.com:10901
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=store.example.com:10901
+
+  - it: static endpoints replace auto-wired storegateway and receive endpoints
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: true
+      receive.enabled: true
+      query.endpoints.autogen.enabled: false
+      query.endpoints.static:
+        - external.example.com:10901
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint=external\\.example\\.com:10901$"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[4]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*storegateway.*"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[4]
+          pattern: "--endpoint=dnssrv\\+_grpc\\._tcp\\..*receive.*"
+
+  - it: renders static endpoints alongside auto-wired endpoints when autogen enabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: true
+      receive.enabled: true
+      query.endpoints.autogen.enabled: true
+      query.endpoints.static:
+        - external.example.com:10901
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*storegateway.*"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[4]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*receive.*"
+      - equal:
+          path: spec.template.spec.containers[0].args[5]
+          value: --endpoint=external.example.com:10901
+
+  - it: renders no --endpoint args when autogen disabled and static empty
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: true
+      receive.enabled: true
+      query.endpoints.autogen.enabled: false
+      query.endpoints.static: []
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint="
+
+  - it: renders --endpoint args from deprecated query.stores
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      query.endpoints.autogen.enabled: false
+      query.stores:
+        - legacy.example.com:10901
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=legacy.example.com:10901
 
   - it: passes extra CLI args
     template: query/deployment.yaml

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2581,6 +2581,45 @@
           "title": "enabled",
           "type": "boolean"
         },
+        "endpoints": {
+          "additionalProperties": true,
+          "description": "Configuration for the --endpoint arguments passed to thanos query.",
+          "properties": {
+            "autogen": {
+              "additionalProperties": true,
+              "description": "Auto-generated endpoints for the in-chart components (Receive, Store Gateway).",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway).\nThese use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "title": "autogen",
+              "type": "object"
+            },
+            "static": {
+              "description": "Optional static endpoint arguments. When non-empty will be added as extra endpoints.\nWhen `query.endpoints.autogen.enabled` is `false`, `query.endpoints.static[]` will give you full control over the endpoints.",
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "static",
+              "type": "array"
+            }
+          },
+          "required": [
+            "autogen",
+            "static"
+          ],
+          "title": "endpoints",
+          "type": "object"
+        },
         "extraArgs": {
           "description": "Additional CLI arguments appended to the `thanos query` command.",
           "items": {
@@ -3554,7 +3593,7 @@
           "type": "object"
         },
         "stores": {
-          "description": "List of gRPC Store API endpoints that Query should connect to.\nIn-chart components (Receive, Store Gateway, Ruler) are wired automatically.\nAdd external Prometheus sidecars or remote store gateways here.",
+          "description": "Deprecated. Use `query.endpoints.static[]` instead.",
           "items": {
             "required": []
           },
@@ -3596,6 +3635,7 @@
         "httpRoute",
         "grpcRoute",
         "autoscaling",
+        "endpoints",
         "stores",
         "replicaLabels",
         "extraArgs",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -906,14 +906,27 @@ query:
     # -- Target memory utilisation percentage for Query autoscaling. Null disables memory-based scaling.
     targetMemoryUtilizationPercentage: null
 
-  # -- List of gRPC Store API endpoints that Query should connect to.
-  # In-chart components (Receive, Store Gateway, Ruler) are wired automatically.
-  # Add external Prometheus sidecars or remote store gateways here.
+  # Configuration for the --endpoint arguments passed to thanos query.
+  endpoints:
+    # Auto-generated endpoints for the in-chart components (Receive, Store Gateway).
+    autogen:
+      # -- Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway).
+      # These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.
+      enabled: true
+    # -- Optional static endpoint arguments. When non-empty will be added as extra endpoints.
+    # When `query.endpoints.autogen.enabled` is `false`, these will give you full control over the endpoints.
+    # @default -- []
+    static: []
+    # Example
+    # static:
+    #   - thanos-storegateway.cluster1.internal:443
+    #   - thanos-receive.cluster1.internal:443
+    #   - thanos-gateway.cluster2.internal:443
+    #   - thanos-gateway.cluster3.internal:443
+
+  # -- Deprecated. Use `query.endpoints.static[]` instead.
   # @default -- []
   stores: []
-  # Example:
-  # stores:
-  #   - dnssrv+_grpc._tcp.thanos-storegateway.monitoring.svc.cluster.local
 
   # Label names that identify replica identity for result deduplication.
   replicaLabels:


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Change how the query endpoints are configured to provide more control.
e.g. The user can completely override them if they like.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

I need this to be able to query TLS enabled Thanos endpoints on remote clusters.
The in-chart components are non-TLS and thanos query does not support mixing TLS and non-TLS endpoints.
I need to be able to disable the automatically added endpoints so that I can add them to a list of endpoints using paths that are TLS enabled.

To achieve my goal I can set these in the values (the `cluster*.internal` DNS domains below are fictional):
```yaml
# Create an ingress for storegateway that will expose it via TLS on a loadbalancer
storegateway:
  ingress:
    grpc:
      className: traefik
      enabled: true
      hosts:
        - host: thanos-storegateway.cluster1.interal
          paths:
            - path: /
              pathType: Prefix

   service:                                                                      
    annotations:                                                                
      # Required for gRPC to work via the traefik Ingress to this service.      
      traefik.ingress.kubernetes.io/service.serversscheme: h2c

query:
  endpoints:
    autogen:
      # Disable the auto-generated endpoints since they are non TLS and I'll add the TLS equivalent to the static[] list below.
      enabled: false
    static:
      # The storegateway for this Thanos installation as exposed via a TLS load-balancer that is handling the Ingresses.
      - thanos-storegateway.cluster1.interal:443
      # Other external TLS endpoints.
      - thanos-gateway.cluster2.internal:443
      - thanos-gateway.cluster3.internal:443

  extraArgs:                                                                    
    # Use TLS to talk to all of the endpoints.
    - --grpc-client-tls-secure
```

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
