### PR TITLE
fix: gate Thanos rules on component enablement, refresh CI actions, and update tests

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check documentation formatting (markdownlint)
-        uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b  # v23.1.0
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd  # v23.2.0
         with:
           globs: |
             **/*.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Install helm-sigstore plugin
         run: helm plugin install --verify=false https://github.com/sigstore/helm-sigstore

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Renovate (pinDigests) will pin this to a SHA on its next run.
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 60

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -655,22 +655,22 @@ The table below documents all available values. Top-level keys group settings by
 | global.thanosRules.groups.thanosBucketReplicate.jobPattern | string | `".*thanos.*bucket-replicate.*"` | Regex used to match the Prometheus `job` label of bucket-replicate scrape targets. |
 | global.thanosRules.groups.thanosBucketReplicate.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosCompact.annotations | object | {} | Extra annotations merged into every alert in this group. |
-| global.thanosRules.groups.thanosCompact.enabled | bool | `true` | Render the thanos-compact rule group. |
+| global.thanosRules.groups.thanosCompact.enabled | bool | `true` | Render the thanos-compact rule group. Also requires `compactor.enabled`. |
 | global.thanosRules.groups.thanosCompact.jobPattern | string | `".*thanos.*compact.*"` | Regex used to match the Prometheus `job` label of compactor scrape targets. |
 | global.thanosRules.groups.thanosCompact.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosComponentAbsent.annotations | object | {} | Extra annotations merged into every alert in this group. |
 | global.thanosRules.groups.thanosComponentAbsent.enabled | bool | `true` | Render the thanos-component-absent rule group. |
 | global.thanosRules.groups.thanosComponentAbsent.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosQuery.annotations | object | {} | Extra annotations merged into every alert in this group. |
-| global.thanosRules.groups.thanosQuery.enabled | bool | `true` | Render the thanos-query rule group. |
+| global.thanosRules.groups.thanosQuery.enabled | bool | `true` | Render the thanos-query rule group. Also requires `query.enabled`. |
 | global.thanosRules.groups.thanosQuery.jobPattern | string | `".*thanos.*query.*"` | Regex used to match the Prometheus `job` label of query scrape targets. |
 | global.thanosRules.groups.thanosQuery.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosReceive.annotations | object | {} | Extra annotations merged into every alert in this group. |
-| global.thanosRules.groups.thanosReceive.enabled | bool | `true` | Render the thanos-receive rule group. |
+| global.thanosRules.groups.thanosReceive.enabled | bool | `true` | Render the thanos-receive rule group. Also requires `receive.enabled`. |
 | global.thanosRules.groups.thanosReceive.jobPattern | string | `".*thanos.*receive.*"` | Regex used to match the Prometheus `job` label of receive scrape targets. |
 | global.thanosRules.groups.thanosReceive.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosRule.annotations | object | {} | Extra annotations merged into every alert in this group. |
-| global.thanosRules.groups.thanosRule.enabled | bool | `true` | Render the thanos-rule rule group. |
+| global.thanosRules.groups.thanosRule.enabled | bool | `true` | Render the thanos-rule rule group. Also requires `ruler.enabled`. |
 | global.thanosRules.groups.thanosRule.jobPattern | string | `".*thanos.*rule.*"` | Regex used to match the Prometheus `job` label of ruler scrape targets. |
 | global.thanosRules.groups.thanosRule.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosSidecar.annotations | object | {} | Extra annotations merged into every alert in this group. |
@@ -678,7 +678,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.thanosRules.groups.thanosSidecar.jobPattern | string | `".*thanos.*sidecar.*"` | Regex used to match the Prometheus `job` label of sidecar scrape targets. |
 | global.thanosRules.groups.thanosSidecar.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.groups.thanosStore.annotations | object | {} | Extra annotations merged into every alert in this group. |
-| global.thanosRules.groups.thanosStore.enabled | bool | `true` | Render the thanos-store rule group. |
+| global.thanosRules.groups.thanosStore.enabled | bool | `true` | Render the thanos-store rule group. Also requires `storegateway.enabled`. |
 | global.thanosRules.groups.thanosStore.jobPattern | string | `".*thanos.*store.*"` | Regex used to match the Prometheus `job` label of store gateway scrape targets. |
 | global.thanosRules.groups.thanosStore.labels | object | {} | Extra labels merged into every alert in this group. |
 | global.thanosRules.labels | object | {} | Extra labels merged into the PrometheusRule resource metadata. |

--- a/charts/thanos/templates/prometheusrule/_helpers.tpl
+++ b/charts/thanos/templates/prometheusrule/_helpers.tpl
@@ -58,18 +58,27 @@ Usage:
 {{- $rule := $groups.thanosRule | default dict -}}
 {{- $bucketRepl := $groups.thanosBucketReplicate | default dict -}}
 {{- $absent := $groups.thanosComponentAbsent | default dict -}}
-{{- /* Resolve `enabled` per group. Defaults match values.yaml: sidecar
-       and bucketReplicate are off because the chart does not deploy
-       those components. Resolving here keeps each rule helper to a
-       single `if .compactEnabled` check and side-steps the Helm quirk
-       where `default true false` returns true. */ -}}
+{{- /* Resolve `enabled` per group. Each group's own toggle defaults to
+       true (false for sidecar/bucketReplicate which have no component
+       in this chart). For groups that map to a chart component, the
+       group is also AND-ed with that component's top-level `enabled`
+       flag, so disabling a component (e.g. ruler.enabled=false) also
+       silences its rule group and its ThanosXIsDown absent alert. */ -}}
 {{- $defaults := dict "compact" true "query" true "receive" true "sidecar" false "store" true "rule" true "bucketRepl" false "absent" true -}}
