### PR TITLE
fix(compactor): always pass --wait and expose typed retention values

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -376,12 +376,16 @@ compactor:
   enabled: true
   replicaCount: 1           # Do NOT increase — compactor must run as a singleton
 
+  # Retention is exposed as typed values. Set any of these to "" to disable.
+  retention:
+    resolutionRaw: 30d      # Keep raw samples for 30 days
+    resolution5m: 90d       # Keep 5m-downsampled data for 90 days
+    resolution1h: 365d      # Keep 1h-downsampled data for 1 year
+
+  # --wait is always passed by the chart so the compactor keeps running as a
+  # long-lived StatefulSet pod. Use extraArgs for everything else.
   extraArgs:
-    - --retention.resolution-raw=30d    # Keep raw samples for 30 days
-    - --retention.resolution-5m=90d     # Keep 5m-downsampled data for 90 days
-    - --retention.resolution-1h=365d    # Keep 1h-downsampled data for 1 year
     - --consistency-delay=30m
-    - --wait
 
   persistence:
     enabled: true
@@ -576,11 +580,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.enabled | bool | `true` | Enable the Compactor StatefulSet. |
 | compactor.extraArgs[0] | string | `"--log.level=info"` |  |
 | compactor.extraArgs[1] | string | `"--log.format=logfmt"` |  |
-| compactor.extraArgs[2] | string | `"--retention.resolution-raw=30d"` |  |
-| compactor.extraArgs[3] | string | `"--retention.resolution-5m=90d"` |  |
-| compactor.extraArgs[4] | string | `"--retention.resolution-1h=365d"` |  |
-| compactor.extraArgs[5] | string | `"--consistency-delay=30m"` |  |
-| compactor.extraArgs[6] | string | `"--wait"` |  |
+| compactor.extraArgs[2] | string | `"--consistency-delay=30m"` |  |
 | compactor.extraContainers | list | [] | Extra sidecar containers for the Compactor pod. |
 | compactor.extraEnv | list | [] | Extra environment variables injected into the Compactor container. |
 | compactor.extraEnvFrom | list | [] | Extra environment variable sources for the Compactor container. |
@@ -632,6 +632,9 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Compactor startup probe times out. |
 | compactor.replicaCount | int | `1` | Number of Compactor replicas. Must remain 1 — running multiple compactors against the same bucket causes data corruption. |
 | compactor.resources | object | {} | Resource requests and limits for the Compactor container. |
+| compactor.retention.resolution1h | string | `"365d"` | Retention for 1h downsampled blocks (--retention.resolution-1h). |
+| compactor.retention.resolution5m | string | `"90d"` | Retention for 5m downsampled blocks (--retention.resolution-5m). |
+| compactor.retention.resolutionRaw | string | `"30d"` | Retention for raw resolution blocks (--retention.resolution-raw). |
 | compactor.service.annotations | object | {} | Extra annotations for the Compactor Service. |
 | compactor.service.labels | object | {} | Extra labels for the Compactor Service. |
 | compactor.service.port | int | `10902` | HTTP port exposed by the Compactor Service. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -364,12 +364,16 @@ compactor:
   enabled: true
   replicaCount: 1           # Do NOT increase — compactor must run as a singleton
 
+  # Retention is exposed as typed values. Set any of these to "" to disable.
+  retention:
+    resolutionRaw: 30d      # Keep raw samples for 30 days
+    resolution5m: 90d       # Keep 5m-downsampled data for 90 days
+    resolution1h: 365d      # Keep 1h-downsampled data for 1 year
+
+  # --wait is always passed by the chart so the compactor keeps running as a
+  # long-lived StatefulSet pod. Use extraArgs for everything else.
   extraArgs:
-    - --retention.resolution-raw=30d    # Keep raw samples for 30 days
-    - --retention.resolution-5m=90d     # Keep 5m-downsampled data for 90 days
-    - --retention.resolution-1h=365d    # Keep 1h-downsampled data for 1 year
     - --consistency-delay=30m
-    - --wait
 
   persistence:
     enabled: true

--- a/charts/thanos/ci/ci-values.yaml
+++ b/charts/thanos/ci/ci-values.yaml
@@ -2,7 +2,6 @@
 # Goals:
 #   1. Use a local RustFS instance as an S3-compatible object store
 #   2. Fit within a 2-worker kind cluster (reduce replicas to 1)
-#   3. Keep the compactor pod running so the StatefulSet reports Ready
 
 # ---- RustFS: local S3-compatible store (disabled by default) -----------
 rustfs:
@@ -57,9 +56,3 @@ storegateway:
 
 query:
   replicaCount: 1
-
-compactor:
-  # Without --wait, `thanos compact` runs once and exits with code 0.
-  # Kubernetes restarts the pod immediately, so the StatefulSet is never Ready.
-  extraArgs:
-    - --wait

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -44,6 +44,16 @@ spec:
             - --http-address=0.0.0.0:{{ .Values.compactor.service.port }}
             - --objstore.config-file=/etc/thanos/objstore.yml
             - --data-dir=/var/thanos/compact
+            - --wait
+          {{- with .Values.compactor.retention.resolutionRaw }}
+            - --retention.resolution-raw={{ . }}
+          {{- end }}
+          {{- with .Values.compactor.retention.resolution5m }}
+            - --retention.resolution-5m={{ . }}
+          {{- end }}
+          {{- with .Values.compactor.retention.resolution1h }}
+            - --retention.resolution-1h={{ . }}
+          {{- end }}
           {{- range .Values.compactor.extraArgs }}
             - {{ . | quote }}
           {{- end }}

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -49,11 +49,64 @@ tests:
       compactor.enabled: true
       compactor.extraArgs:
         - --log.level=debug
