### PR TITLE
fix: Add component labels to services

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/templates/bucket/service.yaml
+++ b/charts/thanos/templates/bucket/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   labels:
+    app.kubernetes.io/component: bucketweb
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.bucket.bucketweb.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/compactor/service.yaml
+++ b/charts/thanos/templates/compactor/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   labels:
+    app.kubernetes.io/component: compactor
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.compactor.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/query-frontend/service.yaml
+++ b/charts/thanos/templates/query-frontend/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   labels:
+    app.kubernetes.io/component: query-frontend
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.queryFrontend.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/query/service.yaml
+++ b/charts/thanos/templates/query/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   labels:
+    app.kubernetes.io/component: query
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.query.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
   labels:
+    app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.receive.service.labels }}
     {{- toYaml . | nindent 4 }}
@@ -31,6 +32,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}-headless
   labels:
+    app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.receive.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
+    app.kubernetes.io/component: ruler
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.ruler.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/storegateway/service.yaml
+++ b/charts/thanos/templates/storegateway/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   labels:
+    app.kubernetes.io/component: storegateway
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.storegateway.service.labels }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add component labels to services.

Without the app.kubernetes.io/component label on the Service resources, the ServiceMonitor resources do not match them, and no metrics are collected by Prometheus for them.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
