### PR TITLE
chore(deps): update kube-prometheus-stack to 85.2.0 and rustfs to 0.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
+# Renovate owns version-update PRs for these ecosystems (see renovate.json).
+# Dependabot is kept enabled for security updates only: open-pull-requests-limit: 0
+# disables its routine version-update PRs while still allowing security PRs,
+# avoiding duplicate dependency PRs from both bots.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "github-actions"
@@ -13,6 +18,7 @@ updates:
       - "/charts/*"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "helm"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Renovate
-        uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a  # v46.1.13
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961  # v46.1.14
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/thanos/Chart.lock
+++ b/charts/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 84.5.0
+  version: 85.2.0
 - name: rustfs
   repository: https://charts.rustfs.com/
-  version: 0.1.0
-digest: sha256:ede14eaaa2a2436e9cee5e30eb7f9203551488e05d829fe6488221f57689578c
-generated: "2026-05-06T14:54:19.444322047+02:00"
+  version: 0.3.0
+digest: sha256:6b208778b630d09a55acd2fe48aa30eb90244091428cf276e41696860cabc84c
+generated: "2026-05-20T10:21:43.40615492+02:00"

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.12.5
+version: 0.13.0
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -25,11 +25,11 @@ maintainers:
 dependencies:
   - name: kube-prometheus-stack
     alias: kube-prometheus-stack
-    version: 84.5.0
+    version: 85.2.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled
   - name: rustfs
-    version: "0.1.0"
+    version: "0.3.0"
     repository: https://charts.rustfs.com/
     condition: rustfs.enabled
 annotations:
@@ -51,5 +51,7 @@ annotations:
     - name: Slack
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
-    - kind: added
-      description: GPG chart signing with ArtifactHub signKey annotation and Rekor transparency via helm-sigstore
+    - kind: changed
+      description: Upgrade kube-prometheus-stack dependency to 85.2.0
+    - kind: changed
+      description: Upgrade rustfs dependency to 0.3.0

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.12.5](https://img.shields.io/badge/Version-0.12.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -45,8 +45,8 @@ Kubernetes: `>= 1.30.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.rustfs.com/ | rustfs | 0.1.0 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 84.5.0 |
+| https://charts.rustfs.com/ | rustfs | 0.3.0 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 85.2.0 |
 
 ## Component Overview
 
@@ -1201,6 +1201,7 @@ The table below documents all available values. Top-level keys group settings by
 | rustfs.initBucket.existingSecretKeys.secretKey | string | `"secret-key"` | Key in the existing Secret for the secret key. |
 | rustfs.initBucket.image | string | `"rustfs/rc:latest"` | Image used by the init-bucket Job to create the S3 bucket via the RustFS CLI. |
 | rustfs.initBucket.secretKey | string | `"rustfsadmin"` | RustFS admin password. Ignored when existingSecret is set. |
+| rustfs.secret.allowInsecureDefaults | bool | `true` | Opt into the well-known default rustfs credentials. Dev/CI only. |
 | storegateway.affinity | object | {} | Affinity rules for Store Gateway pod scheduling. |
 | storegateway.annotations | object | {} | Extra annotations applied to Store Gateway resources. |
 | storegateway.autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler for the Store Gateway. |

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -2718,6 +2718,15 @@ rustfs:
   # -- Deploy a local RustFS instance as an S3-compatible object store alongside Thanos.
   # Intended for CI and development only. Do not enable in production.
   enabled: false
+  # RustFS subchart secret handling. Since rustfs 0.3.0 the subchart refuses
+  # to render unless real credentials are supplied (secret.rustfs.access_key /
+  # secret_key or secret.existingSecret) or the well-known defaults are opted
+  # into. As this instance is for CI/development only and the init-bucket Job
+  # below already uses the rustfsadmin defaults, opt in so it renders out of
+  # the box. For any real use, set credentials and remove allowInsecureDefaults.
+  secret:
+    # -- Opt into the well-known default rustfs credentials. Dev/CI only.
+    allowInsecureDefaults: true
   initBucket:
     # -- Image used by the init-bucket Job to create the S3 bucket via the RustFS CLI.
     image: rustfs/rc:latest


### PR DESCRIPTION
#### What this PR does / why we need it:

Consolidates the open Renovate/Dependabot dependency PRs into a single change. The bot PRs cannot merge on their own because `ct lint` enforces `check-version-increment` and neither bot bumps the chart's own `version`; they were also raised in duplicate (both Renovate and Dependabot run on the same ecosystems).

**Dependency updates**
- `kube-prometheus-stack` 84.5.0 → **85.2.0** (latest)
- `rustfs` 0.1.0 → **0.3.0** (+ `Chart.lock`)
- `renovatebot/github-action` v46.1.13 → **v46.1.14** (renovate workflow)
- chart `version` 0.12.5 → **0.13.0**; refreshed `artifacthub.io/changes`

**rustfs 0.3.0 breaking change**
rustfs 0.3.0 hardened its secret handling: the subchart now refuses to render unless real credentials are supplied (`secret.rustfs.access_key`/`secret_key` or `secret.existingSecret`) or the well-known defaults are explicitly opted into. As this instance is documented **CI/development only** and the init-bucket Job already defaults to `rustfsadmin`, this PR sets `rustfs.secret.allowInsecureDefaults: true` so the chart renders out of the box. README regenerated via helm-docs.

**Stop duplicate dependency PRs**
Renovate already owns version updates for helm + github-actions, so `open-pull-requests-limit: 0` is set on both Dependabot ecosystems. Dependabot stays enabled for security updates but no longer opens routine version-update PRs.

#### Special notes for your reviewer:

Verified locally: `helm lint` clean, default + `ci/ci-values.yaml` render OK, and all **601 helm-unittest tests pass** (3 previously failed under rustfs 0.3.0 before the `allowInsecureDefaults` fix).

Supersedes and closes #133, #132, #131, #130, #123, #121.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md