### PR TITLE
fix: storegateway.cachingBucketConfig rendering

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/templates/storegateway/configmap-caching.yaml
+++ b/charts/thanos/templates/storegateway/configmap-caching.yaml
@@ -9,5 +9,5 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "storegateway-caching") | nindent 4 }}
 data:
   caching-bucket.yaml: |
-    {{- toYaml (tpl .Values.storegateway.cachingBucketConfig .) | nindent 4 }}
+    {{- tpl .Values.storegateway.cachingBucketConfig . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The storegateway.cachingBucketConfig is asked to be specified as an inline YAML string.
The template uses the `toYaml` against the string after passing it through the `tpl` function. `toYaml` seeing a multiline string adds a `|` beforehand to preserve it as a string, but the template code already adds that.
The fix is just to remove the use of the `toYaml` function.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #52

#### Special notes for your reviewer:

Using the following configuration under the `storegateway:` field:
```yaml
  cachingBucketConfig: |
    config:
      max_size: 0
      max_size_items: 2048
      validity: 6h
    type: IN-MEMORY
```

The helm chart wanted to render this (shown in diff format):
```diff
+ data:
+   caching-bucket.yaml: |
+     |
+       config:
+         max_size: 0
+         max_size_items: 2048
+         validity: 6h
+       type: IN-MEMORY
```
Note the double `|`.

After the change it looks like this:
```diff
+ data:
+   caching-bucket.yaml: |
+     config:
+       max_size: 0
+       max_size_items: 2048
+       validity: 6h
+     type: IN-MEMORY
```

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
