### PR TITLE
fix(receive): set router external label in split mode

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.16.0
+version: 0.16.1
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -52,6 +52,4 @@ annotations:
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
     - kind: fixed
-      description: Store Gateway CrashLoopBackOff when storegateway.cachingBucketConfig is set, caused by mounting the caching-bucket config into the read-only objstore Secret directory
-    - kind: added
-      description: Ruler now mounts the global objstore Secret and is auto-wired as a Query StoreAPI endpoint
+      description: Receive Router CrashLoopBackOff in split mode caused by missing uniquely-identifying external labels; the Router now sets --label=receive_router_replica

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -55,6 +55,7 @@ spec:
             - --receive.hashrings-file=/etc/thanos/hashrings.json
             - --receive.hashrings-algorithm=ketama
             - --receive.replication-factor={{ $rt.replicationFactor | default 1 }}
+            - --label=receive_router_replica="$(POD_NAME)"
             {{- if $cfg.tenancyHeader }}
             - --receive.tenant-header={{ $cfg.tenancyHeader }}
             {{- end }}

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -1415,6 +1415,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --receive.replication-factor=1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --label=receive_router_replica="$(POD_NAME)"
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --tsdb.path=/var/thanos/receive


### PR DESCRIPTION
#### What this PR does / why we need it:

In `split` mode the Receive Router started with no external labels and crashed on boot:

> no external labels configured for receive, uniquely identifying external labels must be configured (ideally with `receive_` prefix); see https://thanos.io/tip/thanos/storage.md#external-labels for details.

The Router now passes `--label=receive_router_replica="$(POD_NAME)"`, mirroring the Ingester's `receive_replica` label, so it has a uniquely identifying external label and starts cleanly.

#### Which issue this PR fixes

- fixes #147

#### Special notes for your reviewer:

- Chart version bumped `0.16.0` → `0.16.1`.
- Overlaps `Chart.yaml`/`README.md` with #135 (feat: minReadySeconds); whichever merges second will need a quick version rebase.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md