### PR TITLE
feat(endpoints): Allow disabling query endpoints

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -235,7 +235,7 @@ query:
   replicaLabels:
     - prometheus_replica
 
-  # gRPC endpoints to query. Auto-discovered components are wired automatically.
+  # gRPC endpoints to query. Auto-discovered components are wired automatically unless query.addComponentEndpoints is false.
   # Add external Prometheus sidecars or remote store gateways here.
   stores: []
   # Example:
@@ -659,6 +659,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.tolerations | list | [] | Toleration rules applied to every pod by default. |
 | global.topologySpreadConstraints | list | [] | Topology spread constraints applied to every pod by default. |
 | kube-prometheus-stack.enabled | bool | `false` | Enable the kube-prometheus-stack subchart. Deploys Prometheus Operator and associated components into the same namespace as Thanos. |
+| query.addComponentEndpoints | bool | `true` | Enable auto-populating endpoints with the in-chart components (Receive, Store Gateway, Ruler) |
 | query.affinity | object | {} | Affinity rules for Query pod scheduling. |
 | query.annotations | object | {} | Extra annotations applied to Query resources. |
 | query.autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler for the Query component. |
@@ -753,7 +754,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.serviceMonitor.scheme | string | `""` | Scrape scheme for Query (http or https). |
 | query.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Query. Empty uses the Prometheus operator default. |
 | query.serviceMonitor.tlsConfig | object | {} | TLS configuration for Query scraping. |
-| query.stores | list | [] | List of gRPC Store API endpoints that Query should connect to. In-chart components (Receive, Store Gateway, Ruler) are wired automatically. Add external Prometheus sidecars or remote store gateways here. |
+| query.stores | list | [] | List of gRPC Store API endpoints that Query should connect to. In-chart components (Receive, Store Gateway, Ruler) are wired automatically unless query.addComponentEndpoints is false. Add external Prometheus sidecars or remote store gateways here. |
 | query.tolerations | list | [] | Tolerations for Query pod scheduling. |
 | query.topologySpreadConstraints | list | [] | Topology spread constraints for Query pods. |
 | queryFrontend.affinity | object | {} | Affinity rules for Query Frontend pod scheduling. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -223,7 +223,7 @@ query:
   replicaLabels:
     - prometheus_replica
 
-  # gRPC endpoints to query. Auto-discovered components are wired automatically.
+  # gRPC endpoints to query. Auto-discovered components are wired automatically unless query.addComponentEndpoints is false.
   # Add external Prometheus sidecars or remote store gateways here.
   stores: []
   # Example:

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -39,13 +39,13 @@ spec:
             - query
             - --http-address=0.0.0.0:{{ .Values.query.service.httpPort }}
             - --grpc-address=0.0.0.0:{{ .Values.query.service.grpcPort }}
