### PR TITLE
ci(renovate): bump chart version on helm dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
       "/(^|/)charts/.+/values\\.yaml$/"
     ]
   },
+  "helmv3": {
+    "bumpVersion": "minor"
+  },
   "packageRules": [
     {
       "description": "Group Thanos image tag (values.yaml) and appVersion (Chart.yaml) into one PR",


### PR DESCRIPTION
#### What this PR does / why we need it:

Renovate (and Dependabot) bump the *dependency* version in `Chart.yaml`/`Chart.lock` but never the chart's **own** `version` field. Because `ct lint` enforces `check-version-increment: true`, every helm dependency PR fails `lint-chart` and can never merge on its own — which is exactly why the recent dependency PRs had to be consolidated by hand in #144.

This enables Renovate's built-in [`bumpVersion`](https://docs.renovatebot.com/configuration-options/#bumpversion) for the `helmv3` manager:

```json
"helmv3": {
  "bumpVersion": "minor"
}
```

Now whenever Renovate updates a helm chart dependency, it also bumps `charts/*/Chart.yaml` `version` (minor), so the PR satisfies `check-version-increment` and can pass CI / merge unattended. `helmv3` also maintains `Chart.lock`, so the lock stays in sync.

#### Special notes for your reviewer:

- `bumpVersion` officially supports the `helmv3` manager (per Renovate docs).
- Validated locally with `renovate-config-validator` → "Config validated successfully".
- Scope: applies to all helm dependency updates (kube-prometheus-stack, rustfs, and any future ones). Adjust the level (`patch`/`minor`/`major`) per package via a `packageRules` entry if needed.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [ ] Chart Version bumped (if the pr is an update to an existing chart) — N/A, CI config only
- [ ] Variables are documented in the README.md — N/A