### PR TITLE
fix(query): Deduplicate metrics against receive_replica label

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -45,8 +45,8 @@ Kubernetes: `>= 1.30.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.rustfs.com/ | rustfs | 0.0.98 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 84.0.1 |
+| https://charts.rustfs.com/ | rustfs | 0.1.0 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 84.5.0 |
 
 ## Component Overview
 
@@ -234,6 +234,7 @@ query:
   # Labels that identify replica identity — used for deduplication
   replicaLabels:
     - prometheus_replica
+    - receive_replica
 
   # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway) are auto-wired
   # when autogen.enabled is true. Endpoints defined in static[] are always appended; set
@@ -739,6 +740,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Query startup probe times out. |
 | query.replicaCount | int | `2` | Number of Query pod replicas. Two or more is recommended for HA. |
 | query.replicaLabels[0] | string | `"prometheus_replica"` |  |
+| query.replicaLabels[1] | string | `"receive_replica"` |  |
 | query.resources | object | {} | Resource requests and limits for the Query container. |
 | query.service.annotations | object | {} | Extra annotations for the Query Service. |
 | query.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Query Service. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -222,6 +222,7 @@ query:
   # Labels that identify replica identity — used for deduplication
   replicaLabels:
     - prometheus_replica
+    - receive_replica
 
   # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway) are auto-wired
   # when autogen.enabled is true. Endpoints defined in static[] are always appended; set

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -58,6 +58,18 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --query.replica-label=thanos_replica
 
+  - it: sets default replica labels when nothing is specified
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --query.replica-label=prometheus_replica
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --query.replica-label=receive_replica
+
   - it: adds store endpoints for storegateway when enabled
     template: query/deployment.yaml
     set:

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -919,6 +919,7 @@ query:
   # Label names that identify replica identity for result deduplication.
   replicaLabels:
     - prometheus_replica
+    - receive_replica
 
   # Additional CLI arguments appended to the `thanos query` command.
   extraArgs:


### PR DESCRIPTION
The receiver is adding a receive_replica label, but the querier is not deduplicating the metrics against it.



<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

- Fixes: #105

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
