### PR TITLE
feat(receive): add split mode (router + ingester)

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -295,6 +295,59 @@ prometheus:
   prometheusSpec:
     remoteWrite:
       - url: http://thanos-receive.monitoring.svc.cluster.local:10908/api/v1/receive
+```
+
+#### Split mode (separate Router and Ingester)
+
+For high-availability and horizontal scalability, Receive can be deployed as
+two separate workloads following the [receive split proposal](https://thanos.io/tip/proposals-accepted/202012-receive-split.md):
+
+- **Router** — stateless `Deployment` that terminates client `remote_write`
+  traffic and forwards each request to the correct Ingester(s) according to the
+  hashring config (with optional replication).
+- **Ingester** — stateful `StatefulSet` that stores samples in a local TSDB WAL
+  and ships blocks to the object store, just like standalone Receive.
+
+Set `receive.mode: split` to opt in. In `split` mode the top-level `receive.*`
+fields are **ignored**: configure the Ingester StatefulSet (renamed to
+`<release>-thanos-receive-ingester`) via `receive.ingester.*`, and the Router
+Deployment (`<release>-thanos-receive-router`) via `receive.router.*`. The
+schema enforces that both `ingester` and `router` are populated when
+`mode: split`.
+
+```yaml
+receive:
+  enabled: true
+  mode: split             # standalone (default) | split
+
+  ingester:
+    replicaCount: 3       # Minimum 3 for replication factor 2
+    tsdb:
+      retention: 24h
+      walCompression: true
+    service:
+      grpcPort: 10901
+      httpPort: 10902
+      remoteWritePort: 10908
+    persistence:
+      enabled: true
+      size: 10Gi
+    hashrings:
+      autogen:
+        enabled: true
+
+  router:
+    replicaCount: 2
+    replicationFactor: 2  # Each write fans out to N ingesters
+```
+
+In standalone mode (default), leave `receive.ingester` and `receive.router`
+empty — all configuration lives directly under `receive.*`.
+
+In split mode clients should remote-write to the Router service:
+
+```
+http://<release>-thanos-receive-router.<namespace>.svc.cluster.local:10908/api/v1/receive
 ```
 
 ### Store Gateway
@@ -883,6 +936,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Receive HTTP endpoint. |
 | receive.httpRoute.hostnames | list | [] | Hostnames to match on the Receive HTTPRoute. |
 | receive.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Receive HTTPRoute. |
+| receive.ingester | object | {} | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. |
 | receive.ingress.annotations | object | {} | Deprecated. Use `receive.ingress.http.annotations` instead. |
 | receive.ingress.className | string | `""` | Deprecated. Use `receive.ingress.http.className` instead. |
 | receive.ingress.enabled | bool | `false` | Deprecated. Use `receive.ingress.http.enabled` instead. |
@@ -905,6 +959,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.ingress.http.tls | list | [] | TLS configuration for the Receive HTTP Ingress. |
 | receive.ingress.tls | list | [] | Deprecated. Use `receive.ingress.http.tls` instead. |
 | receive.labels | object | {} | Extra labels applied to Receive resources. |
+| receive.mode | string | `"standalone"` | Receive deployment topology. One of: `standalone` — single workload that both routes and ingests (RouterIngestor mode); `split` — separate Router (Deployment) and Ingester (StatefulSet) workloads, following the receive split proposal (https://thanos.io/tip/proposals-accepted/202012-receive-split.md).  Field shape depends on mode:   - `standalone`: configure the workload directly via top-level `receive.*`     fields (replicaCount, tsdb, service, persistence, etc.). `receive.ingester`     and `receive.router` are ignored.   - `split`: configure each workload via `receive.ingester.*` and     `receive.router.*`. Top-level `receive.*` fields are ignored. The schema     requires both `ingester` and `router` to be populated in this mode. |
 | receive.nodeSelector | object | {} | Node selector for Receive pod scheduling. |
 | receive.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Receive. |
 | receive.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Receive pods during a disruption. |
@@ -937,8 +992,84 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Receive startup probe. |
 | receive.probes.startup.successThreshold | int | `1` | Consecutive successes before the Receive startup probe is considered passed. |
 | receive.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Receive startup probe times out. |
-| receive.replicaCount | int | `3` | Number of Receive pod replicas. Minimum 3 is recommended for replication factor 2 (write quorum = floor(replicaCount/2)+1). |
+| receive.replicaCount | int | `3` | Number of Receive pod replicas. Minimum 3 is recommended for replication factor 2 (write quorum = floor(replicaCount/2)+1). In `split` mode this controls the Ingester StatefulSet replica count. |
 | receive.resources | object | {} | Resource requests and limits for the Receive container. |
+| receive.router.affinity | object | {} | Affinity rules for Router pod scheduling. Falls back to receive.affinity. |
+| receive.router.annotations | object | {} | Extra annotations applied to Router resources. |
+| receive.router.containerSecurityContext | object | {} | Container security context for the Router container. Falls back to receive.containerSecurityContext, then global.containerSecurityContext. |
+| receive.router.dnsConfig | object | {} | DNS configuration for Router pods. Falls back to receive.dnsConfig. |
+| receive.router.extraArgs | list | [] | Additional CLI arguments appended to the `thanos receive` command for the Router. |
+| receive.router.extraContainers | list | [] | Extra sidecar containers for Router pods. |
+| receive.router.extraEnv | list | [] | Extra environment variables injected into the Router container. |
+| receive.router.extraEnvFrom | list | [] | Extra environment variable sources for the Router container. |
+| receive.router.extraInitContainers | list | [] | Extra init containers for Router pods. |
+| receive.router.extraVolumeMounts | list | [] | Extra volume mounts for the Router container. |
+| receive.router.extraVolumes | list | [] | Extra volumes for Router pods. |
+| receive.router.httpRoute.annotations | object | {} | Annotations for the Router HTTPRoute resource. |
+| receive.router.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Router HTTP endpoint. |
+| receive.router.httpRoute.hostnames | list | [] | Hostnames to match on the Router HTTPRoute. |
+| receive.router.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Router HTTPRoute. |
+| receive.router.ingress.http.annotations | object | {} | Extra annotations for the Router HTTP Ingress. |
+| receive.router.ingress.http.className | string | `""` | Ingress class name for Router HTTP endpoint. |
+| receive.router.ingress.http.enabled | bool | `false` | Enable a Kubernetes Ingress for the Router HTTP endpoint. |
+| receive.router.ingress.http.hosts[0].host | string | `"thanos-receive-router.local"` |  |
+| receive.router.ingress.http.hosts[0].paths[0].path | string | `"/"` |  |
+| receive.router.ingress.http.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| receive.router.ingress.http.tls | list | [] | TLS configuration for the Router HTTP Ingress. |
+| receive.router.labels | object | {} | Extra labels applied to Router resources. |
+| receive.router.nodeSelector | object | {} | Node selector for Router pod scheduling. Falls back to receive.nodeSelector. |
+| receive.router.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Router. |
+| receive.router.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Router pods during a disruption. |
+| receive.router.pdb.minAvailable | int or string | `""` | Minimum available Router pods during a disruption. |
+| receive.router.podSecurityContext | object | {} | Pod security context for Router pods. Falls back to receive.podSecurityContext, then global.podSecurityContext. |
+| receive.router.priorityClassName | string | `""` | Priority class name for Router pods. Falls back to receive.priorityClassName. |
+| receive.router.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Router. |
+| receive.router.probes.liveness.failureThreshold | int | `6` | Consecutive failures before the Router container is restarted. |
+| receive.router.probes.liveness.initialDelaySeconds | int | `30` | Seconds to wait before starting the Router liveness probe. |
+| receive.router.probes.liveness.path | string | `"/-/healthy"` | HTTP path checked by the Router liveness probe. |
+| receive.router.probes.liveness.periodSeconds | int | `10` | How often (seconds) to run the Router liveness probe. |
+| receive.router.probes.liveness.successThreshold | int | `1` | Consecutive successes before the Router container is considered live. |
+| receive.router.probes.liveness.timeoutSeconds | int | `5` | Seconds after which the Router liveness probe times out. |
+| receive.router.probes.readiness.enabled | bool | `true` | Enable the readiness probe for Router. |
+| receive.router.probes.readiness.failureThreshold | int | `6` | Consecutive failures before the Router pod is marked not-ready. |
+| receive.router.probes.readiness.initialDelaySeconds | int | `5` | Seconds to wait before starting the Router readiness probe. |
+| receive.router.probes.readiness.path | string | `"/-/ready"` | HTTP path checked by the Router readiness probe. |
+| receive.router.probes.readiness.periodSeconds | int | `10` | How often (seconds) to run the Router readiness probe. |
+| receive.router.probes.readiness.successThreshold | int | `1` | Consecutive successes before the Router pod is marked ready. |
+| receive.router.probes.readiness.timeoutSeconds | int | `5` | Seconds after which the Router readiness probe times out. |
+| receive.router.probes.startup.enabled | bool | `true` | Enable the startup probe for Router. |
+| receive.router.probes.startup.failureThreshold | int | `60` | Consecutive failures during Router startup before the container is killed. |
+| receive.router.probes.startup.initialDelaySeconds | int | `0` | Seconds to wait before starting the Router startup probe. |
+| receive.router.probes.startup.path | string | `"/-/ready"` | HTTP path checked by the Router startup probe. |
+| receive.router.probes.startup.periodSeconds | int | `5` | How often (seconds) to run the Router startup probe. |
+| receive.router.probes.startup.successThreshold | int | `1` | Consecutive successes before the Router startup probe is considered passed. |
+| receive.router.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Router startup probe times out. |
+| receive.router.replicaCount | int | `2` | Number of Router pod replicas. Routers are stateless so scale horizontally based on incoming write throughput. |
+| receive.router.replicationFactor | int | `1` | Replication factor used when forwarding writes to Ingesters. Each write is sent to this many Ingesters. Must be <= ingester replicaCount. |
+| receive.router.resources | object | {} | Resource requests and limits for the Router container. |
+| receive.router.service.annotations | object | {} | Extra annotations for the Router Service. |
+| receive.router.service.httpPort | int | `10902` | HTTP port exposed by the Router Service (metrics, probes). |
+| receive.router.service.labels | object | {} | Extra labels for the Router Service. |
+| receive.router.service.remoteWritePort | int | `10908` | Remote-write ingestion port exposed by the Router Service. |
+| receive.router.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Router component. |
+| receive.router.serviceMonitor.annotations | object | {} | Extra annotations for the Router ServiceMonitor. |
+| receive.router.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Router. |
+| receive.router.serviceMonitor.interval | string | `""` | Scrape interval for Router. Empty uses the Prometheus operator default. |
+| receive.router.serviceMonitor.labels | object | {} | Extra labels for the Router ServiceMonitor. |
+| receive.router.serviceMonitor.metricRelabelings | list | [] | Metric relabeling rules applied after Router metrics are ingested. |
+| receive.router.serviceMonitor.relabelings | list | [] | Relabeling rules applied before Router metrics are ingested. |
+| receive.router.serviceMonitor.scheme | string | `""` | Scrape scheme for Router (http or https). |
+| receive.router.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for Router. Empty uses the Prometheus operator default. |
+| receive.router.serviceMonitor.tlsConfig | object | {} | TLS configuration for Router scraping. |
+| receive.router.tolerations | list | [] | Tolerations for Router pod scheduling. Falls back to receive.tolerations. |
+| receive.router.topologySpreadConstraints | list | [] | Topology spread constraints for Router pods. Falls back to receive.topologySpreadConstraints. |
+| receive.router.vpa.enabled | bool | `false` | Enable a VerticalPodAutoscaler for the Router Deployment. |
+| receive.router.vpa.maxAllowed.cpu | string | `"2"` | Maximum CPU resource enforced by the Router VPA. |
+| receive.router.vpa.maxAllowed.memory | string | `"4Gi"` | Maximum memory resource enforced by the Router VPA. |
+| receive.router.vpa.minAllowed.cpu | string | `"100m"` | Minimum CPU resource enforced by the Router VPA. |
+| receive.router.vpa.minAllowed.memory | string | `"256Mi"` | Minimum memory resource enforced by the Router VPA. |
+| receive.router.vpa.targetKind | string | `"Deployment"` | Kubernetes workload kind targeted by the Router VPA. |
+| receive.router.vpa.updateMode | string | `"Auto"` | VPA update mode for Router. One of Auto, Off, or Initial. |
 | receive.service.annotations | object | {} | Extra annotations for the Receive Service. |
 | receive.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Receive Service. |
 | receive.service.httpPort | int | `10902` | HTTP port exposed by the Receive Service. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -285,6 +285,59 @@ prometheus:
       - url: http://thanos-receive.monitoring.svc.cluster.local:10908/api/v1/receive
 ```
 
