### PR TITLE
Clean probe ports

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -481,7 +481,6 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the liveness probe. |
 | bucket.bucketweb.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the liveness probe. |
 | bucket.bucketweb.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the liveness probe. |
-| bucket.bucketweb.probes.liveness.port | int or string | `"http"` | Port checked by the liveness probe. |
 | bucket.bucketweb.probes.liveness.successThreshold | int | `1` | Consecutive successes before the container is considered live. |
 | bucket.bucketweb.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Bucketweb. |
@@ -489,7 +488,6 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the readiness probe. |
 | bucket.bucketweb.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the readiness probe. |
 | bucket.bucketweb.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the readiness probe. |
-| bucket.bucketweb.probes.readiness.port | int or string | `"http"` | Port checked by the readiness probe. |
 | bucket.bucketweb.probes.readiness.successThreshold | int | `1` | Consecutive successes before the pod is marked ready. |
 | bucket.bucketweb.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.probes.startup.enabled | bool | `true` | Enable the startup probe for Bucketweb. |
@@ -497,7 +495,6 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the startup probe. |
 | bucket.bucketweb.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the startup probe. |
 | bucket.bucketweb.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the startup probe. |
-| bucket.bucketweb.probes.startup.port | int or string | `"http"` | Port checked by the startup probe. |
 | bucket.bucketweb.probes.startup.successThreshold | int | `1` | Consecutive successes required before the startup probe is considered passed. |
 | bucket.bucketweb.probes.startup.timeoutSeconds | int | `5` | Seconds after which the probe times out. |
 | bucket.bucketweb.replicaCount | int | `1` | Number of Bucketweb pod replicas. |
@@ -563,7 +560,6 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Compactor liveness probe. |
 | compactor.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Compactor liveness probe. |
 | compactor.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Compactor liveness probe. |
-| compactor.probes.liveness.port | int or string | `"http"` | Port checked by the Compactor liveness probe. |
 | compactor.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Compactor container is considered live. |
 | compactor.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Compactor liveness probe times out. |
 | compactor.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Compactor. |
@@ -571,7 +567,6 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Compactor readiness probe. |
 | compactor.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Compactor readiness probe. |
 | compactor.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Compactor readiness probe. |
-| compactor.probes.readiness.port | int or string | `"http"` | Port checked by the Compactor readiness probe. |
 | compactor.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Compactor pod is marked ready. |
 | compactor.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Compactor readiness probe times out. |
 | compactor.probes.startup.enabled | bool | `true` | Enable the startup probe for the Compactor. |
@@ -579,7 +574,6 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Compactor startup probe. |
 | compactor.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Compactor startup probe. |
 | compactor.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Compactor startup probe. |
-| compactor.probes.startup.port | int or string | `"http"` | Port checked by the Compactor startup probe. |
 | compactor.probes.startup.successThreshold | int | `1` | Consecutive successes before the Compactor startup probe is considered passed. |
 | compactor.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Compactor startup probe times out. |
 | compactor.replicaCount | int | `1` | Number of Compactor replicas. Must remain 1 — running multiple compactors against the same bucket causes data corruption. |
@@ -727,7 +721,6 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query liveness probe. |
 | query.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query liveness probe. |
 | query.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query liveness probe. |
-| query.probes.liveness.port | int or string | `"http"` | Port checked by the Query liveness probe. |
 | query.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query container is considered live. |
 | query.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query liveness probe times out. |
 | query.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query. |
@@ -735,7 +728,6 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query readiness probe. |
 | query.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query readiness probe. |
 | query.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query readiness probe. |
-| query.probes.readiness.port | int or string | `"http"` | Port checked by the Query readiness probe. |
 | query.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query pod is marked ready. |
 | query.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query readiness probe times out. |
 | query.probes.startup.enabled | bool | `true` | Enable the startup probe for Query. |
@@ -743,7 +735,6 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query startup probe. |
 | query.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query startup probe. |
 | query.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query startup probe. |
