### PR TITLE
fix(ruler,storegateway): mount objstore config for Ruler and fix Store Gateway caching-bucket mount conflict

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.15.0
+version: 0.16.0
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -51,5 +51,7 @@ annotations:
     - name: Slack
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Store Gateway CrashLoopBackOff when storegateway.cachingBucketConfig is set, caused by mounting the caching-bucket config into the read-only objstore Secret directory
     - kind: added
-      description: Sharded Store Gateway topology (storegateway.sharded) with hash- and time-based partitioning
+      description: Ruler now mounts the global objstore Secret and is auto-wired as a Query StoreAPI endpoint

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -236,7 +236,7 @@ query:
     - prometheus_replica
     - receive_replica
 
-  # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway) are auto-wired
+  # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway, Ruler) are auto-wired
   # when autogen.enabled is true. Endpoints defined in static[] are always appended; set
   # autogen.enabled to false to take full control of what endpoint arguments are passed.
   endpoints:
@@ -763,7 +763,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.containerSecurityContext | object | {} | Container security context for Query. Overrides global.containerSecurityContext. |
 | query.dnsConfig | object | {} | DNS configuration for Query pods. Overrides global.dnsConfig. |
 | query.enabled | bool | `true` | Enable the Query Deployment. |
-| query.endpoints.autogen.enabled | bool | `true` | Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway). These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format. |
+| query.endpoints.autogen.enabled | bool | `true` | Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway, Ruler). These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format. |
 | query.endpoints.static | list | [] | Optional static endpoint arguments. When non-empty will be added as extra endpoints. When `query.endpoints.autogen.enabled` is `false`, these will give you full control over the endpoints. |
 | query.extraArgs[0] | string | `"--log.level=info"` |  |
 | query.extraContainers | list | [] | Extra sidecar containers for Query pods. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -224,7 +224,7 @@ query:
     - prometheus_replica
     - receive_replica
 
-  # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway) are auto-wired
+  # gRPC --endpoint arguments. The in-chart components (Receive, Store Gateway, Ruler) are auto-wired
   # when autogen.enabled is true. Endpoints defined in static[] are always appended; set
   # autogen.enabled to false to take full control of what endpoint arguments are passed.
   endpoints:

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -49,6 +49,9 @@ spec:
           {{- if .Values.receive.enabled }}
             - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.receiveHeadless" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
