### PR TITLE
fix: point query at receive headless service for gRPC SRV lookup

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -45,8 +45,7 @@ spec:
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
           {{- if .Values.receive.enabled }}
-            # - --endpoint={{ include "thanos.compName" (list . "receive") }}-headless:{{ .Values.receive.service.grpcPort }}
-            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "receive") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.receiveHeadless" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
         {{- end }}
           {{- range .Values.query.endpoints.static }}


### PR DESCRIPTION
## Summary

- Query was doing `dnssrv+_grpc._tcp.thanos-receive.<ns>.svc...` but the regular `thanos-receive` service does not expose the `grpc` port — only `thanos-receive-headless` does. SRV lookups returned NXDOMAIN and the querier never saw receivers.
- Switch the endpoint to use the existing `thanos.receiveHeadless` helper so the lookup hits the right service.
- Bump chart `0.8.2 → 0.8.3`.

Fixes #85. Supersedes #88 (uses the dedicated helper rather than `compName \"receive-headless\"` for consistency with how the headless service is referenced elsewhere in the chart).

## Test plan

- [x] `helm template` renders `--endpoint=dnssrv+_grpc._tcp.thanos-receive-headless.<ns>.svc.<clusterDomain>`
- [x] `helm lint charts/thanos` passes
- [ ] Deploy on a cluster and verify `thanos-query` logs no longer show `failed to lookup SRV records` for the receive endpoint