+#### Split mode (separate Router and Ingester)
+
+For high-availability and horizontal scalability, Receive can be deployed as
+two separate workloads following the [receive split proposal](https://thanos.io/tip/proposals-accepted/202012-receive-split.md):
+
+- **Router** — stateless `Deployment` that terminates client `remote_write`
+  traffic and forwards each request to the correct Ingester(s) according to the
+  hashring config (with optional replication).
+- **Ingester** — stateful `StatefulSet` that stores samples in a local TSDB WAL
+  and ships blocks to the object store, just like standalone Receive.
+
+Set `receive.mode: split` to opt in. In `split` mode the top-level `receive.*`
+fields are **ignored**: configure the Ingester StatefulSet (renamed to
+`<release>-thanos-receive-ingester`) via `receive.ingester.*`, and the Router
+Deployment (`<release>-thanos-receive-router`) via `receive.router.*`. The
+schema enforces that both `ingester` and `router` are populated when
+`mode: split`.
+
+```yaml
+receive:
+  enabled: true
+  mode: split             # standalone (default) | split
+
+  ingester:
+    replicaCount: 3       # Minimum 3 for replication factor 2
+    tsdb:
+      retention: 24h
+      walCompression: true
+    service:
+      grpcPort: 10901
+      httpPort: 10902
+      remoteWritePort: 10908
+    persistence:
+      enabled: true
+      size: 10Gi
+    hashrings:
+      autogen:
+        enabled: true
+
+  router:
+    replicaCount: 2
+    replicationFactor: 2  # Each write fans out to N ingesters
+```
+
+In standalone mode (default), leave `receive.ingester` and `receive.router`
+empty — all configuration lives directly under `receive.*`.
+
+In split mode clients should remote-write to the Router service:
+
+```
+http://<release>-thanos-receive-router.<namespace>.svc.cluster.local:10908/api/v1/receive
+```
+
 ### Store Gateway
 
 The Store Gateway exposes historical blocks from the object store over the Store API. Query routes requests for older data to this component.

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -48,41 +48,97 @@ app.kubernetes.io/part-of: thanos
 {{- end }}
 {{- end }}
 
+{{- /*
+Render a pod-level securityContext block with component → (optional parent) → global fallback.
+Usage:
+  {{ include "thanos.podSC" (dict "root" . "key" "compactor") }}
+  {{ include "thanos.podSC" (dict "root" . "key" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.podSC" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
-{{- $psc := $comp.podSecurityContext | default $root.Values.global.podSecurityContext -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
+{{- $psc := $comp.podSecurityContext | default $par.podSecurityContext | default $root.Values.global.podSecurityContext -}}
 {{- if $psc }}
 securityContext:
   {{- toYaml $psc | nindent 2 }}
 {{- end }}
 {{- end }}
 
+{{- /*
+Render a container-level securityContext block with component → (optional parent) → global fallback.
+Usage:
+  {{ include "thanos.containerSC" (dict "root" . "key" "compactor") }}
+  {{ include "thanos.containerSC" (dict "root" . "key" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.containerSC" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
-{{- $csc := $comp.containerSecurityContext | default $root.Values.global.containerSecurityContext -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
+{{- $csc := $comp.containerSecurityContext | default $par.containerSecurityContext | default $root.Values.global.containerSecurityContext -}}
 {{- if $csc }}
 securityContext:
   {{- toYaml $csc | nindent 2 }}
 {{- end }}
 {{- end }}
 
+{{- /*
+Render dnsConfig with component → (optional parent) → global fallback.
+Usage:
+  {{ include "thanos.dnsConfig" (dict "Values" .Values "component" "compactor") }}
+  {{ include "thanos.dnsConfig" (dict "Values" .Values "component" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.dnsConfig" -}}
-{{- $component := (index .Values .component) | default dict -}}
-{{- with ($component.dnsConfig | default .Values.global.dnsConfig) -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = (index .Values .component) | default dict -}}
+{{- end -}}
+{{- with ($component.dnsConfig | default $par.dnsConfig | default .Values.global.dnsConfig) -}}
 dnsConfig:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 
+{{- /*
+Render readiness/liveness/startup probes with component → (optional parent) → global fallback.
+Usage:
+  {{ include "thanos.httpProbes" (dict "root" . "key" "compactor") }}
+  {{ include "thanos.httpProbes" (dict "root" . "key" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.httpProbes" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
-{{- $probes := $comp.probes | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
+{{- $probes := $comp.probes | default $par.probes | default dict -}}
 {{- with $probes.readiness }}
 {{- if .enabled }}
 readinessProbe:
@@ -124,14 +180,32 @@ startupProbe:
 {{- end }}
 {{- end }}
 
+{{- /*
+Render extra volume entries (concatenated) from global, optional parent, then component.
+Usage:
+  {{ include "thanos.extraVolumeItems" (dict "root" . "key" "compactor") }}
+  {{ include "thanos.extraVolumeItems" (dict "root" . "key" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.extraVolumeItems" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
 {{- $glob := $root.Values.global | default dict -}}
 {{- $volsGlob := $glob.extraVolumes | default list -}}
+{{- $volsPar := $par.extraVolumes | default list -}}
 {{- $volsComp := $comp.extraVolumes | default list -}}
 {{- range $volsGlob }}
+- {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- range $volsPar }}
 - {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- range $volsComp }}
@@ -142,24 +216,51 @@ startupProbe:
 {{- define "thanos.extraVolumesBlock" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
 {{- $glob := $root.Values.global | default dict -}}
 {{- $volsGlob := $glob.extraVolumes | default list -}}
+{{- $volsPar := $par.extraVolumes | default list -}}
 {{- $volsComp := $comp.extraVolumes | default list -}}
-{{- if or (gt (len $volsGlob) 0) (gt (len $volsComp) 0) }}
+{{- if or (gt (len $volsGlob) 0) (gt (len $volsPar) 0) (gt (len $volsComp) 0) }}
 volumes:
-  {{- include "thanos.extraVolumeItems" (dict "root" $root "key" $key) | nindent 2 }}
+  {{- include "thanos.extraVolumeItems" (dict "root" $root "key" $key "parent" $parent) | nindent 2 }}
 {{- end }}
 {{- end }}
 
+{{- /*
+Render extra volume-mount entries (concatenated) from global, optional parent, then component.
+Usage:
+  {{ include "thanos.extraMountItems" (dict "root" . "key" "compactor") }}
+  {{ include "thanos.extraMountItems" (dict "root" . "key" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.extraMountItems" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
 {{- $glob := $root.Values.global | default dict -}}
 {{- $mtsGlob := $glob.extraVolumeMounts | default list -}}
+{{- $mtsPar := $par.extraVolumeMounts | default list -}}
 {{- $mtsComp := $comp.extraVolumeMounts | default list -}}
 {{- range $mtsGlob }}
+- {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- range $mtsPar }}
 - {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- range $mtsComp }}
@@ -170,13 +271,22 @@ volumes:
 {{- define "thanos.extraMountsBlock" -}}
 {{- $root := .root -}}
 {{- $key := .key -}}
-{{- $comp := index $root.Values $key | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
 {{- $glob := $root.Values.global | default dict -}}
 {{- $mtsGlob := $glob.extraVolumeMounts | default list -}}
+{{- $mtsPar := $par.extraVolumeMounts | default list -}}
 {{- $mtsComp := $comp.extraVolumeMounts | default list -}}
-{{- if or (gt (len $mtsGlob) 0) (gt (len $mtsComp) 0) }}
+{{- if or (gt (len $mtsGlob) 0) (gt (len $mtsPar) 0) (gt (len $mtsComp) 0) }}
 volumeMounts:
-  {{- include "thanos.extraMountItems" (dict "root" $root "key" $key) | nindent 2 }}
+  {{- include "thanos.extraMountItems" (dict "root" $root "key" $key "parent" $parent) | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -184,40 +294,90 @@ volumeMounts:
 {{- /* Scheduling and placement       */ -}}
 {{- /* ============================== */ -}}
 
+{{- /*
+Scheduling helpers: each renders a single field with
+  component → (optional parent) → global fallback.
+
+Standard usage:
+  {{ include "thanos.affinity" (dict "Values" .Values "component" "compactor") }}
+
+Nested usage (e.g. receive.router falls back to receive then global):
+  {{ include "thanos.affinity" (dict "Values" .Values "component" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.affinity" -}}
-{{- $component := index .Values .component | default dict -}}
-{{- with ($component.affinity | default .Values.global.affinity) -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
+{{- with ($component.affinity | default $par.affinity | default .Values.global.affinity) -}}
 affinity:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "thanos.nodeSelector" -}}
-{{- $component := index .Values .component | default dict -}}
-{{- with ($component.nodeSelector | default .Values.global.nodeSelector) -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
+{{- with ($component.nodeSelector | default $par.nodeSelector | default .Values.global.nodeSelector) -}}
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "thanos.priorityClassName" -}}
-{{- $component := index .Values .component | default dict -}}
-{{- with ($component.priorityClassName | default .Values.global.priorityClassName) -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
+{{- with ($component.priorityClassName | default $par.priorityClassName | default .Values.global.priorityClassName) -}}
 priorityClassName: {{ . }}
 {{- end }}
 {{- end }}
 
 {{- define "thanos.tolerations" -}}
-{{- $component := index .Values .component | default dict -}}
-{{- with ($component.tolerations | default .Values.global.tolerations) -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
+{{- with ($component.tolerations | default $par.tolerations | default .Values.global.tolerations) -}}
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "thanos.topologySpreadConstraints" -}}
-{{- $component := index .Values .component | default dict -}}
-{{- with ($component.topologySpreadConstraints | default .Values.global.topologySpreadConstraints) -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
+{{- with ($component.topologySpreadConstraints | default $par.topologySpreadConstraints | default .Values.global.topologySpreadConstraints) -}}
 topologySpreadConstraints:
   {{- toYaml . | nindent 2 }}
 {{- end }}
@@ -227,10 +387,27 @@ topologySpreadConstraints:
 {{- /* Extra env / envFrom helpers    */ -}}
 {{- /* ============================== */ -}}
 
+{{- /*
+Render merged extraEnv items (global → optional parent → component, by name).
+Usage:
+  {{ include "thanos.extraEnvItems" (dict "Values" .Values "component" "compactor") }}
+  {{ include "thanos.extraEnvItems" (dict "Values" .Values "component" "router" "parent" "receive") }}
+*/ -}}
 {{- define "thanos.extraEnvItems" -}}
-{{- $component := index .Values .component | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
 {{- $merged := dict -}}
 {{- range (.Values.global.extraEnv | default list) }}
+{{- $_ := set $merged .name . }}
+{{- end }}
+{{- range ($par.extraEnv | default list) }}
 {{- $_ := set $merged .name . }}
 {{- end }}
 {{- range ($component.extraEnv | default list) }}
@@ -242,16 +419,27 @@ topologySpreadConstraints:
 {{- end }}
 
 {{- define "thanos.extraEnvBlock" -}}
-{{- if include "thanos.extraEnvItems" $ }}
+{{- if include "thanos.extraEnvItems" . }}
 env:
-  {{- include "thanos.extraEnvItems" $ | nindent 2 }}
+  {{- include "thanos.extraEnvItems" . | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "thanos.extraEnvFromItems" -}}
-{{- $component := index .Values .component | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = index .Values .component | default dict -}}
+{{- end -}}
 {{- $merged := dict -}}
 {{- range (.Values.global.extraEnvFrom | default list) }}
+{{- $_ := set $merged .name . }}
+{{- end }}
+{{- range ($par.extraEnvFrom | default list) }}
 {{- $_ := set $merged .name . }}
 {{- end }}
 {{- range ($component.extraEnvFrom | default list) }}
@@ -263,9 +451,9 @@ env:
 {{- end }}
 
 {{- define "thanos.extraEnvFromBlock" -}}
-{{- if include "thanos.extraEnvFromItems" $ }}
+{{- if include "thanos.extraEnvFromItems" . }}
 envFrom:
-  {{- include "thanos.extraEnvFromItems" $ | nindent 2 }}
+  {{- include "thanos.extraEnvFromItems" . | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -273,14 +461,32 @@ envFrom:
 {{- /* Init / sidecar containers      */ -}}
 {{- /* ============================== */ -}}
 
+{{- /*
+Render initContainers (concatenated) from global, optional parent, then component.
+Usage:
+  {{ include "thanos.initContainers" (dict "Values" .Values "component" "compactor" "root" .) }}
+  {{ include "thanos.initContainers" (dict "Values" .Values "component" "router" "parent" "receive" "root" .) }}
+*/ -}}
 {{- define "thanos.initContainers" -}}
 {{- $root := .root -}}
-{{- $component := (index .Values .component) | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = (index .Values .component) | default dict -}}
+{{- end -}}
 {{- $icGlob := .Values.global.extraInitContainers | default list -}}
+{{- $icPar := $par.extraInitContainers | default list -}}
 {{- $icComp := $component.extraInitContainers | default list -}}
-{{- if or (gt (len $icGlob) 0) (gt (len $icComp) 0) }}
+{{- if or (gt (len $icGlob) 0) (gt (len $icPar) 0) (gt (len $icComp) 0) }}
 initContainers:
   {{- range $icGlob }}
+  - {{ tpl (toYaml .) $root | nindent 4 }}
+  {{- end }}
+  {{- range $icPar }}
   - {{ tpl (toYaml .) $root | nindent 4 }}
   {{- end }}
   {{- range $icComp }}
@@ -289,12 +495,30 @@ initContainers:
 {{- end }}
 {{- end }}
 
+{{- /*
+Render extra sidecar containers (concatenated) from global, optional parent, then component.
+Usage:
+  {{ include "thanos.extraContainers" (dict "Values" .Values "component" "compactor" "root" .) }}
+  {{ include "thanos.extraContainers" (dict "Values" .Values "component" "router" "parent" "receive" "root" .) }}
+*/ -}}
 {{- define "thanos.extraContainers" -}}
 {{- $root := .root -}}
-{{- $component := (index .Values .component) | default dict -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $component := dict -}}
+{{- if $parent -}}
+{{- $par = index .Values $parent | default dict -}}
+{{- $component = index $par .component | default dict -}}
+{{- else -}}
+{{- $component = (index .Values .component) | default dict -}}
+{{- end -}}
 {{- $cGlob := .Values.global.extraContainers | default list -}}
+{{- $cPar := $par.extraContainers | default list -}}
 {{- $cComp := $component.extraContainers | default list -}}
 {{- range $cGlob }}
+- {{ tpl (toYaml .) $root | nindent 2 }}
+{{- end }}
+{{- range $cPar }}
 - {{ tpl (toYaml .) $root | nindent 2 }}
 {{- end }}
 {{- range $cComp }}
@@ -303,10 +527,66 @@ initContainers:
 {{- end }}
 
 {{- /* ============================== */ -}}
+{{- /* Receive split-mode helpers     */ -}}
+{{- /* ============================== */ -}}
+
+{{- /*
+Returns the resolved receive mode. Defaults to "standalone".
+Accepted values: "standalone", "split".
+*/ -}}
+{{- define "thanos.receive.mode" -}}
+{{- default "standalone" .Values.receive.mode -}}
+{{- end -}}
+
+{{- define "thanos.receive.isSplit" -}}
+{{- if eq (include "thanos.receive.mode" .) "split" -}}true{{- end -}}
+{{- end -}}
+
+{{- /*
+Returns the resolved Ingester values block as YAML.
+  - standalone mode → returns the top-level `receive.*` block
+  - split mode      → returns the `receive.ingester.*` block
+Use with `fromYaml` to get a dict:
+  {{ $cfg := include "thanos.receive.cfg" . | fromYaml }}
+*/ -}}
+{{- define "thanos.receive.cfg" -}}
+{{- if eq (include "thanos.receive.mode" .) "split" -}}
+{{- toYaml (.Values.receive.ingester | default dict) -}}
+{{- else -}}
+{{- toYaml .Values.receive -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+Resolved name for the Receive (StatefulSet) workload and its associated
+resources. In standalone mode this is `<fullname>-receive` (unchanged).
+In split mode the name is suffixed with `-ingester` so the StatefulSet,
+service, ServiceMonitor, etc. become `<fullname>-receive-ingester`.
+The Ingester reads its values from `receive.ingester.*` in split mode,
+or from the top-level `receive.*` fields in standalone mode (see
+`thanos.receive.cfg`).
+*/ -}}
+{{- define "thanos.receive.workloadName" -}}
+{{- if eq (include "thanos.receive.mode" .) "split" -}}
+{{- include "thanos.compName" (list . "receive-ingester") -}}
+{{- else -}}
+{{- include "thanos.compName" (list . "receive") -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Router resource name: <fullname>-receive-router. Only used in split mode. */ -}}
+{{- define "thanos.receive.routerName" -}}
+{{- include "thanos.compName" (list . "receive-router") -}}
+{{- end -}}
+
+{{- /* ============================== */ -}}
 {{- /* Receive headless service name  */ -}}
+{{- /* Returns                        */ -}}
+{{- /*  - <fullname>-receive-headless         (standalone)                */ -}}
+{{- /*  - <fullname>-receive-ingester-headless (split)                    */ -}}
 {{- /* ============================== */ -}}
 {{- define "thanos.receiveHeadless" -}}
-{{- printf "%s-%s" (include "thanos.fullname" .) "receive-headless" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "thanos.receive.workloadName" .) "headless" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- /* ============================== */ -}}
@@ -317,8 +597,14 @@ initContainers:
 {{- include "thanos.compName" (list . "receive-hashrings") -}}
 {{- end -}}
 
+{{- /*
+Render the hashrings JSON. Endpoints reference the Receive workload pods
+via its headless service. The workload name is resolved by
+`thanos.receive.workloadName` (`-ingester` suffix in split mode), so the
+same helper produces a valid hashring for both standalone and split modes.
+*/ -}}
 {{- define "thanos.receive.hashrings" -}}
-{{- $vals := .Values.receive | default dict -}}
+{{- $vals := include "thanos.receive.cfg" . | fromYaml -}}
 {{- $grpcPort := int (dig "service" "grpcPort" 10901 $vals) -}}
 {{- $rc := int (default 1 $vals.replicaCount) -}}
 {{- $ns := .Release.Namespace -}}
@@ -328,7 +614,7 @@ initContainers:
 {{ $vals.hashrings.static | toPrettyJson }}
 
 {{- else if and (hasKey $vals "hashrings") (hasKey $vals.hashrings "autogen") ($vals.hashrings.autogen.enabled | default false) -}}
-  {{- $name := include "thanos.compName" (list . "receive") -}}
+  {{- $name := include "thanos.receive.workloadName" . -}}
   {{- $svcName := include "thanos.receiveHeadless" . -}}
   {{- $eps := list -}}
   {{- range $i, $_ := until $rc -}}
@@ -339,7 +625,7 @@ initContainers:
 {{ $rings | toPrettyJson }}
 
 {{- else -}}
-  {{- $name := include "thanos.compName" (list . "receive") -}}
+  {{- $name := include "thanos.receive.workloadName" . -}}
   {{- $svcName := include "thanos.receiveHeadless" . -}}
   {{- $eps := list (printf "%s-0.%s.%s.svc.%s:%d" $name $svcName $ns $domain $grpcPort) -}}
   {{- $rings := list (dict "endpoints" $eps) -}}

--- a/charts/thanos/templates/receive/configmap-hashrings.yaml
+++ b/charts/thanos/templates/receive/configmap-hashrings.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "thanos.compName" (list . "receive-hashrings") }}
+  name: {{ include "thanos.receive.hashringsConfigMapName" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    {{- include "thanos.annotations" (dict "Values" .Values "component" "receive-hashrings") | nindent 4 }}
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 4 }}
 data:
   hashrings.json: |
     {{- include "thanos.receive.hashrings" . | nindent 4 }}

--- a/charts/thanos/templates/receive/grpcroute.yaml
+++ b/charts/thanos/templates/receive/grpcroute.yaml
@@ -1,3 +1,6 @@
-{{- if and .Values.receive.enabled .Values.receive.grpcRoute.enabled }}
-{{ include "thanos.grpcRoute" (list . "receive" .Values.receive.service.grpcPort .Values.receive.grpcRoute) }}
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.mode" .) "standalone") }}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- if $cfg.grpcRoute.enabled }}
+{{ include "thanos.grpcRoute" (list . "receive" $cfg.service.grpcPort $cfg.grpcRoute) }}
+{{- end }}
 {{- end }}

--- a/charts/thanos/templates/receive/httproute.yaml
+++ b/charts/thanos/templates/receive/httproute.yaml
@@ -1,3 +1,6 @@
-{{- if and .Values.receive.enabled .Values.receive.httpRoute.enabled }}
-{{ include "thanos.httpRoute" (list . "receive" .Values.receive.service.httpPort .Values.receive.httpRoute) }}
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.mode" .) "standalone") }}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- if $cfg.httpRoute.enabled }}
+{{ include "thanos.httpRoute" (list . "receive" $cfg.service.httpPort $cfg.httpRoute) }}
+{{- end }}
 {{- end }}

--- a/charts/thanos/templates/receive/ingress.yaml
+++ b/charts/thanos/templates/receive/ingress.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.receive.enabled }}
-{{- $http := .Values.receive.ingress.http.enabled | ternary .Values.receive.ingress.http .Values.receive.ingress }}
-{{- $ingresses := dict "http" $http "grpc" .Values.receive.ingress.grpc }}
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.mode" .) "standalone") }}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- $http := $cfg.ingress.http.enabled | ternary $cfg.ingress.http $cfg.ingress }}
+{{- $ingresses := dict "http" $http "grpc" $cfg.ingress.grpc }}
 {{- $sep := "" }}
 {{- range $port, $ingress := $ingresses }}
 {{- if $ingress.enabled }}

