### PR TITLE
fix(servicemonitor): add namespace specification

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -45,8 +45,8 @@ Kubernetes: `>= 1.30.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.rustfs.com/ | rustfs | 0.0.91 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 83.0.2 |
+| https://charts.rustfs.com/ | rustfs | 0.0.98 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 84.0.1 |
 
 ## Component Overview
 
@@ -502,6 +502,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.serviceMonitor.interval | string | `""` | Scrape interval for Bucketweb. Empty uses the Prometheus operator default. |
 | bucket.bucketweb.serviceMonitor.labels | object | {} | Extra labels for the Bucketweb ServiceMonitor. |
 | bucket.bucketweb.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Bucketweb metrics are ingested. |
+| bucket.bucketweb.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | bucket.bucketweb.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Bucketweb metrics are ingested. |
 | bucket.bucketweb.serviceMonitor.scheme | string | `""` | Scrape scheme for Bucketweb (http or https). |
 | bucket.bucketweb.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Bucketweb. Empty uses the Prometheus operator default. |
@@ -584,6 +585,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.serviceMonitor.interval | string | `""` | Scrape interval for the Compactor. Empty uses the Prometheus operator default. |
 | compactor.serviceMonitor.labels | object | {} | Extra labels for the Compactor ServiceMonitor. |
 | compactor.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Compactor metrics are ingested. |
+| compactor.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | compactor.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Compactor metrics are ingested. |
 | compactor.serviceMonitor.scheme | string | `""` | Scrape scheme for the Compactor (http or https). |
 | compactor.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for the Compactor. Empty uses the Prometheus operator default. |
@@ -637,7 +639,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.serviceMonitor.interval | string | `""` | Scrape interval. Empty string uses the Prometheus operator default. |
 | global.serviceMonitor.labels | object | {} | Extra labels merged into every ServiceMonitor resource. |
 | global.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after ingestion. |
-| global.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor resources are created. Empty means the same namespace as the release. |
+| global.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitors are created. Empty means the same namespace as the release. |
 | global.serviceMonitor.relabelings | list | [] | Relabeling rules applied to scraped metrics before ingestion. |
 | global.serviceMonitor.scheme | string | `""` | Scrape scheme: http or https. |
 | global.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout. Empty string uses the Prometheus operator default. |
@@ -734,6 +736,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.serviceMonitor.interval | string | `""` | Scrape interval for Query. Empty uses the Prometheus operator default. |
 | query.serviceMonitor.labels | object | {} | Extra labels for the Query ServiceMonitor. |
 | query.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Query metrics are ingested. |
+| query.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | query.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Query metrics are ingested. |
 | query.serviceMonitor.scheme | string | `""` | Scrape scheme for Query (http or https). |
 | query.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query. Empty uses the Prometheus operator default. |
@@ -813,6 +816,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.serviceMonitor.interval | string | `""` | Scrape interval for Query Frontend. Empty uses the Prometheus operator default. |
 | queryFrontend.serviceMonitor.labels | object | {} | Extra labels for the Query Frontend ServiceMonitor. |
 | queryFrontend.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Query Frontend metrics are ingested. |
+| queryFrontend.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | queryFrontend.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Query Frontend metrics are ingested. |
 | queryFrontend.serviceMonitor.scheme | string | `""` | Scrape scheme for Query Frontend (http or https). |
 | queryFrontend.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query Frontend. Empty uses the Prometheus operator default. |
@@ -898,6 +902,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.serviceMonitor.interval | string | `""` | Scrape interval for Receive. Empty uses the Prometheus operator default. |
 | receive.serviceMonitor.labels | object | {} | Extra labels for the Receive ServiceMonitor. |
 | receive.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Receive metrics are ingested. |
+| receive.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | receive.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Receive metrics are ingested. |
 | receive.serviceMonitor.scheme | string | `""` | Scrape scheme for Receive (http or https). |
 | receive.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Receive. Empty uses the Prometheus operator default. |
@@ -994,6 +999,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.serviceMonitor.interval | string | `""` | Scrape interval for the Ruler. Empty uses the Prometheus operator default. |
 | ruler.serviceMonitor.labels | object | {} | Extra labels for the Ruler ServiceMonitor. |
 | ruler.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Ruler metrics are ingested. |
+| ruler.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | ruler.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Ruler metrics are ingested. |
 | ruler.serviceMonitor.scheme | string | `""` | Scrape scheme for the Ruler (http or https). |
 | ruler.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for the Ruler. Empty uses the Prometheus operator default. |
@@ -1089,6 +1095,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.serviceMonitor.interval | string | `""` | Scrape interval for the Store Gateway. Empty uses the Prometheus operator default. |
 | storegateway.serviceMonitor.labels | object | {} | Extra labels for the Store Gateway ServiceMonitor. |
 | storegateway.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Store Gateway metrics are ingested. |
+| storegateway.serviceMonitor.namespace | string | `""` | Namespace where ServiceMonitor is created. Empty means the same namespace as the release. |
 | storegateway.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Store Gateway metrics are ingested. |
 | storegateway.serviceMonitor.scheme | string | `""` | Scrape scheme for the Store Gateway (http or https). |
 | storegateway.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for the Store Gateway. Empty uses the Prometheus operator default. |

--- a/charts/thanos/templates/bucket/servicemonitor.yaml
+++ b/charts/thanos/templates/bucket/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.bucket.bucketweb.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.bucket.bucketweb.serviceMonitor.labels }}{{ toYaml .Values.bucket.bucketweb.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/templates/compactor/servicemonitor.yaml
+++ b/charts/thanos/templates/compactor/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.compactor.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.compactor.serviceMonitor.labels }}{{ toYaml .Values.compactor.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/charts/thanos/templates/query-frontend/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.queryFrontend.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.queryFrontend.serviceMonitor.labels }}{{ toYaml .Values.queryFrontend.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/templates/query/servicemonitor.yaml
+++ b/charts/thanos/templates/query/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.query.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.query.serviceMonitor.labels }}{{ toYaml .Values.query.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/templates/receive/servicemonitor.yaml
+++ b/charts/thanos/templates/receive/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "receive") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.receive.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.receive.serviceMonitor.labels }}{{ toYaml .Values.receive.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/templates/ruler/servicemonitor.yaml
+++ b/charts/thanos/templates/ruler/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.ruler.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.ruler.serviceMonitor.labels }}{{ toYaml .Values.ruler.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/templates/storegateway/servicemonitor.yaml
+++ b/charts/thanos/templates/storegateway/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
+  namespace: {{ default .Release.Namespace (default .Values.global.serviceMonitor.namespace .Values.storegateway.serviceMonitor.namespace) | quote }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.storegateway.serviceMonitor.labels }}{{ toYaml .Values.storegateway.serviceMonitor.labels | nindent 4 }}{{- end }}

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -716,6 +716,13 @@
                   "title": "enabled",
                   "type": "boolean"
                 },
+                "namespace": {
+                  "default": "",
+                  "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+                  "required": [],
+                  "title": "namespace",
+                  "type": "string"
+                },
                 "interval": {
                   "default": "",
                   "description": "Scrape interval for Bucketweb. Empty uses the Prometheus operator default.",
@@ -1598,6 +1605,13 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "namespace": {
+              "default": "",
+              "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
+            },
             "interval": {
               "default": "",
               "description": "Scrape interval for the Compactor. Empty uses the Prometheus operator default.",
@@ -2223,7 +2237,7 @@
             },
             "namespace": {
               "default": "",
-              "description": "Namespace where ServiceMonitor resources are created.\nEmpty means the same namespace as the release.",
+              "description": "Namespace where ServiceMonitors are created.\nEmpty means the same namespace as the release.",
               "required": [],
               "title": "namespace",
               "type": "string"
@@ -3275,6 +3289,13 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "namespace": {
+              "default": "",
+              "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
+            },
             "interval": {
               "default": "",
               "description": "Scrape interval for Query. Empty uses the Prometheus operator default.",
@@ -4129,6 +4150,13 @@
               "required": [],
               "title": "enabled",
               "type": "boolean"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
             },
             "interval": {
               "default": "",
@@ -5084,6 +5112,13 @@
               "required": [],
               "title": "enabled",
               "type": "boolean"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
             },
             "interval": {
               "default": "",
@@ -6196,6 +6231,13 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "namespace": {
+              "default": "",
+              "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
+            },
             "interval": {
               "default": "",
               "description": "Scrape interval for the Ruler. Empty uses the Prometheus operator default.",
@@ -7251,6 +7293,13 @@
               "required": [],
               "title": "enabled",
               "type": "boolean"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace where ServiceMonitor is created.\nEmpty means the same namespace as the release.",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
             },
             "interval": {
               "default": "",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -216,7 +216,7 @@ global:
     # -- Enable a Prometheus Operator ServiceMonitor for every component.
     # Individual components can override this with their own serviceMonitor.enabled.
     enabled: false
-    # -- Namespace where ServiceMonitor resources are created.
+    # -- Namespace where ServiceMonitors are created.
     # Empty means the same namespace as the release.
     namespace: ""
     # -- Extra labels merged into every ServiceMonitor resource.
@@ -481,6 +481,9 @@ bucket:
     serviceMonitor:
       # -- Enable a Prometheus Operator ServiceMonitor for Bucketweb.
       enabled: false
+      # -- Namespace where ServiceMonitor is created.
+      # Empty means the same namespace as the release.
+      namespace: ""
       # -- Extra labels for the Bucketweb ServiceMonitor.
       # @default -- {}
       labels: {}
@@ -742,6 +745,9 @@ compactor:
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for the Compactor.
     enabled: false
+    # -- Namespace where ServiceMonitor is created.
+    # Empty means the same namespace as the release.
+    namespace: ""
     # -- Extra labels for the Compactor ServiceMonitor.
     # @default -- {}
     labels: {}
@@ -1013,6 +1019,9 @@ query:
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for Query.
     enabled: false
+    # -- Namespace where ServiceMonitor is created.
+    # Empty means the same namespace as the release.
+    namespace: ""
     # -- Extra labels for the Query ServiceMonitor.
     # @default -- {}
     labels: {}
@@ -1256,6 +1265,9 @@ queryFrontend:
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for Query Frontend.
     enabled: false
+    # -- Namespace where ServiceMonitor is created.
+    # Empty means the same namespace as the release.
+    namespace: ""
     # -- Extra labels for the Query Frontend ServiceMonitor.
     # @default -- {}
     labels: {}
@@ -1526,6 +1538,9 @@ storegateway:
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for the Store Gateway.
     enabled: false
+    # -- Namespace where ServiceMonitor is created.
+    # Empty means the same namespace as the release.
+    namespace: ""
     # -- Extra labels for the Store Gateway ServiceMonitor.
     # @default -- {}
     labels: {}
@@ -1835,6 +1850,9 @@ receive:
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for Receive.
     enabled: false
+    # -- Namespace where ServiceMonitor is created.
+    # Empty means the same namespace as the release.
+    namespace: ""
     # -- Extra labels for the Receive ServiceMonitor.
     # @default -- {}
     labels: {}
@@ -2129,6 +2147,9 @@ ruler:
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for the Ruler.
     enabled: false
+    # -- Namespace where ServiceMonitor is created.
+    # Empty means the same namespace as the release.
+    namespace: ""
     # -- Extra labels for the Ruler ServiceMonitor.
     # @default -- {}
     labels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add the namespace specification for all ServiceMonitor templates, default is current release version. It can be changed via `serviceMonitor.namespace` variable.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
