### PR TITLE
chore: thanos chart dependencies update

### DIFF
--- a/charts/thanos/Chart.lock
+++ b/charts/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 83.0.2
+  version: 84.0.1
 - name: rustfs
   repository: https://charts.rustfs.com/
-  version: 0.0.91
-digest: sha256:79c3aa86bed6980b09027a9094c1ea775a7515d608a1d748278a32f3a4c53096
-generated: "2026-04-08T09:09:21.57565454+02:00"
+  version: 0.0.98
+digest: sha256:38048c73a0069ab416246fcb09f1e3e84b511020e47edeee77ccdec9595439d7
+generated: "2026-04-25T11:11:47.518000895+02:00"

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.5.3
+version: 0.6.0
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -25,11 +25,11 @@ maintainers:
 dependencies:
   - name: kube-prometheus-stack
     alias: kube-prometheus-stack
-    version: 83.0.2
+    version: 84.0.1
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled
   - name: rustfs
-    version: "0.0.91"
+    version: "0.0.98"
     repository: https://charts.rustfs.com/
     condition: rustfs.enabled
 annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the Thanos chart sub-chart dependencies to their latest versions and bumps the chart version accordingly.

- `kube-prometheus-stack`: `83.0.2` → `84.0.1`
- `rustfs`: `0.0.91` → `0.0.98`
- Chart `version`: `0.5.3` → `0.6.0`

#### Which issue this PR fixes

N/A — routine dependency maintenance.

#### Special notes for your reviewer:

- Only `charts/thanos/Chart.yaml` and `charts/thanos/Chart.lock` are touched.
- No template, values, or schema changes.
- Bumped the chart minor version (`0.5.3` → `0.6.0`) to reflect the upstream `kube-prometheus-stack` minor bump.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [ ] Variables are documented in the README.md *(N/A — no new values introduced)*
