### PR TITLE
feat(thanos): support matches, filters and extraRules httpRoute

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.13.1
+version: 0.14.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -517,7 +517,10 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.extraVolumes | list | [] | Extra volumes for Bucketweb pods. |
 | bucket.bucketweb.httpRoute.annotations | object | {} | Annotations for the HTTPRoute resource. |
 | bucket.bucketweb.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for Bucketweb (alternative to Ingress). |
+| bucket.bucketweb.httpRoute.extraRules | list | [] | Additional custom rules Bucketweb HTTPRoute. |
+| bucket.bucketweb.httpRoute.filters | list | [] | Gateway filters for the Bucketweb HTTPRoute rules. |
 | bucket.bucketweb.httpRoute.hostnames | list | [] | Hostnames to match. Empty matches all hostnames on the parent Gateway. |
+| bucket.bucketweb.httpRoute.matches | list | [] | Gateway matches for the Bucketweb HTTPRoute rules. |
 | bucket.bucketweb.httpRoute.parentRefs | list | [] | Gateway parentRefs the HTTPRoute should attach to. |
 | bucket.bucketweb.ingress.annotations | object | {} | Extra annotations for the Ingress resource. |
 | bucket.bucketweb.ingress.className | string | `""` | Ingress class name (e.g. nginx, traefik). |
@@ -589,7 +592,10 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.extraVolumes | list | [] | Extra volumes for Compactor pods. |
 | compactor.httpRoute.annotations | object | {} | Annotations for the Compactor HTTPRoute resource. |
 | compactor.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Compactor HTTP endpoint. |
+| compactor.httpRoute.extraRules | list | [] | Additional custom rules Compactor HTTPRoute. |
+| compactor.httpRoute.filters | list | [] | Gateway filters for the Compactor HTTPRoute rules. |
 | compactor.httpRoute.hostnames | list | [] | Hostnames to match on the Compactor HTTPRoute. |
+| compactor.httpRoute.matches | list | [] | Gateway matches for the Compactor HTTPRoute rules. |
 | compactor.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Compactor HTTPRoute. |
 | compactor.ingress.className | string | `""` | Ingress class name for the Compactor (e.g. nginx, traefik). |
 | compactor.ingress.enabled | bool | `false` | Enable a Kubernetes Ingress for the Compactor HTTP endpoint. |
@@ -772,7 +778,10 @@ The table below documents all available values. Top-level keys group settings by
 | query.grpcRoute.parentRefs | list | [] | Gateway parentRefs for the Query GRPCRoute. |
 | query.httpRoute.annotations | object | {} | Annotations for the Query HTTPRoute resource. |
 | query.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Query HTTP endpoint. |
+| query.httpRoute.extraRules | list | [] | Additional custom rules for Query HTTPRoute. |
+| query.httpRoute.filters | list | [] | Gateway filters for the Query HTTPRoute rules. |
 | query.httpRoute.hostnames | list | [] | Hostnames to match on the Query HTTPRoute. |
+| query.httpRoute.matches | list | [] | Gateway matches for the Query HTTPRoute rules. |
 | query.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Query HTTPRoute. |
 | query.ingress.annotations | object | {} | Deprecated. Use `query.ingress.http.annotations` instead. |
 | query.ingress.className | string | `""` | Deprecated. Use `query.ingress.http.className` instead. |
@@ -865,7 +874,10 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.extraVolumes | list | [] | Extra volumes for Query Frontend pods. |
 | queryFrontend.httpRoute.annotations | object | {} | Annotations for the Query Frontend HTTPRoute resource. |
 | queryFrontend.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for Query Frontend. |
+| queryFrontend.httpRoute.extraRules | list | [] | Additional custom rules for Query Frontend HTTPRoute. |
+| queryFrontend.httpRoute.filters | list | [] | Gateway filters for the Query Frontend HTTPRoute rules. |
 | queryFrontend.httpRoute.hostnames | list | [] | Hostnames to match on the Query Frontend HTTPRoute. |
+| queryFrontend.httpRoute.matches | list | [] | Gateway matches for the Query Frontend HTTPRoute rules. |
 | queryFrontend.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Query Frontend HTTPRoute. |
 | queryFrontend.ingress.annotations | object | {} | Extra annotations for the Query Frontend Ingress. |
 | queryFrontend.ingress.className | string | `""` | Ingress class name for Query Frontend (e.g. nginx, traefik). |
