### PR TITLE
fix(ruler): Add objstore config and auto-generated Query endpoint for Ruler

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -751,7 +751,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.containerSecurityContext | object | {} | Container security context for Query. Overrides global.containerSecurityContext. |
 | query.dnsConfig | object | {} | DNS configuration for Query pods. Overrides global.dnsConfig. |
 | query.enabled | bool | `true` | Enable the Query Deployment. |
-| query.endpoints.autogen.enabled | bool | `true` | Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway). These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format. |
+| query.endpoints.autogen.enabled | bool | `true` | Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway, Ruler). These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format. |
 | query.endpoints.static | list | [] | Optional static endpoint arguments. When non-empty will be added as extra endpoints. When `query.endpoints.autogen.enabled` is `false`, these will give you full control over the endpoints. |
 | query.extraArgs[0] | string | `"--log.level=info"` |  |
 | query.extraContainers | list | [] | Extra sidecar containers for Query pods. |

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -47,6 +47,9 @@ spec:
           {{- if .Values.receive.enabled }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.receiveHeadless" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
+          {{- if .Values.ruler.enabled }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "ruler") }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+          {{- end }}
         {{- end }}
           {{- range .Values.query.endpoints.static }}
             - --endpoint={{ . }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
             - --http-address=0.0.0.0:{{ .Values.ruler.service.httpPort }}
             - --grpc-address=0.0.0.0:{{ .Values.ruler.service.grpcPort }}
             - --data-dir=/var/thanos/ruler
+            - --objstore.config-file=/etc/thanos/objstore.yml
             - --rule-file=/etc/thanos/rules/*.yaml
           {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
             - --rule-file=/etc/thanos/rules/generated/*.yaml
@@ -66,6 +67,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/thanos/ruler
+            - name: objstore
+              mountPath: /etc/thanos
+              readOnly: true
             - name: rules
               mountPath: /etc/thanos/rules
           {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
@@ -105,6 +109,13 @@ spec:
       {{- include "thanos.tolerations" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       volumes:
+        - name: objstore
+          secret:
+            secretName: {{ .Values.global.objstore.secretName }}
+            items:
+              - key: {{ .Values.global.objstore.secretKey }}
+                path: objstore.yml
+
         - name: rules
           configMap:
             name: {{ include "thanos.compName" (list . "ruler") }}-rules

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -68,7 +68,8 @@ spec:
             - name: data
               mountPath: /var/thanos/ruler
             - name: objstore
-              mountPath: /etc/thanos
+              mountPath: /etc/thanos/objstore.yml
+              subPath: objstore.yml
               readOnly: true
             - name: rules
               mountPath: /etc/thanos/rules

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -76,10 +76,23 @@ tests:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: false
+      ruler.enabled: false
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[3]
           pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*storegateway.*"
+
+  - it: adds store endpoints for ruler when enabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: false
+      receive.enabled: false
+      ruler.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*ruler-headless.*"
 
   - it: renders --endpoint args from query.endpoints.static when autogen disabled
     template: query/deployment.yaml
@@ -97,12 +110,13 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --endpoint=store.example.com:10901
 
-  - it: static endpoints replace auto-wired storegateway and receive endpoints
+  - it: static endpoints replace auto-wired storegateway, receive, and ruler endpoints
     template: query/deployment.yaml
     set:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: true
+      ruler.enabled: true
       query.endpoints.autogen.enabled: false
       query.endpoints.static:
         - external.example.com:10901
@@ -116,6 +130,9 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[4]
           pattern: "--endpoint=dnssrv\\+_grpc\\._tcp\\..*receive.*"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[4]
+          pattern: "--endpoint=dnssrv\\+_grpc\\._tcp\\..*ruler.*"
 
   - it: renders static endpoints alongside auto-wired endpoints when autogen enabled
     template: query/deployment.yaml
@@ -123,6 +140,7 @@ tests:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: true
+      ruler.enabled: true
       query.endpoints.autogen.enabled: true
       query.endpoints.static:
         - external.example.com:10901
@@ -133,8 +151,11 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[4]
           pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*receive.*"
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].args[5]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*ruler-headless.*"
+      - equal:
+          path: spec.template.spec.containers[0].args[6]
           value: --endpoint=external.example.com:10901
 
   - it: renders no --endpoint args when autogen disabled and static empty
@@ -143,6 +164,7 @@ tests:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: true
+      ruler.enabled: true
       query.endpoints.autogen.enabled: false
       query.endpoints.static: []
     asserts:

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -89,6 +89,32 @@ tests:
             name: data
             emptyDir: {}
 
+  - it: configures object storage from global objstore secret
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      global.objstore.secretName: thanos-ruler-objstore
+      global.objstore.secretKey: objstore.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --objstore.config-file=/etc/thanos/objstore.yml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: objstore
+            mountPath: /etc/thanos
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: objstore
+            secret:
+              secretName: thanos-ruler-objstore
+              items:
+                - key: objstore.yaml
+                  path: objstore.yml
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -103,7 +103,8 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: objstore
-            mountPath: /etc/thanos
+            mountPath: /etc/thanos/objstore.yml
+            subPath: objstore.yml
             readOnly: true
       - contains:
           path: spec.template.spec.volumes

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2440,11 +2440,11 @@
           "properties": {
             "autogen": {
               "additionalProperties": true,
-              "description": "Auto-generated endpoints for the in-chart components (Receive, Store Gateway).",
+              "description": "Auto-generated endpoints for the in-chart components (Receive, Store Gateway, Ruler).",
               "properties": {
                 "enabled": {
                   "default": true,
-                  "description": "Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway).\nThese use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.",
+                  "description": "Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway, Ruler).\nThese use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.",
                   "required": [],
                   "title": "enabled",
                   "type": "boolean"

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1011,9 +1011,9 @@ query:
 
   # Configuration for the --endpoint arguments passed to thanos query.
   endpoints:
-    # Auto-generated endpoints for the in-chart components (Receive, Store Gateway).
+    # Auto-generated endpoints for the in-chart components (Receive, Store Gateway, Ruler).
     autogen:
-      # -- Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway).
+      # -- Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway, Ruler).
       # These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.
       enabled: true
     # -- Optional static endpoint arguments. When non-empty will be added as extra endpoints.


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This updates the Ruler chart templates so `thanos rule` is configured consistently with the other object-store-backed components.

## Changes

- Pass `--objstore.config-file=/etc/thanos/objstore.yml` to the Ruler container.
- Mount the global objstore Secret into the Ruler pod using `global.objstore.secretName` and `global.objstore.secretKey`.
- Add Ruler as an auto-generated Query StoreAPI endpoint when `query.endpoints.autogen.enabled=true`.
- Update unit tests and values documentation for the new behavior.


#### Which issue this PR fixes

Fixes #136.

#### Special notes for your reviewer:

@hamdikh please review.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
