### PR TITLE
fix: global.podAnnotations causes YAML parse error in ingress templates

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.12.3](https://img.shields.io/badge/Version-0.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/part-of: thanos
 {{- end }}
 
 {{- if $annotations }}
-  {{- toYaml $annotations | nindent 2 }}
+{{- toYaml $annotations }}
 {{- end }}
 {{- end }}
 

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -26,7 +26,9 @@ spec:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucketweb
       annotations:
-        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
       {{- include "thanos.affinity" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}

--- a/charts/thanos/templates/bucket/ingress.yaml
+++ b/charts/thanos/templates/bucket/ingress.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.bucket.bucketweb.ingress.annotations | nindent 4 }}
+    {{- with .Values.bucket.bucketweb.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 spec:
   {{- with .Values.bucket.bucketweb.ingress.className }}

--- a/charts/thanos/templates/compactor/ingress.yaml
+++ b/charts/thanos/templates/compactor/ingress.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.compactor.ingress.annotations | nindent 4 }}
+    {{- with .Values.compactor.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
 spec:
   {{- with .Values.compactor.ingress.className }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query-frontend
       annotations:
-        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/ingress.yaml
+++ b/charts/thanos/templates/query-frontend/ingress.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.queryFrontend.ingress.annotations | nindent 4 }}
+    {{- with .Values.queryFrontend.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 spec:
   {{- with .Values.queryFrontend.ingress.className }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query
       annotations:
-        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thanos.serviceAccountName" . }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "query") | nindent 6 }}

--- a/charts/thanos/templates/query/ingress.yaml
+++ b/charts/thanos/templates/query/ingress.yaml
@@ -9,7 +9,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- toYaml $ingress.annotations | nindent 4 }}
+    {{- with $ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "query") | nindent 4 }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}

--- a/charts/thanos/templates/receive/ingress.yaml
+++ b/charts/thanos/templates/receive/ingress.yaml
@@ -10,7 +10,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- toYaml $ingress.annotations | nindent 4 }}
+    {{- with $ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "receive") | nindent 4 }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}

--- a/charts/thanos/templates/receive/split/router-ingress.yaml
+++ b/charts/thanos/templates/receive/split/router-ingress.yaml
@@ -4,7 +4,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- toYaml $ingress.annotations | nindent 4 }}
+    {{- with $ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 4 }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/ruler/ingress.yaml
+++ b/charts/thanos/templates/ruler/ingress.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.ruler.ingress.annotations | nindent 4 }}
+    {{- with .Values.ruler.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
 spec:
   {{- with .Values.ruler.ingress.className }}

--- a/charts/thanos/templates/storegateway/ingress.yaml
+++ b/charts/thanos/templates/storegateway/ingress.yaml
@@ -9,7 +9,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- toYaml $ingress.annotations | nindent 4 }}
+    {{- with $ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "storegateway") | nindent 4 }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -643,6 +643,34 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-thanos-compactor
 
+  - it: applies global.podAnnotations to compactor ingress metadata
+    template: compactor/ingress.yaml
+    set:
+      compactor.enabled: true
+      compactor.ingress.enabled: true
+      compactor.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to compactor pod template
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
   - it: does not render ingress when disabled
     template: compactor/ingress.yaml
     set:

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -113,3 +113,85 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "my-bucket"
+
+  # -- global.podAnnotations ---------------------------------------------
+  # Regression coverage for github.com/thanos-community/helm-charts/issues/125
+  # The bug: empty ingress.annotations defaults emitted `{}` and broke YAML
+  # parsing once global.podAnnotations was merged in. These tests pin down
+  # both the resource-metadata and pod-template rendering paths.
+
+  - it: applies global.podAnnotations to resource metadata via thanos.annotations helper
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to pod template metadata
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: renders ingress cleanly when global.podAnnotations is set and ingress.annotations is empty
+    template: bucket/ingress.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.ingress.enabled: true
+      bucket.bucketweb.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: merges ingress.annotations with global.podAnnotations on the Ingress
+    template: bucket/ingress.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.ingress.enabled: true
+      bucket.bucketweb.ingress.annotations:
+        kubernetes.io/ingress.class: nginx
+      bucket.bucketweb.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["kubernetes.io/ingress.class"]
+          value: nginx
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: renders pod template annotations cleanly when global.podAnnotations is empty
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations.placeholder

--- a/charts/thanos/tests/query_frontend_test.yaml
+++ b/charts/thanos/tests/query_frontend_test.yaml
@@ -581,6 +581,34 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-thanos-query-frontend
 
+  - it: applies global.podAnnotations to query-frontend ingress metadata
+    template: query-frontend/ingress.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.ingress.enabled: true
+      queryFrontend.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to query-frontend pod template
+    template: query-frontend/deployment.yaml
+    set:
+      queryFrontend.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
   - it: does not render ingress when disabled
     template: query-frontend/ingress.yaml
     set:

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -680,6 +680,34 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-thanos-query
 
+  - it: applies global.podAnnotations to query ingress metadata
+    template: query/ingress.yaml
+    set:
+      query.enabled: true
+      query.ingress.enabled: true
+      query.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to query pod template
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
   - it: does not render ingress when disabled
     template: query/ingress.yaml
     set:

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -620,6 +620,64 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-thanos-receive
 
+  - it: applies global.podAnnotations to receive ingress metadata
+    template: receive/ingress.yaml
+    set:
+      receive.enabled: true
+      receive.ingress.enabled: true
+      receive.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to receive pod template
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to receive router ingress in split mode
+    template: receive/split/router-ingress.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.ingress.http.enabled: true
+      receive.router.ingress.http.hosts:
+        - host: receive.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to receive router pod template in split mode
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
   - it: does not render ingress when disabled
     template: receive/ingress.yaml
     set:

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -714,6 +714,34 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-thanos-ruler
 
+  - it: applies global.podAnnotations to ruler ingress metadata
+    template: ruler/ingress.yaml
+    set:
+      ruler.enabled: true
+      ruler.ingress.enabled: true
+      ruler.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to ruler pod template
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
   - it: does not render ingress when disabled
     template: ruler/ingress.yaml
     set:

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -574,6 +574,34 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-thanos-storegateway
 
+  - it: applies global.podAnnotations to storegateway ingress metadata
+    template: storegateway/ingress.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.ingress.enabled: true
+      storegateway.ingress.hosts:
+        - host: thanos.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
+  - it: applies global.podAnnotations to storegateway pod template
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      global.podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
+          value: "false"
+
   - it: does not render ingress when disabled
     template: storegateway/ingress.yaml
     set:


### PR DESCRIPTION
## Summary

Fixes #125.

- Remove duplicate `nindent 2` from the `thanos.annotations` helper — all 56 callers already pipe through `| nindent 4`, so the inner indent was producing 6-space output that mis-aligned with sibling blocks.
- Guard `toYaml` of `ingress.annotations` in all 7 ingress templates with `{{- with ... }}` so the empty-map default no longer emits `{}` and break subsequent annotation lines.
- Normalize pod-template annotations in `bucket`, `query`, and `query-frontend` deployments to use the same `{{- with .Values.global.podAnnotations }}` guard already used by the other components.

## Test plan

- [x] `helm template` with the exact repro from the issue renders successfully.
- [x] `helm template` with non-empty `ingress.annotations` merged on top of `global.podAnnotations` renders both at the correct indent.
- [x] `helm lint charts/thanos` passes.
- [x] `helm unittest charts/thanos` — 587 tests pass (19 new regression tests covering empty + populated `global.podAnnotations` across every Ingress, Deployment, and StatefulSet, plus split-mode receive router).