-| query.probes.startup.port | int or string | `"http"` | Port checked by the Query startup probe. |
 | query.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query startup probe is considered passed. |
 | query.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query startup probe times out. |
 | query.replicaCount | int | `2` | Number of Query pod replicas. Two or more is recommended for HA. |
@@ -808,7 +799,6 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Query Frontend liveness probe. |
-| queryFrontend.probes.liveness.port | int or string | `"http"` | Port checked by the Query Frontend liveness probe. |
 | queryFrontend.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Query Frontend container is considered live. |
 | queryFrontend.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Query Frontend liveness probe times out. |
 | queryFrontend.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Query Frontend. |
@@ -816,7 +806,6 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Query Frontend readiness probe. |
-| queryFrontend.probes.readiness.port | int or string | `"http"` | Port checked by the Query Frontend readiness probe. |
 | queryFrontend.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Query Frontend pod is marked ready. |
 | queryFrontend.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Query Frontend readiness probe times out. |
 | queryFrontend.probes.startup.enabled | bool | `true` | Enable the startup probe for Query Frontend. |
@@ -824,7 +813,6 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Query Frontend startup probe. |
 | queryFrontend.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Query Frontend startup probe. |
 | queryFrontend.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Query Frontend startup probe. |
-| queryFrontend.probes.startup.port | int or string | `"http"` | Port checked by the Query Frontend startup probe. |
 | queryFrontend.probes.startup.successThreshold | int | `1` | Consecutive successes before the Query Frontend startup probe is considered passed. |
 | queryFrontend.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query Frontend startup probe times out. |
 | queryFrontend.replicaCount | int | `2` | Number of Query Frontend pod replicas. |
@@ -905,7 +893,6 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Receive liveness probe. |
 | receive.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Receive liveness probe. |
 | receive.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Receive liveness probe. |
-| receive.probes.liveness.port | int or string | `"http"` | Port checked by the Receive liveness probe. |
 | receive.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Receive container is considered live. |
 | receive.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Receive liveness probe times out. |
 | receive.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Receive. |
@@ -913,7 +900,6 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Receive readiness probe. |
 | receive.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Receive readiness probe. |
 | receive.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Receive readiness probe. |
-| receive.probes.readiness.port | int or string | `"http"` | Port checked by the Receive readiness probe. |
 | receive.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Receive pod is marked ready. |
 | receive.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Receive readiness probe times out. |
 | receive.probes.startup.enabled | bool | `true` | Enable the startup probe for Receive. |
@@ -921,7 +907,6 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Receive startup probe. |
 | receive.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Receive startup probe. |
 | receive.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Receive startup probe. |
-| receive.probes.startup.port | int or string | `"http"` | Port checked by the Receive startup probe. |
 | receive.probes.startup.successThreshold | int | `1` | Consecutive successes before the Receive startup probe is considered passed. |
 | receive.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Receive startup probe times out. |
 | receive.replicaCount | int | `3` | Number of Receive pod replicas. Minimum 3 is recommended for replication factor 2 (write quorum = floor(replicaCount/2)+1). |
@@ -1000,7 +985,6 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Ruler liveness probe. |
 | ruler.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Ruler liveness probe. |
 | ruler.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Ruler liveness probe. |
-| ruler.probes.liveness.port | int or string | `"http"` | Port checked by the Ruler liveness probe. |
 | ruler.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Ruler container is considered live. |
 | ruler.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Ruler liveness probe times out. |
 | ruler.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Ruler. |
@@ -1008,7 +992,6 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Ruler readiness probe. |
 | ruler.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Ruler readiness probe. |
 | ruler.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Ruler readiness probe. |
-| ruler.probes.readiness.port | int or string | `"http"` | Port checked by the Ruler readiness probe. |
 | ruler.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Ruler pod is marked ready. |
 | ruler.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Ruler readiness probe times out. |
 | ruler.probes.startup.enabled | bool | `true` | Enable the startup probe for the Ruler. |