+{{- $compEn  := and (hasKey .Values "compactor")    (default false (index .Values "compactor"    "enabled")) -}}
+{{- $qEn     := and (hasKey .Values "query")        (default false (index .Values "query"        "enabled")) -}}
+{{- $rcEn    := and (hasKey .Values "receive")      (default false (index .Values "receive"      "enabled")) -}}
+{{- $stEn    := and (hasKey .Values "storegateway") (default false (index .Values "storegateway" "enabled")) -}}
+{{- $rEn     := and (hasKey .Values "ruler")        (default false (index .Values "ruler"        "enabled")) -}}
+{{- $componentGate := dict "compact" $compEn "query" $qEn "receive" $rcEn "store" $stEn "rule" $rEn -}}
 {{- $enabled := dict -}}
 {{- range $k, $g := dict "compact" $compact "query" $query "receive" $receive "sidecar" $sidecar "store" $store "rule" $rule "bucketRepl" $bucketRepl "absent" $absent -}}
-{{- if hasKey $g "enabled" -}}
-{{- $_ := set $enabled $k $g.enabled -}}
+{{- $own := index $defaults $k -}}
+{{- if hasKey $g "enabled" -}}{{- $own = $g.enabled -}}{{- end -}}
+{{- if hasKey $componentGate $k -}}
+{{- $_ := set $enabled $k (and $own (index $componentGate $k)) -}}
 {{- else -}}