-        - --wait
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--log.level=debug"
+
+  - it: renders default retention flags and --wait
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-raw=30d"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-5m=90d"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-1h=365d"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--wait"
+
+  - it: overrides retention durations via compactor.retention
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.retention.resolutionRaw: 2d
+      compactor.retention.resolution5m: 10d
+      compactor.retention.resolution1h: 11d
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-raw=2d"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-5m=10d"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-1h=11d"
+
+  - it: omits retention flag when the value is empty
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.retention.resolutionRaw: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--retention.resolution-raw="
+          any: true
+
+  - it: always passes --wait to keep the StatefulSet pod alive
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.extraArgs: []
+    asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--wait"

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -846,25 +846,9 @@
           "type": "boolean"
         },
         "extraArgs": {
-          "description": "Additional CLI arguments appended to the `thanos compact` command.\nUse this to configure retention, consistency delay, and wait mode.",
+          "description": "Additional CLI arguments appended to the `thanos compact` command.\n`--wait` is always passed (the StatefulSet requires the compactor to run\ncontinuously); retention is managed via `retention.*` above.",
           "items": {
             "anyOf": [
-              {
-                "required": [],
-                "type": "string"
-              },
-              {
-                "required": [],
-                "type": "string"
-              },
-              {
-                "required": [],
-                "type": "string"
-              },
-              {
-                "required": [],
-                "type": "string"
-              },
               {
                 "required": [],
                 "type": "string"
@@ -883,6 +867,40 @@
           "required": [],
           "title": "extraArgs",
           "type": "array"
+        },
+        "retention": {
+          "additionalProperties": true,
+          "description": "Retention policy for compacted blocks in the object store.\nEach duration follows the Prometheus duration syntax (e.g. 30d, 12h).\nAn empty value disables retention for that resolution.",
+          "properties": {
+            "resolutionRaw": {
+              "default": "30d",
+              "description": "Retention for raw resolution blocks (--retention.resolution-raw).",
+              "required": [],
+              "title": "resolutionRaw",
+              "type": "string"
+            },
+            "resolution5m": {
+              "default": "90d",
+              "description": "Retention for 5m downsampled blocks (--retention.resolution-5m).",
+              "required": [],
+              "title": "resolution5m",
+              "type": "string"
+            },
+            "resolution1h": {
+              "default": "365d",
+              "description": "Retention for 1h downsampled blocks (--retention.resolution-1h).",
+              "required": [],
+              "title": "resolution1h",
+              "type": "string"
+            }
+          },
+          "required": [
+            "resolutionRaw",
+            "resolution5m",
+            "resolution1h"
+          ],
+          "title": "retention",
+          "type": "object"
         },
         "extraContainers": {
           "description": "Extra sidecar containers for the Compactor pod.",
@@ -1698,6 +1716,7 @@
         "ingress",
         "httpRoute",
         "vpa",
+        "retention",
         "extraArgs",
         "resources",
         "podSecurityContext",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -732,16 +732,24 @@ compactor:
       # -- Maximum memory resource enforced by the Compactor VPA.
       memory: 8Gi
 
+  # Retention policy for compacted blocks in the object store.
+  # Each duration follows the Prometheus duration syntax (e.g. 30d, 12h).
+  # An empty value disables retention for that resolution.
+  retention:
+    # -- Retention for raw resolution blocks (--retention.resolution-raw).
+    resolutionRaw: 30d
+    # -- Retention for 5m downsampled blocks (--retention.resolution-5m).
+    resolution5m: 90d
+    # -- Retention for 1h downsampled blocks (--retention.resolution-1h).
+    resolution1h: 365d
+
   # Additional CLI arguments appended to the `thanos compact` command.
-  # Use this to configure retention, consistency delay, and wait mode.
+  # `--wait` is always passed (the StatefulSet requires the compactor to run
+  # continuously); retention is managed via `retention.*` above.
   extraArgs:
     - --log.level=info
     - --log.format=logfmt
-    - --retention.resolution-raw=30d
-    - --retention.resolution-5m=90d
-    - --retention.resolution-1h=365d
     - --consistency-delay=30m
-    - --wait
 
   # -- Resource requests and limits for the Compactor container.
   # @default -- {}


### PR DESCRIPTION
## Summary

- Fixes the Compactor exiting after a single iteration when users override `extraArgs` without `--wait`. Because the Compactor is deployed as a StatefulSet, `--wait` is now hardcoded in the template so the pod always runs continuously.
- Exposes retention as typed values under `compactor.retention.{resolutionRaw,resolution5m,resolution1h}` instead of relying on raw `extraArgs` entries. Setting any of them to `""` disables that retention level.
- Bumps `charts/thanos` to `0.12.2`, refreshes the schema, regenerates the README via `helm-docs`, and adds unit tests covering the defaults, overrides, empty-value disable, and the always-on `--wait` guarantee.

Closes #124

## Test plan

- [x] `helm unittest charts/thanos` — 568 tests pass (4 new compactor tests)
- [x] `helm lint charts/thanos` — clean
- [x] `helm template` on defaults still renders `--wait` plus the three retention flags