@@ -1016,7 +999,6 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Ruler startup probe. |
 | ruler.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Ruler startup probe. |
 | ruler.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Ruler startup probe. |
-| ruler.probes.startup.port | int or string | `"http"` | Port checked by the Ruler startup probe. |
 | ruler.probes.startup.successThreshold | int | `1` | Consecutive successes before the Ruler startup probe is considered passed. |
 | ruler.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Ruler startup probe times out. |
 | ruler.query.urls | list | [] | List of Query component base URLs used by the Ruler to evaluate rules. |
@@ -1111,7 +1093,6 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Store Gateway liveness probe. |
 | storegateway.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Store Gateway liveness probe. |
 | storegateway.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Store Gateway liveness probe. |
-| storegateway.probes.liveness.port | int or string | `"http"` | Port checked by the Store Gateway liveness probe. |
 | storegateway.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Store Gateway container is considered live. |
 | storegateway.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Store Gateway liveness probe times out. |
 | storegateway.probes.readiness.enabled | bool | `true` | Enable the readiness probe for the Store Gateway. |
@@ -1119,7 +1100,6 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Store Gateway readiness probe. |
 | storegateway.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Store Gateway readiness probe. |
 | storegateway.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Store Gateway readiness probe. |
-| storegateway.probes.readiness.port | int or string | `"http"` | Port checked by the Store Gateway readiness probe. |
 | storegateway.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Store Gateway pod is marked ready. |
 | storegateway.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Store Gateway readiness probe times out. |
 | storegateway.probes.startup.enabled | bool | `true` | Enable the startup probe for the Store Gateway. |
@@ -1127,7 +1107,6 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Store Gateway startup probe. |
 | storegateway.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Store Gateway startup probe. |
 | storegateway.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Store Gateway startup probe. |
-| storegateway.probes.startup.port | int or string | `"http"` | Port checked by the Store Gateway startup probe. |
 | storegateway.probes.startup.successThreshold | int | `1` | Consecutive successes before the Store Gateway startup probe is considered passed. |
 | storegateway.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Store Gateway startup probe times out. |
 | storegateway.replicaCount | int | `2` | Number of Store Gateway pod replicas. Two or more is recommended for HA. |

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -81,7 +81,6 @@ dnsConfig:
 {{- define "thanos.httpProbes" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $port := .port -}}
 {{- $comp := index $root.Values $key | default dict -}}
 {{- $probes := $comp.probes | default dict -}}
 {{- with $probes.readiness }}
@@ -89,7 +88,7 @@ dnsConfig:
 readinessProbe:
   httpGet:
     path: {{ default "/-/ready" .path | quote }}
-    port: {{ default $port .port }}
+    port: http
   initialDelaySeconds: {{ default 5 .initialDelaySeconds }}
   periodSeconds: {{ default 10 .periodSeconds }}
   timeoutSeconds: {{ default 5 .timeoutSeconds }}
@@ -102,7 +101,7 @@ readinessProbe:
 livenessProbe:
   httpGet:
     path: {{ default "/-/healthy" .path | quote }}
-    port: {{ default $port .port }}
+    port: http
   initialDelaySeconds: {{ default 30 .initialDelaySeconds }}
   periodSeconds: {{ default 10 .periodSeconds }}
   timeoutSeconds: {{ default 5 .timeoutSeconds }}
@@ -115,7 +114,7 @@ livenessProbe:
 startupProbe:
   httpGet:
     path: {{ default "/-/ready" .path | quote }}
