### PR TITLE
fix(rbac): create RBAC for ruler PrometheusRule auto-import

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/ruler/rbac.yaml
+++ b/charts/thanos/templates/ruler/rbac.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.ruler.enabled .Values.ruler.autoImportPrometheusRules.enabled .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "thanos.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -1115,6 +1115,90 @@ tests:
           path: data["import.sh"]
           pattern: 'SELECTOR="role=alert-rules,team=observability"'
 
+  # -- RBAC for auto-import PrometheusRules --------------------------------
+
+  - it: renders ClusterRole and ClusterRoleBinding when autoImport and rbac are enabled
+    template: ruler/rbac.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-ruler-rule-importer
+        documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - monitoring.coreos.com
+            resources:
+              - prometheusrules
+            verbs:
+              - get
+              - list
+              - watch
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-ruler-rule-importer
+        documentIndex: 1
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-thanos-ruler-rule-importer
+        documentIndex: 1
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+        documentIndex: 1
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-thanos-thanos
+        documentIndex: 1
+
+  - it: does not render rbac when ruler is disabled
+    template: ruler/rbac.yaml
+    set:
+      ruler.enabled: false
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render rbac when autoImport is disabled
+    template: ruler/rbac.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: false
+      global.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render rbac when global.rbac.create is false
+    template: ruler/rbac.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   # -- NetworkPolicy -------------------------------------------------------
 
   - it: does not render networkpolicy when networkPolicies is disabled


### PR DESCRIPTION
#### What this PR does / why we need it:

The chart documents `global.rbac.create` and defaults it to `true`, but no template ever materializes RBAC resources. As a result, the Ruler's `prometheus-rule-importer` sidecar (which runs `kubectl get prometheusrules.monitoring.coreos.com -A`) gets denied by the API server, and `autoImportPrometheusRules` is non-functional out of the box.

This PR adds the missing `ClusterRole` and `ClusterRoleBinding` granting `get/list/watch` on `prometheusrules.monitoring.coreos.com` to the chart's ServiceAccount, gated on `ruler.enabled && ruler.autoImportPrometheusRules.enabled && global.rbac.create`.

Audited the other components: the Ruler auto-import sidecar is the only thing in the chart that calls the Kubernetes API — query/store/compactor/receive/bucket all use object-store, DNS-SD, or static endpoints — so the fix is correctly scoped to the Ruler.

#### Which issue this PR fixes

- fixes #82

#### Special notes for your reviewer:

- New template: `charts/thanos/templates/ruler/rbac.yaml`
- Tests added in `charts/thanos/tests/ruler_test.yaml` covering rendered/not-rendered combinations across all three gates (`ruler.enabled`, `autoImportPrometheusRules.enabled`, `global.rbac.create`).
- Verified locally: `helm lint`, `helm template` (resources render with ruler enabled, suppressed when any gate is false), and `helm unittest .` (502/502 pass).

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Variables are documented in the README.md