--- a/charts/thanos/templates/receive/pdb.yaml
+++ b/charts/thanos/templates/receive/pdb.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.receive.enabled (or .Values.receive.pdb.enabled .Values.global.pdb.enabled) }}
-{{- $minAvail := .Values.receive.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
-{{- $maxUnavail := .Values.receive.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- if and .Values.receive.enabled (or $cfg.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $pdb := $cfg.pdb -}}
+{{- $minAvail := $pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := $pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "thanos.compName" (list . "receive") }}
+  name: {{ include "thanos.receive.workloadName" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -1,27 +1,28 @@
 {{- if .Values.receive.enabled }}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "thanos.compName" (list . "receive") }}
+  name: {{ include "thanos.receive.workloadName" . }}
   labels:
     app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}
-    {{- with .Values.receive.service.labels }}
+    {{- with $cfg.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
-    {{- with .Values.receive.service.annotations }}
+    {{- with $cfg.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ .Values.receive.service.type }}
+  type: {{ $cfg.service.type }}
   ports:
     - name: http
-      port: {{ .Values.receive.service.httpPort }}
+      port: {{ $cfg.service.httpPort }}
       targetPort: http
     - name: remote-write
-      port: {{ .Values.receive.service.remoteWritePort }}
+      port: {{ $cfg.service.remoteWritePort }}
       targetPort: remote-write
   selector:
     app.kubernetes.io/component: receive
@@ -30,16 +31,16 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "thanos.compName" (list . "receive") }}-headless
+  name: {{ include "thanos.receiveHeadless" . }}
   labels:
     app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}
-    {{- with .Values.receive.service.labels }}
+    {{- with $cfg.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
-    {{- with .Values.receive.service.annotations }}
+    {{- with $cfg.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -47,7 +48,7 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: {{ .Values.receive.service.grpcPort }}
+      port: {{ $cfg.service.grpcPort }}
       targetPort: grpc
   selector:
     app.kubernetes.io/component: receive

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -1,0 +1,104 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") }}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- $rt := .Values.receive.router -}}
+{{- $httpPort := default 10902 $rt.service.httpPort -}}
+{{- $rwPort := default 10908 $rt.service.remoteWritePort -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thanos.receive.routerName" . }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-router
+    {{- with $rt.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
+    {{- with $rt.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $rt.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: receive-router
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "thanos.labels" . | nindent 8 }}
+        app.kubernetes.io/component: receive-router
+        {{- with $rt.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- $anns := dict -}}
+        {{- if .Values.global.podAnnotations }}
+        {{- $anns = merge $anns .Values.global.podAnnotations -}}
+        {{- end }}
+        {{- $_ := set $anns "checksum/hashrings" (include "thanos.receive.hashrings" . | sha256sum) -}}
+        {{- toYaml $anns | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "router" "parent" "receive") | nindent 6 }}
+      containers:
+        - name: receive-router
+          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args:
+            - receive
+            - --http-address=0.0.0.0:{{ $httpPort }}
+            - --remote-write.address=0.0.0.0:{{ $rwPort }}
+            - --receive.hashrings-file=/etc/thanos/hashrings.json
+            - --receive.hashrings-algorithm=ketama
+            - --receive.replication-factor={{ $rt.replicationFactor | default 1 }}
+            {{- if $cfg.tenancyHeader }}
+            - --receive.tenant-header={{ $cfg.tenancyHeader }}
+            {{- end }}
+            {{- range $rt.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $httpPort }}
+            - name: remote-write
+              containerPort: {{ $rwPort }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- include "thanos.extraEnvItems" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 12 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 10 }}
+          volumeMounts:
+            - name: thanos-config
+              mountPath: /etc/thanos
+              readOnly: true
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "router" "parent" "receive") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "router" "parent" "receive") | nindent 10 }}
+          resources:
+            {{- toYaml ($rt.resources | default dict) | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "router" "parent" "receive") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "router" "parent" "receive" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "router" "parent" "receive" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
+      volumes:
+        - name: thanos-config
+          configMap:
+            name: {{ include "thanos.receive.hashringsConfigMapName" . }}
+            items:
+              - key: hashrings.json
+                path: hashrings.json
+        {{- include "thanos.extraVolumeItems" (dict "root" . "key" "router" "parent" "receive") | nindent 8 }}
+{{- end }}

--- a/charts/thanos/templates/receive/split/router-httproute.yaml
+++ b/charts/thanos/templates/receive/split/router-httproute.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") .Values.receive.router.httpRoute.enabled }}
+{{- $rt := .Values.receive.router -}}
+{{- $port := $rt.service.httpPort | default 10902 -}}
+{{- $cfg := $rt.httpRoute -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-router
+  {{- with $cfg.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $cfg.parentRefs | nindent 4 }}
+  {{- with $cfg.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "thanos.receive.routerName" . }}
+          port: {{ $port }}
+{{- end }}

--- a/charts/thanos/templates/receive/split/router-ingress.yaml
+++ b/charts/thanos/templates/receive/split/router-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") .Values.receive.router.ingress.http.enabled }}
+{{- $ingress := .Values.receive.router.ingress.http -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    {{- toYaml $ingress.annotations | nindent 4 }}
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-router
+  name: {{ include "thanos.receive.routerName" . }}
+spec:
+  {{- with $ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range $ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - backend:
+              service:
+                name: {{ include "thanos.receive.routerName" $ }}
+                port:
+                  name: http
+            path: {{ .path | quote }}
+            pathType: {{ .pathType | default "Prefix" }}
+        {{- end }}
+    {{- end }}
+  {{- with $ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/thanos/templates/receive/split/router-networkpolicy.yaml
+++ b/charts/thanos/templates/receive/split/router-networkpolicy.yaml
@@ -1,22 +1,21 @@
-{{- if and .Values.receive.enabled .Values.global.networkPolicies }}
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") .Values.global.networkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
-    app.kubernetes.io/component: receive
-  name: {{ include "thanos.receive.workloadName" . }}
+    app.kubernetes.io/component: receive-router
+  name: {{ include "thanos.receive.routerName" . }}
 spec:
   egress:
     - {}
   ingress:
     - ports:
-        - port: grpc
         - port: http
         - port: remote-write
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: receive
+      app.kubernetes.io/component: receive-router
       app.kubernetes.io/instance: {{ .Release.Name }}
   policyTypes:
     - Egress

--- a/charts/thanos/templates/receive/split/router-pdb.yaml
+++ b/charts/thanos/templates/receive/split/router-pdb.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") (or .Values.receive.router.pdb.enabled .Values.global.pdb.enabled) }}
+{{- $minAvail := .Values.receive.router.pdb.minAvailable | default .Values.global.pdb.minAvailable -}}
+{{- $maxUnavail := .Values.receive.router.pdb.maxUnavailable | default .Values.global.pdb.maxUnavailable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "thanos.receive.routerName" . }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-router
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: receive-router
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if $minAvail }}
+  minAvailable: {{ $minAvail }}
+  {{- else if $maxUnavail }}
+  maxUnavailable: {{ $maxUnavail }}
+  {{- end }}
+{{- end }}

--- a/charts/thanos/templates/receive/split/router-service.yaml
+++ b/charts/thanos/templates/receive/split/router-service.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") }}
+{{- $rt := .Values.receive.router -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thanos.receive.routerName" . }}
+  labels:
+    app.kubernetes.io/component: receive-router
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- with $rt.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
+    {{- with $rt.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ $rt.service.type | default "ClusterIP" }}
+  ports:
+    - name: http
+      port: {{ $rt.service.httpPort | default 10902 }}
+      targetPort: http
+    - name: remote-write
+      port: {{ $rt.service.remoteWritePort | default 10908 }}
+      targetPort: remote-write
+  selector:
+    app.kubernetes.io/component: receive-router
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/thanos/templates/receive/split/router-servicemonitor.yaml
+++ b/charts/thanos/templates/receive/split/router-servicemonitor.yaml
@@ -1,15 +1,14 @@
-{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
-{{- if and .Values.receive.enabled (or $cfg.serviceMonitor.enabled .Values.global.serviceMonitor.enabled) }}
-{{- $sm := $cfg.serviceMonitor -}}
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") (or .Values.receive.router.serviceMonitor.enabled .Values.global.serviceMonitor.enabled) }}
+{{- $sm := .Values.receive.router.serviceMonitor -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "thanos.receive.workloadName" . }}
+  name: {{ include "thanos.receive.routerName" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if $sm.labels }}{{ toYaml $sm.labels | nindent 4 }}{{- end }}
   annotations:
-    {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
 spec:
   namespaceSelector:
     matchNames:
@@ -18,7 +17,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: thanos
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: receive
+      app.kubernetes.io/component: receive-router
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/receive/split/router-vpa.yaml
+++ b/charts/thanos/templates/receive/split/router-vpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") .Values.receive.router.vpa.enabled (semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion) (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- $vpa := .Values.receive.router.vpa -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "thanos.receive.routerName" . }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-router
+  annotations:
+    {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: {{ $vpa.targetKind | default "Deployment" }}
+    name: {{ include "thanos.receive.routerName" . }}
+  updatePolicy:
+    updateMode: {{ $vpa.updateMode | default "Auto" }}
+  resourcePolicy:
+    containerPolicies:
+      - containerName: thanos
+        mode: Auto
+        controlledResources:
+          - cpu
+          - memory
+        minAllowed:
+          cpu: {{ $vpa.minAllowed.cpu | default "100m" }}
+          memory: {{ $vpa.minAllowed.memory | default "256Mi" }}
+        maxAllowed:
+          cpu: {{ $vpa.maxAllowed.cpu | default "2" }}
+          memory: {{ $vpa.maxAllowed.memory | default "4Gi" }}
+{{- else }}
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") .Values.receive.router.vpa.enabled }}
+{{- printf "# WARNING: VerticalPodAutoscaler CRD not detected on this cluster. Skipping VPA creation for receive-router." }}
+{{- end }}
+{{- end }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -1,21 +1,23 @@
 {{- if .Values.receive.enabled }}
+{{- $isSplit := eq (include "thanos.receive.isSplit" .) "true" -}}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "thanos.compName" (list . "receive") }}
+  name: {{ include "thanos.receive.workloadName" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
-    {{- with .Values.receive.labels }}
+    {{- with $cfg.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
-    {{- with .Values.receive.annotations }}
+    {{- with $cfg.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   serviceName: {{ include "thanos.receiveHeadless" . }}
-  replicas: {{ .Values.receive.replicaCount }}
+  replicas: {{ $cfg.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/component: receive
@@ -30,48 +32,52 @@ spec:
         {{- if .Values.global.podAnnotations }}
         {{- $anns = merge $anns .Values.global.podAnnotations -}}
         {{- end }}
+        {{- if not $isSplit }}
         {{- $_ := set $anns "checksum/hashrings" (include "thanos.receive.hashrings" . | sha256sum) -}}
+        {{- end }}
         {{- $_ := set $anns "checksum/objstore-configuration" (.Values.global.objstore.config | sha256sum) -}}
         {{- toYaml $anns | nindent 8 }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
-      {{- include "thanos.affinity" (dict "Values" .Values "component" "receive") | nindent 6 }}
+      {{- include "thanos.affinity" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      {{- include "thanos.podSC" (dict "root" . "key" "receive") | nindent 6 }}
+      {{- include "thanos.podSC" (dict "root" . "key" "ingester" "parent" "receive") | nindent 6 }}
       containers:
         - name: receive
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           args:
             - receive
-            - --http-address=0.0.0.0:{{ default 10902 .Values.receive.service.httpPort }}
-            - --grpc-address=0.0.0.0:{{ .Values.receive.service.grpcPort }}
-            - --remote-write.address=0.0.0.0:{{ .Values.receive.service.remoteWritePort }}
+            - --http-address=0.0.0.0:{{ default 10902 $cfg.service.httpPort }}
+            - --grpc-address=0.0.0.0:{{ $cfg.service.grpcPort }}
+            - --remote-write.address=0.0.0.0:{{ $cfg.service.remoteWritePort }}
             - --objstore.config-file=/etc/thanos/objstore.yml
             - --tsdb.path=/var/thanos/receive
             - --label=receive_replica="$(POD_NAME)"
+            {{- if not $isSplit }}
             - --receive.hashrings-file=/etc/thanos/hashrings.json
             - --receive.hashrings-algorithm=ketama
-            - --receive.local-endpoint=$(NAME).{{ include "thanos.compName" (list . "receive") }}-headless.$(NAMESPACE).svc.{{ .Values.global.clusterDomain }}:{{ .Values.receive.service.grpcPort }}
-            {{- if .Values.receive.tenancyHeader }}
-            - --receive.tenant-header={{ .Values.receive.tenancyHeader }}
+            - --receive.local-endpoint=$(NAME).{{ include "thanos.receiveHeadless" . }}.$(NAMESPACE).svc.{{ .Values.global.clusterDomain }}:{{ $cfg.service.grpcPort }}
             {{- end }}
-            {{- if .Values.receive.tsdb.retention }}
-            - --tsdb.retention={{ .Values.receive.tsdb.retention }}
+            {{- if $cfg.tenancyHeader }}
+            - --receive.tenant-header={{ $cfg.tenancyHeader }}
             {{- end }}
-            {{- if .Values.receive.tsdb.walCompression }}
+            {{- if $cfg.tsdb.retention }}
+            - --tsdb.retention={{ $cfg.tsdb.retention }}
+            {{- end }}
+            {{- if $cfg.tsdb.walCompression }}
             - --tsdb.wal-compression
             {{- end }}
-            {{- range .Values.receive.extraArgs }}
+            {{- range $cfg.extraArgs }}
             - {{ . | quote }}
             {{- end }}
           ports:
             - name: grpc
-              containerPort: {{ .Values.receive.service.grpcPort }}
+              containerPort: {{ $cfg.service.grpcPort }}
             - name: http
-              containerPort: {{ default 10902 .Values.receive.service.httpPort }}
+              containerPort: {{ default 10902 $cfg.service.httpPort }}
             - name: remote-write
-              containerPort: {{ .Values.receive.service.remoteWritePort }}
+              containerPort: {{ $cfg.service.remoteWritePort }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -85,26 +91,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- include "thanos.extraEnvItems" (dict "Values" .Values "component" "receive") | nindent 12 }}
-          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "receive") | nindent 10 }}
+            {{- include "thanos.extraEnvItems" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 12 }}
+          {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 10 }}
           volumeMounts:
             - name: data
               mountPath: /var/thanos/receive
             - name: thanos-config
               mountPath: /etc/thanos
               readOnly: true
-            {{- include "thanos.extraMountItems" (dict "root" . "key" "receive") | nindent 12 }}
-          {{- include "thanos.containerSC" (dict "root" . "key" "receive") | nindent 10 }}
+            {{- include "thanos.extraMountItems" (dict "root" . "key" "ingester" "parent" "receive") | nindent 12 }}
+          {{- include "thanos.containerSC" (dict "root" . "key" "ingester" "parent" "receive") | nindent 10 }}
           resources:
-            {{- toYaml (.Values.receive.resources | default dict) | nindent 12 }}
-          {{- include "thanos.httpProbes" (dict "root" . "key" "receive") | nindent 10 }}
-        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 8 }}
-      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "receive") | nindent 6 }}
-      {{- include "thanos.initContainers" (dict "Values" .Values "component" "receive" "root" .) | nindent 6 }}
-      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "receive") | nindent 6 }}
-      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "receive") | nindent 6 }}
-      {{- include "thanos.tolerations" (dict "Values" .Values "component" "receive") | nindent 6 }}
-      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "receive") | nindent 6 }}
+            {{- toYaml ($cfg.resources | default dict) | nindent 12 }}
+          {{- include "thanos.httpProbes" (dict "root" . "key" "ingester" "parent" "receive") | nindent 10 }}
+        {{- include "thanos.extraContainers" (dict "Values" .Values "component" "ingester" "parent" "receive" "root" .) | nindent 8 }}
+      {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.initContainers" (dict "Values" .Values "component" "ingester" "parent" "receive" "root" .) | nindent 6 }}
+      {{- include "thanos.nodeSelector" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.priorityClassName" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.tolerations" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
+      {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
       volumes:
         - name: thanos-config
           projected:
@@ -114,27 +120,29 @@ spec:
                   items:
                     - key: {{ .Values.global.objstore.secretKey }}
                       path: objstore.yml
+              {{- if not $isSplit }}
               - configMap:
                   name: {{ include "thanos.receive.hashringsConfigMapName" . }}
                   items:
                     - key: hashrings.json
                       path: hashrings.json
-        {{- if not .Values.receive.persistence.enabled }}
+              {{- end }}
+        {{- if not $cfg.persistence.enabled }}
         - name: data
           emptyDir: {}
         {{- end }}
-        {{- include "thanos.extraVolumeItems" (dict "root" . "key" "receive") | nindent 8 }}
-  {{- if .Values.receive.persistence.enabled }}
+        {{- include "thanos.extraVolumeItems" (dict "root" . "key" "ingester" "parent" "receive") | nindent 8 }}
+  {{- if $cfg.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
-        {{- if .Values.receive.persistence.storageClass }}
-        storageClassName: {{ .Values.receive.persistence.storageClass }}
+        {{- if $cfg.persistence.storageClass }}
+        storageClassName: {{ $cfg.persistence.storageClass }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.receive.persistence.size }}
+            storage: {{ $cfg.persistence.size }}
   {{- end }}
 {{- end }}

--- a/charts/thanos/templates/receive/vpa.yaml
+++ b/charts/thanos/templates/receive/vpa.yaml
@@ -1,8 +1,10 @@
-{{- if and .Values.receive.enabled .Values.receive.vpa.enabled (semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion) (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- if and .Values.receive.enabled $cfg.vpa.enabled (semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion) (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- $vpa := $cfg.vpa -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ include "thanos.compName" (list . "receive") }}
+  name: {{ include "thanos.receive.workloadName" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
@@ -10,10 +12,10 @@ metadata:
 spec:
   targetRef:
     apiVersion: apps/v1
-    kind: {{ .Values.receive.vpa.targetKind | default "StatefulSet" }}
-    name: {{ include "thanos.compName" (list . "receive") }}
+    kind: {{ $vpa.targetKind | default "StatefulSet" }}
+    name: {{ include "thanos.receive.workloadName" . }}
   updatePolicy:
-    updateMode: {{ .Values.receive.vpa.updateMode | default "Auto" }}
+    updateMode: {{ $vpa.updateMode | default "Auto" }}
   resourcePolicy:
     containerPolicies:
       - containerName: thanos
@@ -22,13 +24,13 @@ spec:
           - cpu
           - memory
         minAllowed:
-          cpu: {{ .Values.receive.vpa.minAllowed.cpu | default "500m" }}
-          memory: {{ .Values.receive.vpa.minAllowed.memory | default "512Mi" }}
+          cpu: {{ $vpa.minAllowed.cpu | default "500m" }}
+          memory: {{ $vpa.minAllowed.memory | default "512Mi" }}
         maxAllowed:
-          cpu: {{ .Values.receive.vpa.maxAllowed.cpu | default "4" }}
-          memory: {{ .Values.receive.vpa.maxAllowed.memory | default "8Gi" }}
+          cpu: {{ $vpa.maxAllowed.cpu | default "4" }}
+          memory: {{ $vpa.maxAllowed.memory | default "8Gi" }}
 {{- else }}
-{{- if and .Values.receive.enabled .Values.receive.vpa.enabled }}
+{{- if and .Values.receive.enabled $cfg.vpa.enabled }}
 {{- printf "# WARNING: VerticalPodAutoscaler CRD not detected on this cluster. Skipping VPA creation for receive." }}
 {{- end }}
 {{- end }}

--- a/charts/thanos/tests/_split_defaults.yaml
+++ b/charts/thanos/tests/_split_defaults.yaml
@@ -1,0 +1,128 @@
+# Shared split-mode defaults for receive tests.
+# In split mode the schema requires `receive.ingester` to be fully populated
+# (top-level `receive.*` fields are ignored). Tests `values:`-merge this file
+# to satisfy the schema with minimal noise.
+receive:
+  enabled: true
+  mode: split
+  ingester:
+    replicaCount: 3
+    tenancyHeader: ""
+    tsdb:
+      retention: 24h
+      walCompression: true
+    hashrings:
+      autogen:
+        enabled: true
+        name: default
+      static: []
+    service:
+      type: ClusterIP
+      grpcPort: 10901
+      httpPort: 10902
+      remoteWritePort: 10908
+      annotations: {}
+      labels: {}
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+      http:
+        enabled: false
+        className: ""
+        annotations: {}
+        hosts: []
+        tls: []
+      grpc:
+        enabled: false
+        className: ""
+        annotations: {}
+        hosts: []
+        tls: []
+    httpRoute:
+      enabled: false
+      annotations: {}
+      parentRefs: []
+      hostnames: []
+    grpcRoute:
+      enabled: false
+      annotations: {}
+      parentRefs: []
+      hostnames: []
+    vpa:
+      enabled: false
+      targetKind: StatefulSet
+      updateMode: Auto
+      minAllowed:
+        cpu: 500m
+        memory: 512Mi
+      maxAllowed:
+        cpu: "4"
+        memory: 8Gi
+    persistence:
+      enabled: true
+      size: 10Gi
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+    resources: {}
+    extraArgs: []
+    podSecurityContext:
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    containerSecurityContext: {}
+    dnsConfig: {}
+    extraEnv: []
+    extraEnvFrom: []
+    extraInitContainers: []
+    extraContainers: []
+    probes:
+      readiness:
+        enabled: true
+        path: /-/ready
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 6
+        successThreshold: 1
+      liveness:
+        enabled: true
+        path: /-/healthy
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 6
+        successThreshold: 1
+      startup:
+        enabled: true
+        path: /-/ready
+        initialDelaySeconds: 0
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
+        successThreshold: 1
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    topologySpreadConstraints: []
+    priorityClassName: ""
+    extraVolumes: []
+    extraVolumeMounts: []
+    annotations: {}
+    labels: {}
+    serviceMonitor:
+      enabled: false
+      labels: {}
+      annotations: {}
+      interval: ""
+      scrapeTimeout: ""
+      scheme: ""
+      tlsConfig: {}
+      relabelings: []
+      metricRelabelings: []
+    pdb:
+      enabled: false
+      minAvailable: ""
+      maxUnavailable: ""

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -1050,3 +1050,289 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-thanos-receive
+
+  # -- Split mode -----------------------------------------------------------
+
+  - it: rejects an invalid receive.mode value
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.mode: bogus
+    asserts:
+      - failedTemplate:
+          errorPattern: "standalone.*split"
+
+  - it: defaults to standalone mode and uses the receive name
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-thanos-receive-headless
+
+  - it: suffixes the StatefulSet with -ingester in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-ingester
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-thanos-receive-ingester-headless
+
+  - it: omits router-only flags from the StatefulSet args in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.hashrings-file=/etc/thanos/hashrings.json
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.hashrings-algorithm=ketama
+
+  - it: keeps router flags on the StatefulSet args in standalone mode
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.hashrings-file=/etc/thanos/hashrings.json
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.hashrings-algorithm=ketama
+
+  - it: omits the hashrings configmap volume mount from ingester in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes[0].projected.sources
+          content:
+            configMap:
+              name: RELEASE-NAME-thanos-receive-hashrings
+              items:
+                - key: hashrings.json
+                  path: hashrings.json
+
+  - it: suffixes the headless service with -ingester in split mode
+    template: receive/service.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-ingester
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-ingester-headless
+        documentIndex: 1
+
+  - it: hashrings configmap points to ingester pods in split mode
+    template: receive/configmap-hashrings.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.replicaCount: 2
+    asserts:
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: "RELEASE-NAME-thanos-receive-ingester-0\\.RELEASE-NAME-thanos-receive-ingester-headless"
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: "RELEASE-NAME-thanos-receive-ingester-1\\.RELEASE-NAME-thanos-receive-ingester-headless"
+
+  - it: hashrings configmap points to receive pods in standalone mode
+    template: receive/configmap-hashrings.yaml
+    set:
+      receive.enabled: true
+      receive.replicaCount: 2
+    asserts:
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: "RELEASE-NAME-thanos-receive-0\\.RELEASE-NAME-thanos-receive-headless"
+
+  - it: does not render the standalone ingress in split mode
+    template: receive/ingress.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.ingress.http.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render the standalone httpRoute in split mode
+    template: receive/httproute.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.httpRoute.enabled: true
+      receive.ingester.httpRoute.parentRefs:
+        - name: gateway
+      receive.ingester.httpRoute.hostnames:
+        - thanos.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # -- Split mode: router ---------------------------------------------------
+
+  - it: does not render the router deployment in standalone mode
+    template: receive/split/router-deployment.yaml
+    set:
+      receive.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the router deployment in split mode
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.hashrings-file=/etc/thanos/hashrings.json
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-factor=1
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --tsdb.path=/var/thanos/receive
+
+  - it: applies the configured replication factor on the router
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.replicaCount: 4
+      receive.router.replicationFactor: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 4
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-factor=3
+
+  - it: forwards tenancyHeader to the router when set
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.tenancyHeader: THANOS-TENANT
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.tenant-header=THANOS-TENANT
+
+  - it: renders the router service in split mode
+    template: receive/split/router-service.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: receive-router
+
+  - it: does not render the router service in standalone mode
+    template: receive/split/router-service.yaml
+    set:
+      receive.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the router servicemonitor when enabled in split mode
+    template: receive/split/router-servicemonitor.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.serviceMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+
+  - it: renders the router pdb when enabled in split mode
+    template: receive/split/router-pdb.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.pdb.enabled: true
+      receive.router.pdb.minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: renders the router networkpolicy in split mode when networkPolicies are enabled
+    template: receive/split/router-networkpolicy.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+
+  - it: renders the router ingress when enabled in split mode
+    template: receive/split/router-ingress.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.ingress.http.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+
+  - it: renders the router httpRoute when enabled in split mode
+    template: receive/split/router-httproute.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.httpRoute.enabled: true
+      receive.router.httpRoute.parentRefs:
+        - name: gateway
+      receive.router.httpRoute.hostnames:
+        - thanos-receive.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -4505,6 +4505,14 @@
           "title": "httpRoute",
           "type": "object"
         },
+        "ingester": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Ingester StatefulSet config. Required (and must mirror the top-level `receive.*` shape) when `receive.mode` is `split`; ignored in `standalone` mode.",
+          "required": [],
+          "title": "ingester",
+          "type": "object"
+        },
         "ingress": {
           "additionalProperties": true,
           "description": "Kubernetes Ingress configuration for the Receive endpoint.",
@@ -4817,6 +4825,24 @@
             "grpc"
           ],
           "title": "ingress",
+          "type": "object"
+        },
+        "mode": {
+          "default": "standalone",
+          "description": "Receive deployment topology. One of `standalone` (single workload that both routes and ingests) or `split` (separate Router Deployment and Ingester StatefulSet).",
+          "enum": [
+            "standalone",
+            "split"
+          ],
+          "required": [],
+          "title": "mode",
+          "type": "string"
+        },
+        "router": {
+          "additionalProperties": true,
+          "description": "Receive Router (used only when receive.mode is `split`). Stateless Deployment that fronts the Ingester StatefulSet.",
+          "required": [],
+          "title": "router",
           "type": "object"
         },
         "labels": {
@@ -5480,6 +5506,7 @@
       },
       "required": [
         "enabled",
+        "mode",
         "replicaCount",
         "tenancyHeader",
         "tsdb",
@@ -5510,7 +5537,43 @@
         "annotations",
         "labels",
         "serviceMonitor",
-        "pdb"
+        "pdb",
+        "router"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "split"
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
+          "then": {
+            "properties": {
+              "ingester": {
+                "required": [
+                  "replicaCount",
+                  "tsdb",
+                  "hashrings",
+                  "service",
+                  "vpa",
+                  "persistence",
+                  "podSecurityContext",
+                  "probes",
+                  "serviceMonitor",
+                  "pdb"
+                ]
+              }
+            },
+            "required": [
+              "ingester"
+            ]
+          }
+        }
       ],
       "title": "receive",
       "type": "object"

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1743,8 +1743,28 @@ receive:
   # -- Enable the Receive StatefulSet.
   enabled: true
 
+  # @schema
+  # enum:
+  #   - standalone
+  #   - split
+  # @schema
+  # -- Receive deployment topology. One of:
+  # `standalone` — single workload that both routes and ingests (RouterIngestor mode);
+  # `split` — separate Router (Deployment) and Ingester (StatefulSet) workloads,
+  # following the receive split proposal (https://thanos.io/tip/proposals-accepted/202012-receive-split.md).
+  #
+  # Field shape depends on mode:
+  #   - `standalone`: configure the workload directly via top-level `receive.*`
+  #     fields (replicaCount, tsdb, service, persistence, etc.). `receive.ingester`
+  #     and `receive.router` are ignored.
+  #   - `split`: configure each workload via `receive.ingester.*` and
+  #     `receive.router.*`. Top-level `receive.*` fields are ignored. The schema
+  #     requires both `ingester` and `router` to be populated in this mode.
+  mode: standalone
+
   # -- Number of Receive pod replicas. Minimum 3 is recommended for
   # replication factor 2 (write quorum = floor(replicaCount/2)+1).
+  # In `split` mode this controls the Ingester StatefulSet replica count.
   replicaCount: 3
 
   # -- Optional HTTP header name used to segregate tenants in multi-tenant setups.
@@ -2072,6 +2092,285 @@ receive:
     minAvailable: ""
     # -- (int or string) Maximum unavailable Receive pods during a disruption.
     maxUnavailable: ""
+
+  # ======================================================================
+  # Receive Ingester (only used when `receive.mode` is `split`).
+  # Stateful workload that stores samples in the local TSDB WAL and ships
+  # blocks to the object store. In `split` mode this block REPLACES the
+  # top-level `receive.*` fields above for the Ingester StatefulSet; the
+  # schema requires it to be populated when mode=split.
+  #
+  # The accepted shape mirrors the top-level `receive.*` fields
+  # (replicaCount, tsdb, hashrings, service, ingress, httpRoute, grpcRoute,
+  # vpa, persistence, resources, extraArgs, podSecurityContext,
+  # containerSecurityContext, dnsConfig, extraEnv, extraEnvFrom,
+  # extraInitContainers, extraContainers, probes, nodeSelector, tolerations,
+  # affinity, topologySpreadConstraints, priorityClassName, extraVolumes,
+  # extraVolumeMounts, annotations, labels, serviceMonitor, pdb,
+  # tenancyHeader). Leave empty (`{}`) in standalone mode.
+  # ======================================================================
+  # -- Ingester StatefulSet config. Required when `receive.mode` is `split`;
+  # ignored in `standalone` mode.
+  # @default -- {}
+  ingester: {}
+  # Example (split mode):
+  # ingester:
+  #   replicaCount: 3
+  #   tsdb:
+  #     retention: 24h
+  #     walCompression: true
+  #   service:
+  #     grpcPort: 10901
+  #     httpPort: 10902
+  #     remoteWritePort: 10908
+  #   persistence:
+  #     enabled: true
+  #     size: 10Gi
+  #   hashrings:
+  #     autogen:
+  #       enabled: true
+
+  # ======================================================================
+  # Receive Router (only used when `receive.mode` is `split`).
+  # Stateless Deployment that fronts the Ingester StatefulSet, exposes the
+  # remote-write endpoint to clients, and forwards requests according to the
+  # hashring configuration (with optional replication).
+  # ======================================================================
+  router:
+    # -- Number of Router pod replicas. Routers are stateless so scale
+    # horizontally based on incoming write throughput.
+    replicaCount: 2
+
+    # -- Replication factor used when forwarding writes to Ingesters.
+    # Each write is sent to this many Ingesters. Must be <= ingester replicaCount.
+    replicationFactor: 1
+
+    # Kubernetes Service configuration for the Router component.
+    service:
+      # -- Kubernetes Service type for the Router component.
+      type: ClusterIP
+      # -- HTTP port exposed by the Router Service (metrics, probes).
+      httpPort: 10902
+      # -- Remote-write ingestion port exposed by the Router Service.
+      remoteWritePort: 10908
+      # -- Extra annotations for the Router Service.
+      # @default -- {}
+      annotations: {}
+      # -- Extra labels for the Router Service.
+      # @default -- {}
+      labels: {}
+
+    # Kubernetes Ingress configuration for the Router HTTP/remote-write endpoint.
+    ingress:
+      http:
+        # -- Enable a Kubernetes Ingress for the Router HTTP endpoint.
+        enabled: false
+        # -- Ingress class name for Router HTTP endpoint.
+        className: ""
+        # -- Extra annotations for the Router HTTP Ingress.
+        # @default -- {}
+        annotations: {}
+        # Host rules for the Router HTTP Ingress.
+        hosts:
+          - host: thanos-receive-router.local
+            paths:
+              - path: /
+                pathType: Prefix
+        # -- TLS configuration for the Router HTTP Ingress.
+        # @default -- []
+        tls: []
+
+    # Gateway API HTTPRoute configuration for the Router HTTP endpoint.
+    httpRoute:
+      # -- Enable a Gateway API HTTPRoute for the Router HTTP endpoint.
+      enabled: false
+      # -- Annotations for the Router HTTPRoute resource.
+      # @default -- {}
+      annotations: {}
+      # -- Gateway parentRefs for the Router HTTPRoute.
+      # @default -- []
+      parentRefs: []
+      # -- Hostnames to match on the Router HTTPRoute.
+      # @default -- []
+      hostnames: []
+
+    # VerticalPodAutoscaler configuration for the Router Deployment.
+    vpa:
+      # -- Enable a VerticalPodAutoscaler for the Router Deployment.
+      enabled: false
+      # -- Kubernetes workload kind targeted by the Router VPA.
+      targetKind: Deployment
+      # -- VPA update mode for Router. One of Auto, Off, or Initial.
+      updateMode: Auto
+      # Minimum resource limits enforced by the Router VPA.
+      minAllowed:
+        # -- Minimum CPU resource enforced by the Router VPA.
+        cpu: 100m
+        # -- Minimum memory resource enforced by the Router VPA.
+        memory: 256Mi
+      # Maximum resource limits enforced by the Router VPA.
+      maxAllowed:
+        # -- Maximum CPU resource enforced by the Router VPA.
+        cpu: "2"
+        # -- Maximum memory resource enforced by the Router VPA.
+        memory: 4Gi
+
+    # -- Resource requests and limits for the Router container.
+    # @default -- {}
+    resources: {}
+
+    # -- Additional CLI arguments appended to the `thanos receive` command for the Router.
+    # @default -- []
+    extraArgs: []
+
+    # -- Pod security context for Router pods. Falls back to receive.podSecurityContext, then global.podSecurityContext.
+    # @default -- {}
+    podSecurityContext: {}
+
+    # -- Container security context for the Router container. Falls back to receive.containerSecurityContext, then global.containerSecurityContext.
+    # @default -- {}
+    containerSecurityContext: {}
+
+    # Health and readiness probe configuration for the Router.
+    probes:
+      # Readiness probe for the Router.
+      readiness:
+        # -- Enable the readiness probe for Router.
+        enabled: true
+        # -- HTTP path checked by the Router readiness probe.
+        path: /-/ready
+        # -- Seconds to wait before starting the Router readiness probe.
+        initialDelaySeconds: 5
+        # -- How often (seconds) to run the Router readiness probe.
+        periodSeconds: 10
+        # -- Seconds after which the Router readiness probe times out.
+        timeoutSeconds: 5
+        # -- Consecutive failures before the Router pod is marked not-ready.
+        failureThreshold: 6
+        # -- Consecutive successes before the Router pod is marked ready.
+        successThreshold: 1
+      # Liveness probe for the Router.
+      liveness:
+        # -- Enable the liveness probe for Router.
+        enabled: true
+        # -- HTTP path checked by the Router liveness probe.
+        path: /-/healthy
+        # -- Seconds to wait before starting the Router liveness probe.
+        initialDelaySeconds: 30
+        # -- How often (seconds) to run the Router liveness probe.
+        periodSeconds: 10
+        # -- Seconds after which the Router liveness probe times out.
+        timeoutSeconds: 5
+        # -- Consecutive failures before the Router container is restarted.
+        failureThreshold: 6
+        # -- Consecutive successes before the Router container is considered live.
+        successThreshold: 1
+      # Startup probe for the Router.
+      startup:
+        # -- Enable the startup probe for Router.
+        enabled: true
+        # -- HTTP path checked by the Router startup probe.
+        path: /-/ready
+        # -- Seconds to wait before starting the Router startup probe.
+        initialDelaySeconds: 0
+        # -- How often (seconds) to run the Router startup probe.
+        periodSeconds: 5
+        # -- Seconds after which the Router startup probe times out.
+        timeoutSeconds: 5
+        # -- Consecutive failures during Router startup before the container is killed.
+        failureThreshold: 60
+        # -- Consecutive successes before the Router startup probe is considered passed.
+        successThreshold: 1
+
+    # -- DNS configuration for Router pods. Falls back to receive.dnsConfig.
+    # @default -- {}
+    dnsConfig: {}
+
+    # -- Extra environment variables injected into the Router container.
+    # @default -- []
+    extraEnv: []
+
+    # -- Extra environment variable sources for the Router container.
+    # @default -- []
+    extraEnvFrom: []
+
+    # -- Extra init containers for Router pods.
+    # @default -- []
+    extraInitContainers: []
+
+    # -- Extra sidecar containers for Router pods.
+    # @default -- []
+    extraContainers: []
+
+    # -- Node selector for Router pod scheduling. Falls back to receive.nodeSelector.
+    # @default -- {}
+    nodeSelector: {}
+
+    # -- Tolerations for Router pod scheduling. Falls back to receive.tolerations.
+    # @default -- []
+    tolerations: []
+
+    # -- Affinity rules for Router pod scheduling. Falls back to receive.affinity.
+    # @default -- {}
+    affinity: {}
+
+    # -- Topology spread constraints for Router pods. Falls back to receive.topologySpreadConstraints.
+    # @default -- []
+    topologySpreadConstraints: []
+
+    # -- Priority class name for Router pods. Falls back to receive.priorityClassName.
+    priorityClassName: ""
+
+    # -- Extra volumes for Router pods.
+    # @default -- []
+    extraVolumes: []
+
+    # -- Extra volume mounts for the Router container.
+    # @default -- []
+    extraVolumeMounts: []
+
+    # -- Extra annotations applied to Router resources.
+    # @default -- {}
+    annotations: {}
+
+    # -- Extra labels applied to Router resources.
+    # @default -- {}
+    labels: {}
+
+    # Prometheus Operator ServiceMonitor configuration for the Router.
+    serviceMonitor:
+      # -- Enable a Prometheus Operator ServiceMonitor for Router.
+      enabled: false
+      # -- Extra labels for the Router ServiceMonitor.
+      # @default -- {}
+      labels: {}
+      # -- Extra annotations for the Router ServiceMonitor.
+      # @default -- {}
+      annotations: {}
+      # -- Scrape interval for Router. Empty uses the Prometheus operator default.
+      interval: ""
+      # -- Scrape timeout for Router. Empty uses the Prometheus operator default.
+      scrapeTimeout: ""
+      # -- Scrape scheme for Router (http or https).
+      scheme: ""
+      # -- TLS configuration for Router scraping.
+      # @default -- {}
+      tlsConfig: {}
+      # -- Relabeling rules applied before Router metrics are ingested.
+      # @default -- []
+      relabelings: []
+      # -- Metric relabeling rules applied after Router metrics are ingested.
+      # @default -- []
+      metricRelabelings: []
+
+    # PodDisruptionBudget configuration for the Router.
+    pdb:
+      # -- Enable a PodDisruptionBudget for Router.
+      enabled: false
+      # -- (int or string) Minimum available Router pods during a disruption.
+      minAvailable: ""
+      # -- (int or string) Maximum unavailable Router pods during a disruption.
+      maxUnavailable: ""
 
 # ======================================================================
 # Ruler component


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a new `receive.mode` value to support deploying Thanos Receive as separate Router and Ingester workloads, following the [receive split proposal](https://thanos.io/tip/proposals-accepted/202012-receive-split.md). This is necessary for organizations that need high availability and horizontal scalability of the remote-write path.

- `receive.mode: standalone` (default) — single combined RouterIngestor StatefulSet. **Fully backwards-compatible: rendering byte-identical to the previous chart.**
- `receive.mode: split` — stateless `receive-router` Deployment in front of a stateful `receive-ingester` StatefulSet. The router terminates client `remote_write`, the ingester writes to the local TSDB WAL and ships blocks to the object store.

In split mode the existing `receive.*` block configures the Ingester StatefulSet (renamed `<release>-thanos-receive-ingester`) and a new `receive.router.*` block configures the Router (`<release>-thanos-receive-router`). Router-only flags (`--receive.hashrings-file`, `--receive.hashrings-algorithm`, `--receive.local-endpoint`) and the hashrings configmap mount are stripped from the ingester. The hashrings configmap content auto-generates against ingester pod DNS in split mode.

To minimise duplication, the existing template helpers (`thanos.affinity`, `thanos.nodeSelector`, `thanos.tolerations`, `thanos.priorityClassName`, `thanos.topologySpreadConstraints`, `thanos.dnsConfig`, `thanos.podSC`, `thanos.containerSC`, `thanos.httpProbes`, `thanos.extraEnvItems` / Block, `thanos.extraEnvFromItems` / Block, `thanos.initContainers`, `thanos.extraContainers`, `thanos.extraVolumeItems` / Block, `thanos.extraMountItems` / Block) gained an optional `parent` argument. When set, the helper resolves with `component → parent → global` precedence — letting `receive.router.*` cleanly inherit anything not explicitly overridden from `receive.*`. The change is fully backwards-compatible: helpers called without `parent` behave exactly as before.

#### Which issue this PR fixes

- fixes #54

#### Special notes for your reviewer

- Standalone-mode rendering is unchanged. A diff of \`helm template . --set global.objstore.config=dummy\` against \`master\` is empty for all standalone resources.
- The schema rejects invalid mode values: \`helm template . --set receive.mode=bogus\` fails with \`receive.mode must be one of "standalone", "split"\`.
- 22 new unit tests cover both modes and the new helpers (89 total receive tests, 555 total chart tests, all green).
- Chart version bumped \`0.10.1\` → \`0.11.0\`.
- README regenerated and a Split mode usage section added under \`### Receive\`.
- Migration: switching an existing release from \`standalone\` → \`split\` renames the StatefulSet (\`-receive\` → \`-receive-ingester\`), so PVCs need to be migrated manually if the user wants to retain the local TSDB WAL data.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md