-    port: {{ default $port .port }}
+    port: http
   initialDelaySeconds: {{ default 0 .initialDelaySeconds }}
   periodSeconds: {{ default 5 .periodSeconds }}
   timeoutSeconds: {{ default 5 .timeoutSeconds }}

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" $ctx "key" "bucketweb") | nindent 10 }}
           resources:
             {{- toYaml .Values.bucket.bucketweb.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" $ctx "key" "bucketweb" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" $ctx "key" "bucketweb") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" $ctx.Values "component" "bucketweb" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" $ctx.Values "component" "bucketweb" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "compactor") | nindent 10 }}
           resources:
             {{- toYaml .Values.compactor.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "compactor" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "compactor") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "compactor" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "compactor") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "compactor" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "queryFrontend") | nindent 10 }}
           resources:
             {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "queryFrontend" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "queryFrontend") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "queryFrontend" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "queryFrontend" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -72,7 +72,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "query") | nindent 10 }}
           resources:
             {{- toYaml .Values.query.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "query" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "query") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "query" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "query") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "query" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "receive") | nindent 10 }}
           resources:
             {{- toYaml (.Values.receive.resources | default dict) | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "receive" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "receive") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "receive") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 6 }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "ruler") | nindent 10 }}
           resources:
             {{- toYaml .Values.ruler.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "ruler" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "ruler") | nindent 10 }}
 
         {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
         - name: prometheus-rule-importer

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           {{- include "thanos.containerSC" (dict "root" . "key" "storegateway") | nindent 10 }}
           resources:
             {{- toYaml .Values.storegateway.resources | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "storegateway" "port" "http") | nindent 10 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "storegateway") | nindent 10 }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "storegateway" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "storegateway") | nindent 6 }}
       {{- include "thanos.initContainers" (dict "Values" .Values "component" "storegateway" "root" .) | nindent 6 }}

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -429,20 +429,6 @@
                       "title": "periodSeconds",
                       "type": "integer"
                     },