+          {{- if .Values.ruler.enabled }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "ruler") }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+          {{- end }}
         {{- end }}
           {{- range .Values.query.endpoints.static }}
             - --endpoint={{ . }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
             - --http-address=0.0.0.0:{{ .Values.ruler.service.httpPort }}
             - --grpc-address=0.0.0.0:{{ .Values.ruler.service.grpcPort }}
             - --data-dir=/var/thanos/ruler
+            - --objstore.config-file=/etc/thanos/objstore.yml
             - --rule-file=/etc/thanos/rules/*.yaml
           {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
             - --rule-file=/etc/thanos/rules/generated/*.yaml
@@ -66,6 +67,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/thanos/ruler
+            - name: objstore
+              mountPath: /etc/thanos/objstore.yml
+              subPath: objstore.yml
+              readOnly: true
             - name: rules
               mountPath: /etc/thanos/rules
           {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
@@ -105,6 +110,12 @@ spec:
       {{- include "thanos.tolerations" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       {{- include "thanos.topologySpreadConstraints" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       volumes:
+        - name: objstore
+          secret:
+            secretName: {{ .Values.global.objstore.secretName }}
+            items:
+              - key: {{ .Values.global.objstore.secretKey }}
+                path: objstore.yml
         - name: rules
           configMap:
             name: {{ include "thanos.compName" (list . "ruler") }}-rules

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -84,7 +84,8 @@ spec:
             - name: data
               mountPath: /var/thanos/store
             - name: objstore
-              mountPath: /etc/thanos
+              mountPath: /etc/thanos/objstore.yml
+              subPath: objstore.yml
               readOnly: true
             {{- if $.Values.storegateway.cachingBucketConfig }}
             - name: caching-bucket

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -76,10 +76,50 @@ tests:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: false
+      ruler.enabled: false
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[3]
           pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*storegateway.*"
+
+  - it: adds store endpoints for ruler when enabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: false
+      receive.enabled: false
+      ruler.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[3]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*ruler-headless.*"
+
+  - it: does not add a ruler endpoint when ruler is disabled
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: true
+      receive.enabled: true
+      ruler.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-ruler-headless.NAMESPACE.svc.cluster.local
+
+  - it: targets the ruler headless service with namespace and cluster domain
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      storegateway.enabled: false
+      receive.enabled: false
+      ruler.enabled: true
+      global.clusterDomain: custom.internal
+    release:
+      namespace: monitoring
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-ruler-headless.monitoring.svc.custom.internal
 
   - it: renders --endpoint args from query.endpoints.static when autogen disabled
     template: query/deployment.yaml
@@ -97,12 +137,13 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --endpoint=store.example.com:10901
 
-  - it: static endpoints replace auto-wired storegateway and receive endpoints
+  - it: static endpoints replace auto-wired storegateway, receive, and ruler endpoints
     template: query/deployment.yaml
     set:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: true
+      ruler.enabled: true
       query.endpoints.autogen.enabled: false
       query.endpoints.static:
         - external.example.com:10901
@@ -116,6 +157,9 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[4]
           pattern: "--endpoint=dnssrv\\+_grpc\\._tcp\\..*receive.*"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[4]
+          pattern: "--endpoint=dnssrv\\+_grpc\\._tcp\\..*ruler.*"
 
   - it: renders static endpoints alongside auto-wired endpoints when autogen enabled
     template: query/deployment.yaml
@@ -123,6 +167,7 @@ tests:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: true
+      ruler.enabled: true
       query.endpoints.autogen.enabled: true
       query.endpoints.static:
         - external.example.com:10901
@@ -133,8 +178,11 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[4]
           pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*receive.*"
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].args[5]
+          pattern: "^--endpoint=dnssrv\\+_grpc\\._tcp\\..*ruler-headless.*"
+      - equal:
+          path: spec.template.spec.containers[0].args[6]
           value: --endpoint=external.example.com:10901
 
   - it: renders no --endpoint args when autogen disabled and static empty
@@ -143,6 +191,7 @@ tests:
       query.enabled: true
       storegateway.enabled: true
       receive.enabled: true
+      ruler.enabled: true
       query.endpoints.autogen.enabled: false
       query.endpoints.static: []
     asserts:

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -89,6 +89,77 @@ tests:
             name: data
             emptyDir: {}
 
+  - it: configures object storage from global objstore secret
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      global.objstore.secretName: thanos-ruler-objstore
+      global.objstore.secretKey: objstore.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --objstore.config-file=/etc/thanos/objstore.yml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: objstore
+            mountPath: /etc/thanos/objstore.yml
+            subPath: objstore.yml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: objstore
+            secret:
+              secretName: thanos-ruler-objstore
+              items:
+                - key: objstore.yaml
+                  path: objstore.yml
+
+  - it: mounts the objstore secret using the global defaults
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: objstore
+            secret:
+              secretName: thanos-objstore
+              items:
+                - key: objstore.yml
+                  path: objstore.yml
+
+  - it: mounts the objstore secret via subPath so it does not overlay /etc/thanos
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      # objstore, rules, alertmanagers and query-urls must all coexist under
+      # /etc/thanos, so objstore is a file-level (subPath) mount, never a
+      # read-only overlay of the whole directory (see issue #152).
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: objstore
+            mountPath: /etc/thanos/objstore.yml
+            subPath: objstore.yml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rules
+            mountPath: /etc/thanos/rules
+
+  - it: restarts pods on objstore config change via checksum annotation
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/objstore-configuration"]
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -1112,6 +1112,45 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: mounts the objstore secret via subPath so it does not overlay /etc/thanos
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: objstore
+            mountPath: /etc/thanos/objstore.yml
+            subPath: objstore.yml
+            readOnly: true
+
+  - it: mounts the caching bucket config alongside objstore without a mount conflict
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.cachingBucketConfig: |
+        type: IN-MEMORY
+        config:
+          max_size: 8GB
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--store.caching-bucket.config-file=/etc/thanos/caching-bucket.yaml"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: objstore
+            mountPath: /etc/thanos/objstore.yml
+            subPath: objstore.yml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: caching-bucket
+            mountPath: /etc/thanos/caching-bucket.yaml
+            subPath: caching-bucket.yaml
+
   # -- NetworkPolicy -------------------------------------------------------
 
   - it: does not render networkpolicy when networkPolicies is disabled

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2482,11 +2482,11 @@
           "properties": {
             "autogen": {
               "additionalProperties": true,
-              "description": "Auto-generated endpoints for the in-chart components (Receive, Store Gateway).",
+              "description": "Auto-generated endpoints for the in-chart components (Receive, Store Gateway, Ruler).",
               "properties": {
                 "enabled": {
                   "default": true,
-                  "description": "Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway).\nThese use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.",
+                  "description": "Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway, Ruler).\nThese use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.",
                   "required": [],
                   "title": "enabled",
                   "type": "boolean"

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1144,9 +1144,9 @@ query:
 
   # Configuration for the --endpoint arguments passed to thanos query.
   endpoints:
-    # Auto-generated endpoints for the in-chart components (Receive, Store Gateway).
+    # Auto-generated endpoints for the in-chart components (Receive, Store Gateway, Ruler).
     autogen:
-      # -- Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway).
+      # -- Auto-generate endpoint arguments for the in-chart components (Receive, Store Gateway, Ruler).
       # These use the dnssrv+_grpc._tcp.<svc>.<namespace>.svc.<cluster-domain> format.
       enabled: true
     # -- Optional static endpoint arguments. When non-empty will be added as extra endpoints.


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR addresses two object-store mount issues in the chart, and supersedes #138.

**1. Ruler object storage configuration (#136)**

The Ruler StatefulSet did not configure object storage for `thanos rule`, so recording-rule results could not be uploaded as TSDB blocks or queried back through StoreAPI. This brings the Ruler in line with the other object-store-backed components:

- Pass `--objstore.config-file=/etc/thanos/objstore.yml` to the Ruler container.
- Mount the global objstore Secret into the Ruler pod using `global.objstore.secretName` / `global.objstore.secretKey`.
- Auto-wire the Ruler as a Query StoreAPI endpoint when `query.endpoints.autogen.enabled=true`.

**2. Store Gateway caching-bucket mount conflict (#152)**

Setting `storegateway.cachingBucketConfig` caused the Store Gateway pods to `CrashLoopBackOff` with a runc `not a directory` error. The objstore Secret was mounted read-only over the whole `/etc/thanos` directory, so kubelet could not bind-mount `caching-bucket.yaml` into that read-only projection. Fixed by mounting the objstore Secret with `subPath: objstore.yml` at `/etc/thanos/objstore.yml` instead of overlaying the directory, leaving `/etc/thanos` writable for the caching-bucket mount (suggested fix #1 from the issue).

Unit tests are added/updated for the Ruler objstore mount, the new Query endpoint, and the Store Gateway mount layout; values and README documentation are updated.

#### Which issue this PR fixes

- fixes #136
- fixes #152

#### Special notes for your reviewer:

This supersedes #138 by @r0bj, which implemented the Ruler objstore changes (#136). This PR carries those changes forward and additionally fixes the Store Gateway caching-bucket mount conflict (#152). Thanks to @r0bj for the original work.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