@@ -940,7 +952,10 @@ The table below documents all available values. Top-level keys group settings by
 | receive.hashrings.static | list | [] | Optional static hashring configuration. When non-empty this overrides `autogen` and gives full control over ring topology. |
 | receive.httpRoute.annotations | object | {} | Annotations for the Receive HTTPRoute resource. |
 | receive.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Receive HTTP endpoint. |
+| receive.httpRoute.extraRules | list | [] | Additional custom rules Receive HTTPRoute. |
+| receive.httpRoute.filters | list | [] | Gateway filters for the Receive HTTPRoute rules. |
 | receive.httpRoute.hostnames | list | [] | Hostnames to match on the Receive HTTPRoute. |
+| receive.httpRoute.matches | list | [] | Gateway matches for the Receive HTTPRoute rules. |
 | receive.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Receive HTTPRoute. |
 | receive.ingester | object | {} | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. |
 | receive.ingress.annotations | object | {} | Deprecated. Use `receive.ingress.http.annotations` instead. |
@@ -1020,7 +1035,10 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.extraVolumes | list | [] | Extra volumes for Router pods. |
 | receive.router.httpRoute.annotations | object | {} | Annotations for the Router HTTPRoute resource. |
 | receive.router.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Router HTTP endpoint. |
+| receive.router.httpRoute.extraRules | list | [] | Additional custom rules Router HTTPRoute. |
+| receive.router.httpRoute.filters | list | [] | Gateway filters for the Router HTTPRoute rules. |
 | receive.router.httpRoute.hostnames | list | [] | Hostnames to match on the Router HTTPRoute. |
+| receive.router.httpRoute.matches | list | [] | Gateway matches for the Router HTTPRoute rules. |
 | receive.router.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Router HTTPRoute. |
 | receive.router.ingress.http.annotations | object | {} | Extra annotations for the Router HTTP Ingress. |
 | receive.router.ingress.http.className | string | `""` | Ingress class name for Router HTTP endpoint. |
@@ -1138,7 +1156,10 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.extraVolumes | list | [] | Extra volumes for Ruler pods. |
 | ruler.httpRoute.annotations | object | {} | Annotations for the Ruler HTTPRoute resource. |
 | ruler.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Ruler HTTP endpoint. |
+| ruler.httpRoute.extraRules | list | [] | Additional custom rules Ruler HTTPRoute. |
+| ruler.httpRoute.filters | list | [] | Gateway filters for the Ruler HTTPRoute rules. |
 | ruler.httpRoute.hostnames | list | [] | Hostnames to match on the Ruler HTTPRoute. |
+| ruler.httpRoute.matches | list | [] | Gateway matches for the Ruler HTTPRoute rules. |
 | ruler.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Ruler HTTPRoute. |
 | ruler.ingress.annotations | object | {} | Extra annotations for the Ruler Ingress. |
 | ruler.ingress.className | string | `""` | Ingress class name for Ruler (e.g. nginx, traefik). |
@@ -1233,7 +1254,10 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.grpcRoute.parentRefs | list | [] | Gateway parentRefs for the Store Gateway GRPCRoute. |
 | storegateway.httpRoute.annotations | object | {} | Annotations for the Store Gateway HTTPRoute resource. |
 | storegateway.httpRoute.enabled | bool | `false` | Enable a Gateway API HTTPRoute for the Store Gateway HTTP endpoint. |
+| storegateway.httpRoute.extraRules | list | [] | Additional custom rules Store Gateway HTTPRoute. |
+| storegateway.httpRoute.filters | list | [] | Gateway filters for the Store Gateway HTTPRoute rules. |
 | storegateway.httpRoute.hostnames | list | [] | Hostnames to match on the Store Gateway HTTPRoute. |
+| storegateway.httpRoute.matches | list | [] | Gateway matches for the Store Gateway HTTPRoute rules. |
 | storegateway.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Store Gateway HTTPRoute. |
 | storegateway.ingress.annotations | object | {} | Deprecated. Use `storegateway.ingress.http.annotations` instead. |
 | storegateway.ingress.className | string | `""` | Deprecated. Use `storegateway.ingress.http.className` instead. |

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -710,6 +710,17 @@ spec:
     - backendRefs:
         - name: {{ include "thanos.compName" (list $root $comp) }}
           port: {{ $port }}