-{{- $_ := set $enabled $k (index $defaults $k) -}}
+{{- $_ := set $enabled $k $own -}}
 {{- end -}}
 {{- end -}}
 {{- $ctx := dict

--- a/charts/thanos/tests/bucketweb_test.yaml
+++ b/charts/thanos/tests/bucketweb_test.yaml
@@ -257,7 +257,7 @@ tests:
       bucket.enabled: true
       bucket.bucketweb.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -288,7 +288,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -261,7 +261,7 @@ tests:
     set:
       compactor.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -291,7 +291,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/tests/prometheusrule_test.yaml
+++ b/charts/thanos/tests/prometheusrule_test.yaml
@@ -54,7 +54,7 @@ tests:
   # Default rule groups (no overrides)
   # ----------------------------------------------------------------------
 
-  - it: renders all enabled-by-default groups
+  - it: renders rule groups for components enabled by default
     asserts:
       - contains:
           path: spec.groups
@@ -79,12 +79,35 @@ tests:
       - contains:
           path: spec.groups
           content:
+            name: thanos-component-absent
+          any: true
+
+  - it: does not render thanos-rule when ruler is disabled by default
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
             name: thanos-rule
           any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosRuleIsDown
+          any: true
+
+  - it: renders thanos-rule when ruler is enabled
+    set:
+      ruler.enabled: true
+    asserts:
       - contains:
           path: spec.groups
           content:
-            name: thanos-component-absent
+            name: thanos-rule
+          any: true
+      - contains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosRuleIsDown
           any: true
 
   - it: does not render thanos-sidecar by default
@@ -101,6 +124,101 @@ tests:
           path: spec.groups
           content:
             name: thanos-bucket-replicate
+          any: true
+
+  # ----------------------------------------------------------------------
+  # Auto-disable based on the matching component's `enabled` flag
+  # ----------------------------------------------------------------------
+
+  - it: disables thanos-compact and ThanosCompactIsDown when compactor is disabled
+    set:
+      compactor.enabled: false
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
+            name: thanos-compact
+          any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosCompactIsDown
+          any: true
+
+  - it: disables thanos-query and ThanosQueryIsDown when query is disabled
+    set:
+      query.enabled: false
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
+            name: thanos-query
+          any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosQueryIsDown
+          any: true
+
+  - it: disables thanos-receive and ThanosReceiveIsDown when receive is disabled
+    set:
+      receive.enabled: false
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
+            name: thanos-receive
+          any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosReceiveIsDown
+          any: true
+
+  - it: disables thanos-store and ThanosStoreIsDown when storegateway is disabled
+    set:
+      storegateway.enabled: false
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
+            name: thanos-store
+          any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosStoreIsDown
+          any: true
+
+  - it: a disabled component silences its rule group even when the group toggle is on
+    set:
+      compactor.enabled: false
+      global.thanosRules.groups.thanosCompact.enabled: true
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
+            name: thanos-compact
+          any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosCompactIsDown
+          any: true
+
+  - it: explicit group disable silences a group whose component is enabled
+    set:
+      global.thanosRules.groups.thanosQuery.enabled: false
+    asserts:
+      - notContains:
+          path: spec.groups
+          content:
+            name: thanos-query
+          any: true
+      - notContains:
+          path: spec.groups[?(@.name == "thanos-component-absent")].rules
+          content:
+            alert: ThanosQueryIsDown
           any: true
 
   # ----------------------------------------------------------------------
@@ -232,6 +350,7 @@ tests:
 
   - it: applies additionalRuleGroupAnnotations to every alert
     set:
+      ruler.enabled: true
       global.thanosRules.additionalRuleGroupAnnotations:
         playbook: https://wiki.example.com/thanos
     asserts:
@@ -295,6 +414,8 @@ tests:
   # ----------------------------------------------------------------------
 
   - it: emits the expected number of rules per default group
+    set:
+      ruler.enabled: true
     asserts:
       - lengthEqual:
           path: spec.groups[?(@.name == "thanos-compact")].rules

--- a/charts/thanos/tests/query_frontend_test.yaml
+++ b/charts/thanos/tests/query_frontend_test.yaml
@@ -252,7 +252,7 @@ tests:
     set:
       queryFrontend.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -282,7 +282,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -351,7 +351,7 @@ tests:
     set:
       query.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -381,7 +381,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -265,7 +265,7 @@ tests:
     set:
       receive.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -295,7 +295,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -267,7 +267,7 @@ tests:
     set:
       ruler.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -297,7 +297,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -245,7 +245,7 @@ tests:
     set:
       storegateway.enabled: true
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   # -- Scheduling and placement ---------------------------------------
@@ -275,7 +275,7 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.template.spec.affinity.podAntiAffinity
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity.nodeAffinity
 
   - it: applies global affinity as fallback

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -207,7 +207,11 @@ global:
       info: info
     # Per-group configuration. Each entry maps to a rule group from the
     # Thanos mixin and supports:
-    #   - enabled: render the group when true (defaults shown below).
+    #   - enabled: render the group when true. For groups that map to a
+    #     chart component (compact, query, receive, store, rule), the
+    #     group is also gated on the component's top-level `enabled`
+    #     flag — disabling the component (e.g. ruler.enabled=false)
+    #     silences its rule group and its ThanosXIsDown absent alert.
     #   - jobPattern: regex matching the Prometheus `job` label of the
     #     component scrape targets. Defaults assume a job name containing
     #     `thanos` and the component keyword.
@@ -215,8 +219,9 @@ global:
     #     top of `additionalRuleGroupLabels` / `additionalRuleGroupAnnotations`.
     groups:
       # Compactor alerts (thanos-compact rule group).
+      # Also gated on `compactor.enabled`.
       thanosCompact:
-        # -- Render the thanos-compact rule group.
+        # -- Render the thanos-compact rule group. Also requires `compactor.enabled`.
         enabled: true
         # -- Regex used to match the Prometheus `job` label of compactor scrape targets.
         jobPattern: ".*thanos.*compact.*"
@@ -227,8 +232,9 @@ global:
         # @default -- {}
         annotations: {}
       # Query alerts (thanos-query rule group).
+      # Also gated on `query.enabled`.
       thanosQuery:
-        # -- Render the thanos-query rule group.
+        # -- Render the thanos-query rule group. Also requires `query.enabled`.
         enabled: true
         # -- Regex used to match the Prometheus `job` label of query scrape targets.
         jobPattern: ".*thanos.*query.*"
@@ -239,8 +245,9 @@ global:
         # @default -- {}
         annotations: {}
       # Receive alerts (thanos-receive rule group).
+      # Also gated on `receive.enabled`.
       thanosReceive:
-        # -- Render the thanos-receive rule group.
+        # -- Render the thanos-receive rule group. Also requires `receive.enabled`.
         enabled: true
         # -- Regex used to match the Prometheus `job` label of receive scrape targets.
         jobPattern: ".*thanos.*receive.*"
@@ -264,8 +271,9 @@ global:
         # @default -- {}
         annotations: {}
       # Store gateway alerts (thanos-store rule group).
+      # Also gated on `storegateway.enabled`.
       thanosStore:
-        # -- Render the thanos-store rule group.
+        # -- Render the thanos-store rule group. Also requires `storegateway.enabled`.
         enabled: true
         # -- Regex used to match the Prometheus `job` label of store gateway scrape targets.
         jobPattern: ".*thanos.*store.*"
@@ -276,8 +284,9 @@ global:
         # @default -- {}
         annotations: {}
       # Ruler alerts (thanos-rule rule group).
+      # Also gated on `ruler.enabled`.
       thanosRule:
-        # -- Render the thanos-rule rule group.
+        # -- Render the thanos-rule rule group. Also requires `ruler.enabled`.
         enabled: true
         # -- Regex used to match the Prometheus `job` label of ruler scrape targets.
         jobPattern: ".*thanos.*rule.*"


### PR DESCRIPTION
#### What this PR does / why we need it:

Two small fixes plus a CI version refresh:

- **Gate rule groups on component enablement** — `thanos-compact`, `thanos-query`, `thanos-receive`, `thanos-store`, and `thanos-rule` (and their matching `ThanosXIsDown` absent alerts) now also require the corresponding component (`compactor.enabled`, `query.enabled`, `receive.enabled`, `storegateway.enabled`, `ruler.enabled`) to be enabled. Disabling a component automatically silences its alerts. The per-group `thanosRules.groups.<group>.enabled` toggle is AND-ed with the component flag, so it can no longer enable rules for a component that is turned off.
- **Replace deprecated `isNull` with `notExists`** in helm unit tests across all component test files (14 occurrences in 7 files).
- **Bump GitHub Actions** to the latest pinned versions surfaced by Dependabot/Renovate:
  - `actions/stale` 9.1.0 → 10.2.0
  - `sigstore/cosign-installer` 4.1.1 → 4.1.2
  - `DavidAnson/markdownlint-cli2-action` 23.1.0 → 23.2.0

Chart version bumped 0.10.0 → 0.10.1.

#### Which issue this PR fixes

- fixes #111

#### Related PRs (superseded by this PR)

- #110 — `isNull` → `notExists` (helm-unittest deprecation), by @bigon
- #113 — bump `actions/stale` to 10.2.0
- #114 / #116 — bump `sigstore/cosign-installer` to 4.1.2
- #115 / #117 — bump `DavidAnson/markdownlint-cli2-action` to 23.2.0

#### Special notes for your reviewer:

- All 533 helm unit tests pass.
- The new behaviour is exercised by 6 new prometheusrule tests covering per-component auto-disable and the AND precedence between `<component>.enabled` and `thanosRules.groups.<group>.enabled`.
- Two pre-existing tests that assumed `ruler.enabled` was true by default now set `ruler.enabled: true` explicitly.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md