-          {{- if .Values.storegateway.enabled }}
-            # - --endpoint={{ include "thanos.compName" (list . "storegateway") }}:{{ .Values.storegateway.service.grpcPort }}
+          {{- if .Values.query.addComponentEndpoints }}
+            {{- if .Values.storegateway.enabled }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
-          {{- end }}
-          {{- if .Values.receive.enabled }}
-            # - --endpoint={{ include "thanos.compName" (list . "receive") }}-headless:{{ .Values.receive.service.grpcPort }}
+            {{- end }}
+            {{- if .Values.receive.enabled }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "receive") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            {{- end }}
           {{- end }}
           {{- range .Values.query.replicaLabels }}
             - --query.replica-label={{ . }}

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -69,6 +69,66 @@ tests:
           path: spec.template.spec.containers[0].args[3]
           pattern: "^--endpoint=dnssrv\\+_grpc._tcp\\..*storegateway.*"
 
+  - it: adds store endpoints for receive when enabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: false
+      receive.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint=dnssrv\\+_grpc._tcp\\..*receive.*"
+
+  - it: adds both storegateway and receive endpoints when both are enabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: true
+      receive.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint=dnssrv\\+_grpc._tcp\\..*storegateway.*"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[4]
+          pattern: "^--endpoint=dnssrv\\+_grpc._tcp\\..*receive.*"
+
+  - it: omits component endpoints when addComponentEndpoints is false
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      query.addComponentEndpoints: false
+      storegateway.enabled: true
+      receive.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-storegateway.NAMESPACE.svc.cluster.local
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-receive.NAMESPACE.svc.cluster.local
+
+  - it: still renders user-supplied stores when addComponentEndpoints is false
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      query.addComponentEndpoints: false
+      storegateway.enabled: true
+      receive.enabled: true
+      query.stores:
+        - dnssrv+_grpc._tcp.external-store.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.external-store.example.com
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-storegateway.NAMESPACE.svc.cluster.local
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-receive.NAMESPACE.svc.cluster.local
+
   - it: passes extra CLI args
     template: query/deployment.yaml
     set:

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2501,6 +2501,13 @@
       "additionalProperties": true,
       "description": "======================================================================\nQuery component\nFan-out query engine that queries multiple Store API endpoints\nand deduplicates results. This is the Prometheus-compatible entrypoint.\n======================================================================\nQuery component — fan-out PromQL engine that deduplicates results across stores.",
       "properties": {
+        "addComponentEndpoints": {
+          "default": true,
+          "description": "Enable auto-populating endpoints with the in-chart components (Receive, Store Gateway, Ruler).",
+          "required": [],
+          "title": "addComponentEndpoints",
+          "type": "boolean"
+        },
         "affinity": {
           "additionalProperties": true,
           "description": "Affinity rules for Query pod scheduling.",
@@ -3596,6 +3603,7 @@
         "httpRoute",
         "grpcRoute",
         "autoscaling",
+        "addComponentEndpoints",
         "stores",
         "replicaLabels",
         "extraArgs",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -906,8 +906,11 @@ query:
     # -- Target memory utilisation percentage for Query autoscaling. Null disables memory-based scaling.
     targetMemoryUtilizationPercentage: null
 
+  # -- Enable auto-populating endpoints with the in-chart components (Receive, Store Gateway, Ruler)
+  addComponentEndpoints: true
+
   # -- List of gRPC Store API endpoints that Query should connect to.
-  # In-chart components (Receive, Store Gateway, Ruler) are wired automatically.
+  # In-chart components (Receive, Store Gateway, Ruler) are wired automatically unless query.addComponentEndpoints is false.
   # Add external Prometheus sidecars or remote store gateways here.
   # @default -- []
   stores: []


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add a new query.addComponentEndpoints variable that can be set to false to no longer automatically add the in-chart components to the list of endpoints for Thanos query to talk to.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

I need this to be able to query TLS enabled Thanos endpoints on remote clusters.
The in-chart components are non-TLS and thanos query does not support mixing TLS and non-TLS endpoints.
I need to be able to disable the automatically added endpoints so that I can add them back using paths that are TLS enabled.

To achieve my goal I can set these in the values (the `cluster*.internal` DNS domains below are fictional):
```yaml
# Create an ingress for storegateway that will expose it via TLS on a loadbalancer
storegateway:
  ingress:
    grpc:
      className: traefik
      enabled: true
      hosts:
        - host: thanos-storegateway.cluster1.interal
          paths:
            - path: /
              pathType: Prefix

   service:                                                                      
    annotations:                                                                
      # Required for gRPC to work via the traefik Ingress to this service.      
      traefik.ingress.kubernetes.io/service.serversscheme: h2c

query:
  # No longer automatically add the in-chart components to the list of endpoints.
  addComponentEndpoints: false

  extraArgs:                                                                    
    # Use TLS to talk to all of the endpoints.
    - --grpc-client-tls-secure

  stores:
    # The storegateway for this Thanos installation as exposed via a TLS load-balancer that is handling the Ingresses.
    - thanos-storegateway.cluster1.interal:443
    # Other external TLS endpoints.
    - thanos-gateway.cluster2.internal:443
    - thanos-gateway.cluster3.internal:443
```

**NOTE**: This is an alternative to implementation to https://github.com/thanos-community/helm-charts/pull/71 where it introduces a `query.addComponentEndpoints` boolean that can be used to turn off the automatic addition of in-chart components to the query endpoints and uses the `query.stores[]` value to define all the endpoints instead of just additional ones.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