+      {{- with $cfg.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cfg.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with $cfg.extraRules }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/thanos/tests/gateway_api_test.yaml
+++ b/charts/thanos/tests/gateway_api_test.yaml
@@ -73,6 +73,106 @@ tests:
           path: spec.rules[0].backendRefs[0].port
           value: 9090
 
+  - it: sets matches on query HTTPRoute
+    template: query/httproute.yaml
+    set:
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+      query.httpRoute.matches:
+        - path:
+            type: PathPrefix
+            value: /
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: sets filters on query HTTPRoute
+    template: query/httproute.yaml
+    set:
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+      query.httpRoute.filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 301
+
+  - it: sets extraRules with matches on query HTTPRoute
+    template: query/httproute.yaml
+    set:
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+      query.httpRoute.matches:
+        - path:
+            type: PathPrefix
+            value: /
+      query.httpRoute.extraRules:
+        - backendRefs:
+            - name: compactor
+              port: 10902
+          matches:
+            - path:
+                type: PathPrefix
+                value: /compactor
+    asserts:
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 10902
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /compactor
+
+  - it: sets extraRules with filters on query HTTPRoute
+    template: query/httproute.yaml
+    set:
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+      query.httpRoute.extraRules:
+        - backendRefs:
+            - name: other-service
+              port: 8080
+          matches:
+            - path:
+                type: PathPrefix
+                value: /api
+          filters:
+            - type: RequestRedirect
+              requestRedirect:
+                scheme: https
+                statusCode: 301
+    asserts:
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 8080
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /api
+      - equal:
+          path: spec.rules[1].filters[0].requestRedirect.scheme
+          value: https
+      - equal:
+          path: spec.rules[1].filters[0].requestRedirect.statusCode
+          value: 301
+
   # -- Query GRPCRoute ------------------------------------------------
 
   - it: does not render query GRPCRoute when disabled
@@ -177,6 +277,77 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: sets matches on storegateway HTTPRoute
+    template: storegateway/httproute.yaml
+    set:
+      storegateway.httpRoute.enabled: true
+      storegateway.httpRoute.parentRefs:
+        - name: my-gateway
+      storegateway.httpRoute.matches:
+        - path:
+            type: PathPrefix
+            value: /storegateway
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /storegateway
+
+  - it: sets filters on storegateway HTTPRoute
+    template: storegateway/httproute.yaml
+    set:
+      storegateway.httpRoute.enabled: true
+      storegateway.httpRoute.parentRefs:
+        - name: my-gateway
+      storegateway.httpRoute.filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              - name: X-Forwarded-Proto
+                value: https
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.add[0].name
+          value: X-Forwarded-Proto
+
+  - it: sets extraRules with matches and filters on storegateway HTTPRoute
+    template: storegateway/httproute.yaml
+    set:
+      storegateway.httpRoute.enabled: true
+      storegateway.httpRoute.parentRefs:
+        - name: my-gateway
+      storegateway.httpRoute.extraRules:
+        - backendRefs:
+            - name: other-service
+              port: 8080
+          matches:
+            - path:
+                type: PathPrefix
+                value: /api
+          filters:
+            - type: RequestRedirect
+              requestRedirect:
+                scheme: https
+                statusCode: 301
+    asserts:
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 8080
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /api
+      - equal:
+          path: spec.rules[1].filters[0].requestRedirect.scheme
+          value: https
+      - equal:
+          path: spec.rules[1].filters[0].requestRedirect.statusCode
+          value: 301
 
   # -- Receive HTTPRoute ----------------------------------------------
 

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -467,6 +467,38 @@ bucket:
       # Example:
       # hostnames:
       #   - bucketweb.example.com
+      # -- Gateway matches HTTPRoute rules match conditions.
+      # @default -- []
+      matches: []
+      # Example:
+      # matches:
+      #   - path:
+      #       type: PathPrefix
+      #       value: /
+      # -- Gateway filters HTTPRoute rules filter request/response.
+      # @default -- []
+      filters: []
+      # Example:
+      # filters:
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Forwarded-Proto
+      #           value: https
+      # -- Additional custom rules for Bucketweb HTTPRoute
+      # Each item should be a complete HTTPRouteRule object with
+      # its own backendRefs, matches, filters, etc.
+      # @default -- []
+      extraRules: []
+      # Example:
+      # extraRules:
+      #   - backendRefs:
+      #       - name: other-service
+      #         port: 80
+      #     matches:
+      #       - path:
+      #           type: PathPrefix
+      #           value: /api
 
     # HorizontalPodAutoscaler configuration for Bucketweb.
     autoscaling:
@@ -707,9 +739,49 @@ compactor:
     # -- Gateway parentRefs for the Compactor HTTPRoute.
     # @default -- []
     parentRefs: []
+    # Example:
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: https
     # -- Hostnames to match on the Compactor HTTPRoute.
     # @default -- []
     hostnames: []
+    # Example:
+    # hostnames:
+    #   - compactor.example.com
+    # -- Gateway matches for the Compactor HTTPRoute rules.
+    # @default -- []
+    matches: []
+    # Example:
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    # -- Gateway filters for the Compactor HTTPRoute rules.
+    # @default -- []
+    filters: []
+    # Example:
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       add:
+    #         - name: X-Forwarded-Proto
+    #           value: https
+    # -- Additional custom rules for Compactor HTTPRoute
+    # Each item should be a complete HTTPRouteRule object with
+    # its own backendRefs, matches, filters, etc.
+    # @default -- []
+    extraRules: []
+    # Example:
+    # extraRules:
+    #   - backendRefs:
+    #       - name: other-service
+    #         port: 80
+    #     matches:
+    #       - path:
+    #           type: PathPrefix
+    #           value: /api
 
   # VerticalPodAutoscaler configuration for the Compactor.
   vpa:
@@ -1010,6 +1082,38 @@ query:
     # Example:
     # hostnames:
     #   - thanos-query.example.com
+    # -- Gateway matches for the Query HTTPRoute rules.
+    # @default -- []
+    matches: []
+    # Example:
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    # -- Gateway filters for the Query HTTPRoute rules.
+    # @default -- []
+    filters: []
+    # Example:
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       add:
+    #         - name: X-Forwarded-Proto
+    #           value: https
+    # -- Additional custom rules for Query HTTPRoute
+    # Each item should be a complete HTTPRouteRule object with
+    # its own backendRefs, matches, filters, etc.
+    # @default -- []
+    extraRules: []
+    # Example:
+    # extraRules:
+    #   - backendRefs:
+    #       - name: other-service
+    #         port: 80
+    #     matches:
+    #       - path:
+    #           type: PathPrefix
+    #           value: /api
 
   # Gateway API GRPCRoute configuration for the Query gRPC Store API.
   grpcRoute:
@@ -1285,9 +1389,49 @@ queryFrontend:
     # -- Gateway parentRefs for the Query Frontend HTTPRoute.
     # @default -- []
     parentRefs: []
+    # Example:
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: https
     # -- Hostnames to match on the Query Frontend HTTPRoute.
     # @default -- []
     hostnames: []
+    # Example:
+    # hostnames:
+    #   - query-frontend.example.com
+    # -- Gateway matches for the Query Frontend HTTPRoute rules.
+    # @default -- []
+    matches: []
+    # Example:
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    # -- Gateway filters for the Query Frontend HTTPRoute rules.
+    # @default -- []
+    filters: []
+    # Example:
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       add:
+    #         - name: X-Forwarded-Proto
+    #           value: https
+    # -- Additional custom rules for Query Frontend HTTPRoute
+    # Each item should be a complete HTTPRouteRule object with
+    # its own backendRefs, matches, filters, etc.
+    # @default -- []
+    extraRules: []
+    # Example:
+    # extraRules:
+    #   - backendRefs:
+    #      - name: other-service
+    #         port: 80
+    #     matches:
+    #       - path:
+    #           type: PathPrefix
+    #           value: /api
 
   # HorizontalPodAutoscaler configuration for the Query Frontend.
   autoscaling:
@@ -1555,9 +1699,49 @@ storegateway:
     # -- Gateway parentRefs for the Store Gateway HTTPRoute.
     # @default -- []
     parentRefs: []
+    # Example:
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: https
     # -- Hostnames to match on the Store Gateway HTTPRoute.
     # @default -- []
     hostnames: []
+    # Example:
+    # hostnames:
+    #   - storegateway.example.com
+    # -- Gateway matches for the Store Gateway HTTPRoute rules.
+    # @default -- []
+    matches: []
+    # Example:
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    # -- Gateway filters for the Store Gateway HTTPRoute rules.
+    # @default -- []
+    filters: []
+    # Example:
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       add:
+    #         - name: X-Forwarded-Proto
+    #           value: https
+    # -- Additional custom rules for Store Gateway HTTPRoute
+    # Each item should be a complete HTTPRouteRule object with
+    # its own backendRefs, matches, filters, etc.
+    # @default -- []
+    extraRules: []
+    # Example:
+    # extraRules:
+    #   - backendRefs:
+    #       - name: other-service
+    #         port: 80
+    #     matches:
+    #       - path:
+    #           type: PathPrefix
+    #           value: /api
 
   # Gateway API GRPCRoute configuration for the Store Gateway gRPC Store API.
   grpcRoute:
@@ -1930,9 +2114,49 @@ receive:
     # -- Gateway parentRefs for the Receive HTTPRoute.
     # @default -- []
     parentRefs: []
+    # Example:
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: https
     # -- Hostnames to match on the Receive HTTPRoute.
     # @default -- []
     hostnames: []
+    # Example:
+    # hostnames:
+    #   - receive.example.com
+    # -- Gateway matches for the Receive HTTPRoute rules.
+    # @default -- []
+    matches: []
+    # Example:
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    # -- Gateway filters for the Receive HTTPRoute rules.
+    # @default -- []
+    filters: []
+    # Example:
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       add:
+    #         - name: X-Forwarded-Proto
+    #           value: https
+    # -- Additional custom rules for Receive HTTPRoute
+    # Each item should be a complete HTTPRouteRule object with
+    # its own backendRefs, matches, filters, etc.
+    # @default -- []
+    extraRules: []
+    # Example:
+    # extraRules:
+    #   - backendRefs:
+    #       - name: other-service
+    #         port: 80
+    #     matches:
+    #       - path:
+    #           type: PathPrefix
+    #           value: /api
 
   # Gateway API GRPCRoute configuration for the Receive gRPC Store API.
   grpcRoute:
@@ -2255,9 +2479,49 @@ receive:
       # -- Gateway parentRefs for the Router HTTPRoute.
       # @default -- []
       parentRefs: []
+      # Example:
+      # parentRefs:
+      #   - name: my-gateway
+      #     namespace: gateway-system
+      #     sectionName: https
       # -- Hostnames to match on the Router HTTPRoute.
       # @default -- []
       hostnames: []
+      # Example:
+      # hostnames:
+      #   - receive-router.example.com
+      # -- Gateway matches for the Router HTTPRoute rules.
+      # @default -- []
+      matches: []
+      # Example:
+      # matches:
+      #   - path:
+      #       type: PathPrefix
+      #       value: /
+      # -- Gateway filters for the Router HTTPRoute rules.
+      # @default -- []
+      filters: []
+      # Example:
+      # filters:
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Forwarded-Proto
+      #           value: https
+      # -- Additional custom rules for Router HTTPRoute
+      # Each item should be a complete HTTPRouteRule object with
+      # its own backendRefs, matches, filters, etc.
+      # @default -- []
+      extraRules: []
+      # Example:
+      # extraRules:
+      #   - backendRefs:
+      #       - name: other-service
+      #         port: 80
+      #     matches:
+      #       - path:
+      #           type: PathPrefix
+      #           value: /api
 
     # VerticalPodAutoscaler configuration for the Router Deployment.
     vpa:
@@ -2563,9 +2827,49 @@ ruler:
     # -- Gateway parentRefs for the Ruler HTTPRoute.
     # @default -- []
     parentRefs: []
+    # Example:
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: https
     # -- Hostnames to match on the Ruler HTTPRoute.
     # @default -- []
     hostnames: []
+    # Example:
+    # hostnames:
+    #   - ruler.example.com
+    # -- Gateway matches for the Ruler HTTPRoute rules.
+    # @default -- []
+    matches: []
+    # Example:
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    # -- Gateway filters for the Ruler HTTPRoute rules.
+    # @default -- []
+    filters: []
+    # Example:
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       add:
+    #         - name: X-Forwarded-Proto
+    #           value: https
+    # -- Additional custom rules for Ruler HTTPRoute
+    # Each item should be a complete HTTPRouteRule object with
+    # its own backendRefs, matches, filters, etc.
+    # @default -- []
+    extraRules: []
+    # Example:
+    # extraRules:
+    #   - backendRefs:
+    #       - name: other-service
+    #         port: 80
+    #     matches:
+    #       - path:
+    #           type: PathPrefix
+    #           value: /api
 
   # -- Resource requests and limits for the Ruler container.
   # @default -- {}


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Add support for custom `matches`, `filters`, and `extraRules` config in the Thanos `HTTPRoute` templates.
In practice, `HTTPRoute` commonly needs custom `matches`, `filters`, and `extraRules` as additional rules for path routing, authentication integrations, header manipulation, redirects, and other ingress-related behaviors.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
