### PR TITLE
fix: resolve serviceaccount name to default when create is disabled

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.12.4
+version: 0.12.5
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.12.4](https://img.shields.io/badge/Version-0.12.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.12.5](https://img.shields.io/badge/Version-0.12.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -655,15 +655,16 @@ same helper produces a valid hashring for both standalone and split modes.
 
 {{/*
 Resolve the ServiceAccount name.
-If global.serviceAccount.create is true, we default to "<release>-thanos"
-unless a name is provided. If create is false, we must use the provided name.
+- When global.serviceAccount.create is true, defaults to "<fullname>-thanos"
+  unless global.serviceAccount.name overrides it.
+- When create is false, uses global.serviceAccount.name if provided, otherwise
+  falls back to the namespace "default" ServiceAccount.
 */}}
 {{- define "thanos.serviceAccountName" -}}
-{{- $name := default (printf "%s-%s" (include "thanos.fullname" .) "thanos") .Values.global.serviceAccount.name -}}
 {{- if .Values.global.serviceAccount.create -}}
-{{- $name -}}
+{{- default (printf "%s-%s" (include "thanos.fullname" .) "thanos") .Values.global.serviceAccount.name -}}
 {{- else -}}
-{{- $name -}}
+{{- default "default" .Values.global.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -42,6 +42,82 @@ tests:
           path: metadata.annotations.custom-annotation
           value: my-value
 
+  # -- ServiceAccount name resolution (thanos.serviceAccountName) --------
+  # Exercises every branch of the helper through the pod spec, plus the
+  # ClusterRoleBinding subject which must never resolve to an empty name.
+
+  - it: defaults the pod serviceAccountName to <fullname>-thanos when create is true
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-thanos-thanos
+
+  - it: uses the name override for the pod serviceAccountName when create is true
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.serviceAccount.create: true
+      global.serviceAccount.name: custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa
+
+  - it: falls back to the default serviceaccount when create is false and no name is set
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: uses the name override for the pod serviceAccountName when create is false
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      global.serviceAccount.create: false
+      global.serviceAccount.name: custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa
+
+  - it: binds the ruler rule-importer to the resolved serviceaccount name
+    template: ruler/rbac.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+      global.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-thanos-thanos
+
+  - it: binds the ruler rule-importer to the default serviceaccount when create is false
+    template: ruler/rbac.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+      global.serviceAccount.create: false
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: default
+
   # -- PrometheusRule ----------------------------------------------------
 
   - it: renders prometheusrule when thanosRules are enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

When `global.serviceAccount.create=false` and no `global.serviceAccount.name` is set, the `thanos.serviceAccountName` helper still resolved to `<fullname>-thanos`, so every workload referenced a ServiceAccount that was never created.

The helper now centralizes resolution and falls back to the namespace `default` ServiceAccount in that case:

- `create=true` → `<fullname>-thanos`, or `global.serviceAccount.name` when overridden
- `create=false` + name set → `global.serviceAccount.name`
- `create=false` + no name → `default`

Because the fallback lives in the helper, every caller (pod specs and the ruler rule-importer `ClusterRoleBinding` subject) consumes the resolved name directly with no per-call defaulting.

#### Which issue this PR fixes

- fixes #126

#### Special notes for your reviewer:

Added unit tests in `tests/global_test.yaml` covering all four helper branches through the pod spec, plus the `ClusterRoleBinding` subject — which must never resolve to an empty name.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (0.12.4 → 0.12.5)
- [x] Variables are documented in the README.md