-                    "port": {
-                      "default": "http",
-                      "description": "Port checked by the liveness probe.",
-                      "required": [],
-                      "title": "port",
-                      "oneOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    },
                     "successThreshold": {
                       "default": 1,
                       "description": "Consecutive successes before the container is considered live.",
@@ -461,7 +447,6 @@
                   "required": [
                     "enabled",
                     "path",
-                    "port",
                     "initialDelaySeconds",
                     "periodSeconds",
                     "timeoutSeconds",
@@ -510,20 +495,6 @@
                       "title": "periodSeconds",
                       "type": "integer"
                     },
-                    "port": {
-                      "default": "http",
-                      "description": "Port checked by the readiness probe.",
-                      "required": [],
-                      "title": "port",
-                      "oneOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    },
                     "successThreshold": {
                       "default": 1,
                       "description": "Consecutive successes before the pod is marked ready.",
@@ -542,7 +513,6 @@
                   "required": [
                     "enabled",
                     "path",
-                    "port",
                     "initialDelaySeconds",
                     "periodSeconds",
                     "timeoutSeconds",
@@ -591,20 +561,6 @@
                       "title": "periodSeconds",
                       "type": "integer"
                     },
-                    "port": {
-                      "default": "http",
-                      "description": "Port checked by the startup probe.",
-                      "required": [],
-                      "title": "port",
-                      "oneOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    },
                     "successThreshold": {
                       "default": 1,
                       "description": "Consecutive successes required before the startup probe is considered passed.",
@@ -623,7 +579,6 @@
                   "required": [
                     "enabled",
                     "path",
-                    "port",
                     "initialDelaySeconds",
                     "periodSeconds",
                     "timeoutSeconds",
@@ -1311,20 +1266,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Compactor liveness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Compactor container is considered live.",
@@ -1343,7 +1284,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -1392,20 +1332,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Compactor readiness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Compactor pod is marked ready.",
@@ -1424,7 +1350,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -1473,20 +1398,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Compactor startup probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Compactor startup probe is considered passed.",
@@ -1505,7 +1416,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -3214,20 +3124,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Query liveness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Query container is considered live.",
@@ -3246,7 +3142,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -3295,20 +3190,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Query readiness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Query pod is marked ready.",
@@ -3327,7 +3208,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -3376,20 +3256,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Query startup probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Query startup probe is considered passed.",
@@ -3408,7 +3274,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -4093,20 +3958,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Query Frontend liveness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Query Frontend container is considered live.",
@@ -4125,7 +3976,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -4174,20 +4024,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Query Frontend readiness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Query Frontend pod is marked ready.",
@@ -4206,7 +4042,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -4255,20 +4090,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Query Frontend startup probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Query Frontend startup probe is considered passed.",
@@ -4287,7 +4108,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -5242,20 +5062,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Receive liveness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Receive container is considered live.",
@@ -5274,7 +5080,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -5323,20 +5128,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Receive readiness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Receive pod is marked ready.",
@@ -5355,7 +5146,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -5404,20 +5194,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Receive startup probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Receive startup probe is considered passed.",
@@ -5436,7 +5212,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -6324,20 +6099,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Ruler liveness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Ruler container is considered live.",
@@ -6356,7 +6117,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -6405,20 +6165,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Ruler readiness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Ruler pod is marked ready.",
@@ -6437,7 +6183,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -6486,20 +6231,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Ruler startup probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Ruler startup probe is considered passed.",
@@ -6518,7 +6249,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -7627,20 +7357,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Store Gateway liveness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Store Gateway container is considered live.",
@@ -7659,7 +7375,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -7708,20 +7423,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Store Gateway readiness probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Store Gateway pod is marked ready.",
@@ -7740,7 +7441,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",
@@ -7789,20 +7489,6 @@
                   "title": "periodSeconds",
                   "type": "integer"
                 },
-                "port": {
-                  "default": "http",
-                  "description": "Port checked by the Store Gateway startup probe.",
-                  "required": [],
-                  "title": "port",
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "successThreshold": {
                   "default": 1,
                   "description": "Consecutive successes before the Store Gateway startup probe is considered passed.",
@@ -7821,7 +7507,6 @@
               "required": [
                 "enabled",
                 "path",
-                "port",
                 "initialDelaySeconds",
                 "periodSeconds",
                 "timeoutSeconds",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -389,8 +389,6 @@ bucket:
         enabled: true
         # -- HTTP path checked by the readiness probe.
         path: /-/ready
-        # -- (int or string) Port checked by the readiness probe.
-        port: http
         # -- Seconds to wait before starting the readiness probe.
         initialDelaySeconds: 5
         # -- How often (seconds) to run the readiness probe.
@@ -407,8 +405,6 @@ bucket:
         enabled: true
         # -- HTTP path checked by the liveness probe.
         path: /-/healthy
-        # -- (int or string) Port checked by the liveness probe.
-        port: http
         # -- Seconds to wait before starting the liveness probe.
         initialDelaySeconds: 30
         # -- How often (seconds) to run the liveness probe.
@@ -425,8 +421,6 @@ bucket:
         enabled: true
         # -- HTTP path checked by the startup probe.
         path: /-/ready
-        # -- (int or string) Port checked by the startup probe.
-        port: http
         # -- Seconds to wait before starting the startup probe.
         initialDelaySeconds: 0
         # -- How often (seconds) to run the startup probe.
@@ -654,8 +648,6 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor readiness probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Compactor readiness probe.
-      port: http
       # -- Seconds to wait before starting the Compactor readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Compactor readiness probe.
@@ -672,8 +664,6 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor liveness probe.
       path: /-/healthy
-      # -- (int or string) Port checked by the Compactor liveness probe.
-      port: http
       # -- Seconds to wait before starting the Compactor liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Compactor liveness probe.
@@ -690,8 +680,6 @@ compactor:
       enabled: true
       # -- HTTP path checked by the Compactor startup probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Compactor startup probe.
-      port: http
       # -- Seconds to wait before starting the Compactor startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Compactor startup probe.
@@ -976,8 +964,6 @@ query:
       enabled: true
       # -- HTTP path checked by the Query readiness probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Query readiness probe.
-      port: http
       # -- Seconds to wait before starting the Query readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Query readiness probe.
@@ -994,8 +980,6 @@ query:
       enabled: true
       # -- HTTP path checked by the Query liveness probe.
       path: /-/healthy
-      # -- (int or string) Port checked by the Query liveness probe.
-      port: http
       # -- Seconds to wait before starting the Query liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Query liveness probe.
@@ -1012,8 +996,6 @@ query:
       enabled: true
       # -- HTTP path checked by the Query startup probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Query startup probe.
-      port: http
       # -- Seconds to wait before starting the Query startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Query startup probe.
@@ -1219,8 +1201,6 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend readiness probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Query Frontend readiness probe.
-      port: http
       # -- Seconds to wait before starting the Query Frontend readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Query Frontend readiness probe.
@@ -1237,8 +1217,6 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend liveness probe.
       path: /-/healthy
-      # -- (int or string) Port checked by the Query Frontend liveness probe.
-      port: http
       # -- Seconds to wait before starting the Query Frontend liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Query Frontend liveness probe.
@@ -1255,8 +1233,6 @@ queryFrontend:
       enabled: true
       # -- HTTP path checked by the Query Frontend startup probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Query Frontend startup probe.
-      port: http
       # -- Seconds to wait before starting the Query Frontend startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Query Frontend startup probe.
@@ -1527,8 +1503,6 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway readiness probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Store Gateway readiness probe.
-      port: http
       # -- Seconds to wait before starting the Store Gateway readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Store Gateway readiness probe.
@@ -1545,8 +1519,6 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway liveness probe.
       path: /-/healthy
-      # -- (int or string) Port checked by the Store Gateway liveness probe.
-      port: http
       # -- Seconds to wait before starting the Store Gateway liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Store Gateway liveness probe.
@@ -1563,8 +1535,6 @@ storegateway:
       enabled: true
       # -- HTTP path checked by the Store Gateway startup probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Store Gateway startup probe.
-      port: http
       # -- Seconds to wait before starting the Store Gateway startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Store Gateway startup probe.
@@ -1874,8 +1844,6 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive readiness probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Receive readiness probe.
-      port: http
       # -- Seconds to wait before starting the Receive readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Receive readiness probe.
@@ -1892,8 +1860,6 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive liveness probe.
       path: /-/healthy
-      # -- (int or string) Port checked by the Receive liveness probe.
-      port: http
       # -- Seconds to wait before starting the Receive liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Receive liveness probe.
@@ -1910,8 +1876,6 @@ receive:
       enabled: true
       # -- HTTP path checked by the Receive startup probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Receive startup probe.
-      port: http
       # -- Seconds to wait before starting the Receive startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Receive startup probe.
@@ -2168,8 +2132,6 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler readiness probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Ruler readiness probe.
-      port: http
       # -- Seconds to wait before starting the Ruler readiness probe.
       initialDelaySeconds: 5
       # -- How often (seconds) to run the Ruler readiness probe.
@@ -2186,8 +2148,6 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler liveness probe.
       path: /-/healthy
-      # -- (int or string) Port checked by the Ruler liveness probe.
-      port: http
       # -- Seconds to wait before starting the Ruler liveness probe.
       initialDelaySeconds: 30
       # -- How often (seconds) to run the Ruler liveness probe.
@@ -2204,8 +2164,6 @@ ruler:
       enabled: true
       # -- HTTP path checked by the Ruler startup probe.
       path: /-/ready
-      # -- (int or string) Port checked by the Ruler startup probe.
-      port: http
       # -- Seconds to wait before starting the Ruler startup probe.
       initialDelaySeconds: 0
       # -- How often (seconds) to run the Ruler startup probe.


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Since everywhere in the chart is using port names now, there is no need to configure the port for probes.
Remove the configuration for those and just hard code the 'http' port for the http probes.

This also allows to simplify the thanos.httpProbes template since you no longer have to pass a port argument to it.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

Just some minor clean up to configuration that is now pointless to have based on previous changes I've made to the chart.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
