### PR TITLE
fix(ruler): add missing grpc service

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -985,6 +985,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.resources | object | {} | Resource requests and limits for the Ruler container. |
 | ruler.rules."example-alerts.yaml" | string | `"groups:\n  - name: thanos-example\n    rules:\n      - alert: ExampleAlwaysFiring\n        expr: vector(1)\n        for: 1m\n        labels:\n          severity: warning\n        annotations:\n          summary: Example alert firing\n"` |  |
 | ruler.service.annotations | object | {} | Extra annotations for the Ruler Service. |
+| ruler.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Ruler headless Service. |
 | ruler.service.httpPort | int | `10902` | HTTP port exposed by the Ruler Service. |
 | ruler.service.labels | object | {} | Extra labels for the Ruler Service. |
 | ruler.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Ruler component. |

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -23,4 +23,29 @@ spec:
     app.kubernetes.io/component: ruler
     app.kubernetes.io/instance: {{ .Release.Name }}
   type: {{ .Values.ruler.service.type }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
+    {{- with .Values.ruler.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with .Values.ruler.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "thanos.compName" (list . "ruler") }}-headless
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: {{ .Values.ruler.service.grpcPort }}
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
           args:
             - rule
             - --http-address=0.0.0.0:{{ .Values.ruler.service.httpPort }}
+            - --grpc-address=0.0.0.0:{{ .Values.ruler.service.grpcPort }}
             - --data-dir=/var/thanos/ruler
             - --rule-file=/etc/thanos/rules/*.yaml
           {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
@@ -60,6 +61,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.ruler.service.httpPort }}
+            - name: grpc
+              containerPort: {{ .Values.ruler.service.grpcPort }}
           volumeMounts:
             - name: data
               mountPath: /var/thanos/ruler

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -503,6 +503,148 @@ tests:
             image: busybox:latest
             command: ["echo", "component"]
 
+  # -- gRPC Store API --------------------------------------------------
+
+  - it: adds --grpc-address arg to Ruler
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --grpc-address=0.0.0.0:10901
+
+  - it: honors a custom ruler.service.grpcPort
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.service.grpcPort: 19091
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --grpc-address=0.0.0.0:19091
+
+  - it: exposes grpc container port on Ruler
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: grpc
+            containerPort: 10901
+
+  # -- Service --------------------------------------------------------
+
+  - it: renders both a regular and a headless service for ruler
+    template: ruler/service.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: regular ruler service exposes only http
+    template: ruler/service.yaml
+    documentIndex: 0
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-ruler
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+
+  - it: headless ruler service has clusterIP None
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-ruler-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: headless ruler service exposes only grpc
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.service.grpcPort: 10901
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0].name
+          value: grpc
+      - equal:
+          path: spec.ports[0].port
+          value: 10901
+      - equal:
+          path: spec.ports[0].targetPort
+          value: grpc
+
+  - it: applies service annotations to ruler service
+    template: ruler/service.yaml
+    documentIndex: 0
+    set:
+      ruler.enabled: true
+      ruler.service.annotations:
+        custom-annotation: my-value
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: my-value
+
+  - it: applies service annotations to ruler headless service
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.service.annotations:
+        custom-annotation: my-value
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: my-value
+
+  - it: applies service labels to ruler service
+    template: ruler/service.yaml
+    documentIndex: 0
+    set:
+      ruler.enabled: true
+      ruler.service.labels:
+        monitoring: "true"
+    asserts:
+      - equal:
+          path: metadata.labels.monitoring
+          value: "true"
+
+  - it: applies service labels to ruler headless service
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.service.labels:
+        monitoring: "true"
+    asserts:
+      - equal:
+          path: metadata.labels.monitoring
+          value: "true"
+
   # -- PodDisruptionBudget --------------------------------------------
 
   - it: renders PDB when component pdb is enabled

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -6139,6 +6139,13 @@
               "title": "annotations",
               "type": "object"
             },
+            "grpcPort": {
+              "default": 10901,
+              "description": "gRPC Store API port exposed by the Ruler headless Service.",
+              "required": [],
+              "title": "grpcPort",
+              "type": "integer"
+            },
             "httpPort": {
               "default": 10902,
               "description": "HTTP port exposed by the Ruler Service.",
@@ -6163,6 +6170,7 @@
           },
           "required": [
             "type",
+            "grpcPort",
             "httpPort",
             "annotations",
             "labels"

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1952,6 +1952,8 @@ ruler:
   service:
     # -- Kubernetes Service type for the Ruler component.
     type: ClusterIP
+    # -- gRPC Store API port exposed by the Ruler headless Service.
+    grpcPort: 10901
     # -- HTTP port exposed by the Ruler Service.
     httpPort: 10902
     # -- Extra annotations for the Ruler Service.


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds a Kubernetes (headless) Service that exposes Thanos Ruler's GRPC endpoint on (default) port 10901. This is required for Thanos Query to be able to consume Ruler's StoreAPI.

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
