### PR TITLE
feat(thanos): support minReadySeconds on StatefulSet components

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.16.1
+version: 0.17.0
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -51,5 +51,5 @@ annotations:
     - name: Slack
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Receive Router CrashLoopBackOff in split mode caused by missing uniquely-identifying external labels; the Router now sets --label=receive_router_replica
+    - kind: added
+      description: Support configuring spec.minReadySeconds on the Receive, Ruler, Store Gateway and Compactor StatefulSets

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -604,6 +604,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | compactor.ingress.tls | list | [] | TLS configuration for the Compactor Ingress. |
 | compactor.labels | object | {} | Extra labels applied to Compactor resources. |
+| compactor.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created Compactor Pod must be Running and Ready, without any container crashing, before it is considered available during a rolling update (StatefulSet `spec.minReadySeconds`). Defaults to 0 (available as soon as Ready); the field is omitted when 0. See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds |
 | compactor.nodeSelector | object | {} | Node selector for Compactor pod scheduling. |
 | compactor.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the Compactor. |
 | compactor.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Compactor pods during a disruption. |
@@ -987,6 +988,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.ingress.remoteWrite.tls | list | [] | TLS configuration for the Receive remote-write Ingress. |
 | receive.ingress.tls | list | [] | Deprecated. Use `receive.ingress.http.tls` instead. |
 | receive.labels | object | {} | Extra labels applied to Receive resources. |
+| receive.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created Receive Pod must be Running and Ready, without any container crashing, before it is considered available during a rolling update (StatefulSet `spec.minReadySeconds`). Defaults to 0 (available as soon as Ready); the field is omitted when 0. In `split` mode set `receive.ingester.minReadySeconds` instead. See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds |
 | receive.mode | string | `"standalone"` | Receive deployment topology. One of: `standalone` — single workload that both routes and ingests (RouterIngestor mode); `split` — separate Router (Deployment) and Ingester (StatefulSet) workloads, following the receive split proposal (https://thanos.io/tip/proposals-accepted/202012-receive-split.md).  Field shape depends on mode:   - `standalone`: configure the workload directly via top-level `receive.*`     fields (replicaCount, tsdb, service, persistence, etc.). `receive.ingester`     and `receive.router` are ignored.   - `split`: configure each workload via `receive.ingester.*` and     `receive.router.*`. Top-level `receive.*` fields are ignored. The schema     requires both `ingester` and `router` to be populated in this mode. |
 | receive.nodeSelector | object | {} | Node selector for Receive pod scheduling. |
 | receive.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Receive. |
@@ -1169,6 +1171,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ruler.ingress.tls | list | [] | TLS configuration for the Ruler Ingress. |
 | ruler.labels | object | {} | Extra labels applied to Ruler resources. |
+| ruler.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created Ruler Pod must be Running and Ready, without any container crashing, before it is considered available during a rolling update (StatefulSet `spec.minReadySeconds`). Defaults to 0 (available as soon as Ready); the field is omitted when 0. See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds |
 | ruler.nodeSelector | object | {} | Node selector for Ruler pod scheduling. |
 | ruler.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the Ruler. |
 | ruler.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Ruler pods during a disruption. |
@@ -1281,6 +1284,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.ingress.http.tls | list | [] | TLS configuration for the Store Gateway HTTP Ingress. |
 | storegateway.ingress.tls | list | [] | Deprecated. Use `storegateway.ingress.http.tls` instead. |
 | storegateway.labels | object | {} | Extra labels applied to Store Gateway resources. |
+| storegateway.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created Store Gateway Pod must be Running and Ready, without any container crashing, before it is considered available during a rolling update (StatefulSet `spec.minReadySeconds`). Defaults to 0 (available as soon as Ready); the field is omitted when 0. See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds |
 | storegateway.nodeSelector | object | {} | Node selector for Store Gateway pod scheduling. |
 | storegateway.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the Store Gateway. |
 | storegateway.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Store Gateway pods during a disruption. |

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -16,6 +16,9 @@ metadata:
 spec:
   serviceName: {{ include "thanos.compName" (list . "compactor") }}
   replicas: {{ .Values.compactor.replicaCount }}
+  {{- if .Values.compactor.minReadySeconds }}
+  minReadySeconds: {{ .Values.compactor.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: compactor

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -18,6 +18,9 @@ metadata:
 spec:
   serviceName: {{ include "thanos.receiveHeadless" . }}
   replicas: {{ $cfg.replicaCount }}
+  {{- if $cfg.minReadySeconds }}
+  minReadySeconds: {{ $cfg.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: receive

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -16,6 +16,9 @@ metadata:
 spec:
   serviceName: {{ include "thanos.compName" (list . "ruler") }}
   replicas: {{ .Values.ruler.replicaCount }}
+  {{- if .Values.ruler.minReadySeconds }}
+  minReadySeconds: {{ .Values.ruler.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: ruler

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -21,6 +21,9 @@ metadata:
 spec:
   serviceName: {{ include "thanos.compName" (list $ "storegateway") }}
   replicas: {{ $.Values.storegateway.replicaCount }}
+  {{- if $.Values.storegateway.minReadySeconds }}
+  minReadySeconds: {{ $.Values.storegateway.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: storegateway

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -32,6 +32,25 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: renders minReadySeconds when set
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.minReadySeconds: 30
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 30
+
+  - it: omits minReadySeconds when zero
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.minReadySeconds: 0
+    asserts:
+      - notExists:
+          path: spec.minReadySeconds
+
   - it: uses the global image repository and tag
     template: compactor/statefulset.yaml
     set:

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -32,6 +32,25 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: renders minReadySeconds when set
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.minReadySeconds: 30
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 30
+
+  - it: omits minReadySeconds when zero
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.minReadySeconds: 0
+    asserts:
+      - notExists:
+          path: spec.minReadySeconds
+
   - it: uses the global image repository and tag
     template: receive/statefulset.yaml
     set:
@@ -1288,6 +1307,17 @@ tests:
       - equal:
           path: spec.serviceName
           value: RELEASE-NAME-thanos-receive-ingester-headless
+
+  - it: renders ingester minReadySeconds in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.minReadySeconds: 45
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 45
 
   - it: omits router-only flags from the StatefulSet args in split mode
     template: receive/statefulset.yaml

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -32,6 +32,25 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: renders minReadySeconds when set
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.minReadySeconds: 30
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 30
+
+  - it: omits minReadySeconds when zero
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.minReadySeconds: 0
+    asserts:
+      - notExists:
+          path: spec.minReadySeconds
+
   - it: uses the global image repository and tag
     template: ruler/statefulset.yaml
     set:

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -32,6 +32,25 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: renders minReadySeconds when set
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.minReadySeconds: 30
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 30
+
+  - it: omits minReadySeconds when zero
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.minReadySeconds: 0
+    asserts:
+      - notExists:
+          path: spec.minReadySeconds
+
   - it: uses the global image repository and tag
     template: storegateway/statefulset.yaml
     set:

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -1452,6 +1452,13 @@
           "title": "probes",
           "type": "object"
         },
+        "minReadySeconds": {
+          "default": 0,
+          "description": "Minimum number of seconds for which a newly created Compactor Pod must be\nRunning and Ready, without any container crashing, before it is considered\navailable during a rolling update (StatefulSet `spec.minReadySeconds`).\nDefaults to 0 (available as soon as Ready); the field is omitted when 0.\nSee https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds",
+          "required": [],
+          "title": "minReadySeconds",
+          "type": "integer"
+        },
         "replicaCount": {
           "default": 1,
           "description": "Number of Compactor replicas. Must remain 1 — running multiple\ncompactors against the same bucket causes data corruption.",
@@ -1711,6 +1718,7 @@
       "required": [
         "enabled",
         "replicaCount",
+        "minReadySeconds",
         "persistence",
         "service",
         "ingress",
@@ -5346,6 +5354,13 @@
           "title": "probes",
           "type": "object"
         },
+        "minReadySeconds": {
+          "default": 0,
+          "description": "Minimum number of seconds for which a newly created Receive Pod must be\nRunning and Ready, without any container crashing, before it is considered\navailable during a rolling update (StatefulSet `spec.minReadySeconds`).\nDefaults to 0 (available as soon as Ready); the field is omitted when 0.\nIn `split` mode set `receive.ingester.minReadySeconds` instead.\nSee https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds",
+          "required": [],
+          "title": "minReadySeconds",
+          "type": "integer"
+        },
         "replicaCount": {
           "default": 3,
           "description": "Number of Receive pod replicas. Minimum 3 is recommended for\nreplication factor 2 (write quorum = floor(replicaCount/2)+1).",
@@ -5655,6 +5670,7 @@
         "enabled",
         "mode",
         "replicaCount",
+        "minReadySeconds",
         "tenancyHeader",
         "tsdb",
         "hashrings",
@@ -6440,6 +6456,13 @@
           "title": "query",
           "type": "object"
         },
+        "minReadySeconds": {
+          "default": 0,
+          "description": "Minimum number of seconds for which a newly created Ruler Pod must be\nRunning and Ready, without any container crashing, before it is considered\navailable during a rolling update (StatefulSet `spec.minReadySeconds`).\nDefaults to 0 (available as soon as Ready); the field is omitted when 0.\nSee https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds",
+          "required": [],
+          "title": "minReadySeconds",
+          "type": "integer"
+        },
         "replicaCount": {
           "default": 2,
           "description": "Number of Ruler pod replicas. Multiple replicas require consistent\nrule distribution to avoid duplicate alerts.",
@@ -6636,6 +6659,7 @@
       "required": [
         "enabled",
         "replicaCount",
+        "minReadySeconds",
         "query",
         "alertmanagers",
         "alertQueryUrl",
@@ -7678,6 +7702,13 @@
           "title": "probes",
           "type": "object"
         },
+        "minReadySeconds": {
+          "default": 0,
+          "description": "Minimum number of seconds for which a newly created Store Gateway Pod must\nbe Running and Ready, without any container crashing, before it is considered\navailable during a rolling update (StatefulSet `spec.minReadySeconds`).\nDefaults to 0 (available as soon as Ready); the field is omitted when 0.\nSee https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds",
+          "required": [],
+          "title": "minReadySeconds",
+          "type": "integer"
+        },
         "replicaCount": {
           "default": 2,
           "description": "Number of Store Gateway pod replicas. Two or more is recommended for HA.",
@@ -7914,6 +7945,7 @@
       "required": [
         "enabled",
         "replicaCount",
+        "minReadySeconds",
         "sharded",
         "service",
         "ingress",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -688,6 +688,13 @@ compactor:
   # compactors against the same bucket causes data corruption.
   replicaCount: 1
 
+  # -- Minimum number of seconds for which a newly created Compactor Pod must be
+  # Running and Ready, without any container crashing, before it is considered
+  # available during a rolling update (StatefulSet `spec.minReadySeconds`).
+  # Defaults to 0 (available as soon as Ready); the field is omitted when 0.
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds
+  minReadySeconds: 0
+
   # PersistentVolumeClaim configuration for the Compactor working directory.
   persistence:
     # -- Enable a PersistentVolumeClaim for the Compactor working directory.
@@ -1618,6 +1625,13 @@ storegateway:
   # In sharded mode this is the replica count *per shard*.
   replicaCount: 2
 
+  # -- Minimum number of seconds for which a newly created Store Gateway Pod must
+  # be Running and Ready, without any container crashing, before it is considered
+  # available during a rolling update (StatefulSet `spec.minReadySeconds`).
+  # Defaults to 0 (available as soon as Ready); the field is omitted when 0.
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds
+  minReadySeconds: 0
+
   # Sharded Store Gateway topology. When enabled, the chart renders one
   # StatefulSet per shard (named `<fullname>-storegateway-<index>`) so that each
   # shard serves a subset of the object-storage blocks instead of every replica
@@ -2014,6 +2028,14 @@ receive:
   # In `split` mode this controls the Ingester StatefulSet replica count.
   replicaCount: 3
 
+  # -- Minimum number of seconds for which a newly created Receive Pod must be
+  # Running and Ready, without any container crashing, before it is considered
+  # available during a rolling update (StatefulSet `spec.minReadySeconds`).
+  # Defaults to 0 (available as soon as Ready); the field is omitted when 0.
+  # In `split` mode set `receive.ingester.minReadySeconds` instead.
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds
+  minReadySeconds: 0
+
   # -- Optional HTTP header name used to segregate tenants in multi-tenant setups.
   # When set, Receive routes write requests to the correct tenant shard based on this header.
   tenancyHeader: ""
@@ -2406,7 +2428,7 @@ receive:
   # schema requires it to be populated when mode=split.
   #
   # The accepted shape mirrors the top-level `receive.*` fields
-  # (replicaCount, tsdb, hashrings, service, ingress, httpRoute, grpcRoute,
+  # (replicaCount, minReadySeconds, tsdb, hashrings, service, ingress, httpRoute, grpcRoute,
   # vpa, persistence, resources, extraArgs, podSecurityContext,
   # containerSecurityContext, dnsConfig, extraEnv, extraEnvFrom,
   # extraInitContainers, extraContainers, probes, nodeSelector, tolerations,
@@ -2748,6 +2770,13 @@ ruler:
   # -- Number of Ruler pod replicas. Multiple replicas require consistent
   # rule distribution to avoid duplicate alerts.
   replicaCount: 2
+
+  # -- Minimum number of seconds for which a newly created Ruler Pod must be
+  # Running and Ready, without any container crashing, before it is considered
+  # available during a rolling update (StatefulSet `spec.minReadySeconds`).
+  # Defaults to 0 (available as soon as Ready); the field is omitted when 0.
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds
+  minReadySeconds: 0
 
   # Query endpoint configuration used by the Ruler to evaluate rules.
   query:


### PR DESCRIPTION
#### What this PR does / why we need it:

Exposes a `minReadySeconds` value for the StatefulSet-based components (Receive, Ruler, Store Gateway and Compactor) that renders `spec.minReadySeconds` on the corresponding StatefulSet:

```yaml
receive:
  minReadySeconds: 30
storegateway:
  minReadySeconds: 30
ruler:
  minReadySeconds: 30
```

During a rolling update the StatefulSet controller waits this many seconds with the new Pod Running and Ready before proceeding to the next, making rollouts of stateful Thanos workloads more conservative. Defaults to `0` (unchanged behaviour); the field is omitted from the manifest when `0`. In Receive `split` mode set `receive.ingester.minReadySeconds`.

#### Which issue this PR fixes

- fixes #135

#### Special notes for your reviewer:

- `values.schema.json` was hand-edited (the schema is hand-maintained — `helm schema` regeneration drops existing hand-crafted constraints), mirroring the existing `replicaCount` integer entries.
- Chart version bumped `0.16.0` → `0.17.0`.
- Overlaps `Chart.yaml`/`README.md` with #147 (fix: router external label); whichever merges second will need a quick version rebase.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md