### PR TITLE
feat(thanos): add podLabels for all components

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.17.0
+version: 0.18.0
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -52,4 +52,4 @@ annotations:
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
     - kind: added
-      description: Support configuring spec.minReadySeconds on the Receive, Ruler, Store Gateway and Compactor StatefulSets
+      description: Per-component podLabels to set extra labels on pods (e.g. for workload identity), rendered via a shared thanos.podLabels helper for all workloads (bucketweb, compactor, query, query-frontend, store gateway, receive, receive ingester/router, ruler)

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -535,6 +535,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Bucketweb pods during a disruption. |
 | bucket.bucketweb.pdb.minAvailable | int or string | `""` | Minimum available Bucketweb pods during a disruption. |
 | bucket.bucketweb.persistence | object | {} | Storage configuration for Bucketweb. Bucketweb is stateless; leave empty. |
+| bucket.bucketweb.podLabels | object | {} | Extra labels applied to Bucketweb pods (e.g. for workload identity). |
 | bucket.bucketweb.podSecurityContext | object | {} | Pod security context for Bucketweb. Overrides global.podSecurityContext. |
 | bucket.bucketweb.priorityClassName | string | `""` | Priority class name for Bucketweb pods. |
 | bucket.bucketweb.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Bucketweb. |
@@ -613,6 +614,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Compactor working directory. |
 | compactor.persistence.size | string | `"10Gi"` | Storage capacity for the Compactor PVC (used as a scratch space during compaction). |
 | compactor.persistence.storageClass | string | `""` | StorageClass name for the Compactor PVC. Empty uses the cluster default. |
+| compactor.podLabels | object | {} | Extra labels applied to Compactor pods (e.g. for workload identity). |
 | compactor.podSecurityContext.fsGroup | int | `1000` |  |
 | compactor.podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
 | compactor.priorityClassName | string | `""` | Priority class name for Compactor pods. |
@@ -810,6 +812,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Query. |
 | query.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Query pods during a disruption. |
 | query.pdb.minAvailable | int or string | `""` | Minimum available Query pods during a disruption. |
+| query.podLabels | object | {} | Extra labels applied to Query pods (e.g. for workload identity). |
 | query.podSecurityContext | object | {} | Pod security context for Query pods. Overrides global.podSecurityContext. |
 | query.priorityClassName | string | `""` | Priority class name for Query pods. |
 | query.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Query. |
@@ -892,6 +895,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Query Frontend. |
 | queryFrontend.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Query Frontend pods during a disruption. |
 | queryFrontend.pdb.minAvailable | int or string | `""` | Minimum available Query Frontend pods during a disruption. |
+| queryFrontend.podLabels | object | {} | Extra labels applied to Query Frontend pods (e.g. for workload identity). |
 | queryFrontend.podSecurityContext | object | {} | Pod security context for Query Frontend pods. Overrides global.podSecurityContext. |
 | queryFrontend.priorityClassName | string | `""` | Priority class name for Query Frontend pods. |
 | queryFrontend.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Query Frontend. |
@@ -998,6 +1002,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Receive TSDB WAL. |
 | receive.persistence.size | string | `"10Gi"` | Storage capacity for the Receive PVC. Should be sized to hold at least `tsdb.retention` worth of data. |
 | receive.persistence.storageClass | string | `""` | StorageClass name for the Receive PVC. Empty uses the cluster default. |
+| receive.podLabels | object | {} | Extra labels applied to Receive pods (e.g. for workload identity). In split mode this applies to the Ingester; set `receive.ingester.podLabels` and `receive.router.podLabels` to target each workload independently. |
 | receive.podSecurityContext.fsGroup | int | `1000` |  |
 | receive.podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
 | receive.priorityClassName | string | `""` | Priority class name for Receive pods. |
@@ -1061,6 +1066,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for Router. |
 | receive.router.pdb.maxUnavailable | int or string | `""` | Maximum unavailable Router pods during a disruption. |
 | receive.router.pdb.minAvailable | int or string | `""` | Minimum available Router pods during a disruption. |
+| receive.router.podLabels | object | {} | Extra labels applied to Router pods (e.g. for workload identity). |
 | receive.router.podSecurityContext | object | {} | Pod security context for Router pods. Falls back to receive.podSecurityContext, then global.podSecurityContext. |
 | receive.router.priorityClassName | string | `""` | Priority class name for Router pods. Falls back to receive.priorityClassName. |
 | receive.router.probes.liveness.enabled | bool | `true` | Enable the liveness probe for Router. |
@@ -1180,6 +1186,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ruler data directory. |
 | ruler.persistence.size | string | `"10Gi"` | Storage capacity for the Ruler PVC. |
 | ruler.persistence.storageClass | string | `""` | StorageClass name for the Ruler PVC. Empty uses the cluster default. |
+| ruler.podLabels | object | {} | Extra labels applied to Ruler pods (e.g. for workload identity). |
 | ruler.podSecurityContext.fsGroup | int | `1000` |  |
 | ruler.podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
 | ruler.priorityClassName | string | `""` | Priority class name for Ruler pods. |
@@ -1293,6 +1300,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Store Gateway index cache and chunk store. |
 | storegateway.persistence.size | string | `"10Gi"` | Storage capacity for the Store Gateway PVC. |
 | storegateway.persistence.storageClass | string | `""` | StorageClass name for the Store Gateway PVC. Empty uses the cluster default. |
+| storegateway.podLabels | object | {} | Extra labels applied to Store Gateway pods (e.g. for workload identity). |
 | storegateway.podSecurityContext.fsGroup | int | `1000` |  |
 | storegateway.podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
 | storegateway.priorityClassName | string | `""` | Priority class name for Store Gateway pods. |

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -99,6 +99,31 @@ securityContext:
 {{- end }}
 
 {{- /*
+Render extra pod labels for a component with component → (optional parent) fallback.
+Returns the labels as YAML (no leading newline); empty when none are set.
+Usage:
+  {{- include "thanos.podLabels" (dict "root" . "key" "compactor") | nindent 8 }}
+  {{- include "thanos.podLabels" (dict "root" . "key" "ingester" "parent" "receive") | nindent 8 }}
+*/ -}}
+{{- define "thanos.podLabels" -}}
+{{- $root := .root -}}
+{{- $key := .key -}}
+{{- $parent := .parent | default "" -}}
+{{- $par := dict -}}
+{{- $comp := dict -}}
+{{- if $parent -}}
+{{- $par = index $root.Values $parent | default dict -}}
+{{- $comp = index $par $key | default dict -}}
+{{- else -}}
+{{- $comp = index $root.Values $key | default dict -}}
+{{- end -}}
+{{- $podLabels := $comp.podLabels | default $par.podLabels -}}
+{{- with $podLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- /*
 Render dnsConfig with component → (optional parent) → global fallback.
 Usage:
   {{ include "thanos.dnsConfig" (dict "Values" .Values "component" "compactor") }}

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucketweb
+        {{- include "thanos.podLabels" (dict "root" $ctx "key" "bucketweb") | nindent 8 }}
       annotations:
         {{- with .Values.global.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: compactor
+        {{- include "thanos.podLabels" (dict "root" . "key" "compactor") | nindent 8 }}
       annotations:
         checksum/objstore-configuration: {{ .Values.global.objstore.config | sha256sum }}
         {{- with .Values.global.podAnnotations }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query-frontend
+        {{- include "thanos.podLabels" (dict "root" . "key" "queryFrontend") | nindent 8 }}
       annotations:
         {{- with .Values.global.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query
+        {{- include "thanos.podLabels" (dict "root" . "key" "query") | nindent 8 }}
       annotations:
         {{- with .Values.global.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{- with $rt.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "thanos.podLabels" (dict "root" . "key" "router" "parent" "receive") | nindent 8 }}
       annotations:
         {{- $anns := dict -}}
         {{- if .Values.global.podAnnotations }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: receive
+        {{- include "thanos.podLabels" (dict "root" . "key" "ingester" "parent" "receive") | nindent 8 }}
       annotations:
         {{- $anns := dict -}}
         {{- if .Values.global.podAnnotations }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: ruler
+        {{- include "thanos.podLabels" (dict "root" . "key" "ruler") | nindent 8 }}
       annotations:
         checksum/objstore-configuration: {{ .Values.global.objstore.config | sha256sum }}
         {{- with .Values.global.podAnnotations }}

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
         {{- if $shard.isSharded }}
         thanos.io/storegateway-shard: {{ $shard.index | quote }}
         {{- end }}
+        {{- include "thanos.podLabels" (dict "root" $ "key" "storegateway") | nindent 8 }}
       annotations:
         checksum/objstore-configuration: {{ $.Values.global.objstore.config | sha256sum }}
         {{- with $.Values.global.podAnnotations }}

--- a/charts/thanos/tests/bucketweb_test.yaml
+++ b/charts/thanos/tests/bucketweb_test.yaml
@@ -94,6 +94,20 @@ tests:
           path: metadata.labels.custom-label
           value: my-value
 
+  - it: applies pod labels to the pod template only
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -179,6 +179,19 @@ tests:
           path: metadata.labels.custom-label
           value: my-value
 
+  - it: applies pod labels to the pod template only
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv

--- a/charts/thanos/tests/query_frontend_test.yaml
+++ b/charts/thanos/tests/query_frontend_test.yaml
@@ -98,6 +98,19 @@ tests:
           path: metadata.labels.custom-label
           value: my-value
 
+  - it: applies pod labels to the pod template only
+    template: query-frontend/deployment.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv

--- a/charts/thanos/tests/query_test.yaml
+++ b/charts/thanos/tests/query_test.yaml
@@ -246,6 +246,19 @@ tests:
           path: metadata.labels.custom-label
           value: my-value
 
+  - it: applies pod labels to the pod template only
+    template: query/deployment.yaml
+    set:
+      query.enabled: true
+      query.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -130,6 +130,19 @@ tests:
           path: metadata.labels.custom-label
           value: my-value
 
+  - it: applies pod labels to the pod template only in standalone mode
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv
@@ -1428,6 +1441,42 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: applies ingester pod labels to the ingester pod template in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.podLabels:
+        role: ingester
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.role
+          value: ingester
+
+  - it: falls back to receive.podLabels for the ingester in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.podLabels:
+        tier: write
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.tier
+          value: write
+
+  - it: applies router pod labels to the router pod template in split mode
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.podLabels:
+        role: router
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.role
+          value: router
 
   - it: renders the router deployment in split mode
     template: receive/split/router-deployment.yaml

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -203,6 +203,19 @@ tests:
           path: metadata.labels.team
           value: alerting
 
+  - it: applies pod labels to the pod template only
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   # -- Extra env vars -------------------------------------------------
 
   - it: injects component extraEnv

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -99,6 +99,19 @@ tests:
           path: metadata.labels.team
           value: storage
 
+  - it: applies pod labels to the pod template only
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["azure.workload.identity/use"]
+
   - it: applies component annotations
     template: storegateway/statefulset.yaml
     set:

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -310,6 +310,13 @@
               "title": "labels",
               "type": "object"
             },
+            "podLabels": {
+              "additionalProperties": true,
+              "description": "Extra labels applied to Bucketweb pods (e.g. for workload identity).",
+              "required": [],
+              "title": "podLabels",
+              "type": "object"
+            },
             "nodeSelector": {
               "additionalProperties": true,
               "description": "Node selector for Bucketweb pod scheduling.",
@@ -790,6 +797,7 @@
             "priorityClassName",
             "annotations",
             "labels",
+            "podLabels",
             "extraVolumes",
             "extraVolumeMounts",
             "serviceMonitor",
@@ -1103,6 +1111,13 @@
           "description": "Extra labels applied to Compactor resources.",
           "required": [],
           "title": "labels",
+          "type": "object"
+        },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Compactor pods (e.g. for workload identity).",
+          "required": [],
+          "title": "podLabels",
           "type": "object"
         },
         "nodeSelector": {
@@ -1742,6 +1757,7 @@
         "priorityClassName",
         "annotations",
         "labels",
+        "podLabels",
         "extraVolumes",
         "extraVolumeMounts",
         "serviceMonitor",
@@ -3005,6 +3021,13 @@
           "title": "labels",
           "type": "object"
         },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Query pods (e.g. for workload identity).",
+          "required": [],
+          "title": "podLabels",
+          "type": "object"
+        },
         "nodeSelector": {
           "additionalProperties": true,
           "description": "Node selector for Query pod scheduling.",
@@ -3515,6 +3538,7 @@
         "extraVolumeMounts",
         "annotations",
         "labels",
+        "podLabels",
         "serviceMonitor",
         "pdb"
       ],
@@ -3837,6 +3861,13 @@
           "description": "Extra labels applied to Query Frontend resources.",
           "required": [],
           "title": "labels",
+          "type": "object"
+        },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Query Frontend pods (e.g. for workload identity).",
+          "required": [],
+          "title": "podLabels",
           "type": "object"
         },
         "nodeSelector": {
@@ -4315,6 +4346,7 @@
         "extraVolumeMounts",
         "annotations",
         "labels",
+        "podLabels",
         "serviceMonitor",
         "pdb"
       ],
@@ -5005,6 +5037,13 @@
           "description": "Extra labels applied to Receive resources.",
           "required": [],
           "title": "labels",
+          "type": "object"
+        },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Receive pods (e.g. for workload identity). In split mode this applies to the Ingester; use receive.ingester.podLabels and receive.router.podLabels to target each workload independently.",
+          "required": [],
+          "title": "podLabels",
           "type": "object"
         },
         "nodeSelector": {
@@ -5699,6 +5738,7 @@
         "extraVolumeMounts",
         "annotations",
         "labels",
+        "podLabels",
         "serviceMonitor",
         "pdb",
         "router"
@@ -6087,6 +6127,13 @@
           "description": "Extra labels applied to Ruler resources.",
           "required": [],
           "title": "labels",
+          "type": "object"
+        },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Ruler pods (e.g. for workload identity).",
+          "required": [],
+          "title": "podLabels",
           "type": "object"
         },
         "nodeSelector": {
@@ -6688,6 +6735,7 @@
         "extraVolumeMounts",
         "annotations",
         "labels",
+        "podLabels",
         "serviceMonitor",
         "pdb"
       ],
@@ -7355,6 +7403,13 @@
           "title": "labels",
           "type": "object"
         },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Extra labels applied to Store Gateway pods (e.g. for workload identity).",
+          "required": [],
+          "title": "podLabels",
+          "type": "object"
+        },
         "nodeSelector": {
           "additionalProperties": true,
           "description": "Node selector for Store Gateway pod scheduling.",
@@ -7973,6 +8028,7 @@
         "extraVolumeMounts",
         "annotations",
         "labels",
+        "podLabels",
         "serviceMonitor",
         "pdb"
       ],

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -631,6 +631,10 @@ bucket:
     # @default -- {}
     labels: {}
 
+    # -- Extra labels applied to Bucketweb pods (e.g. for workload identity).
+    # @default -- {}
+    podLabels: {}
+
     # -- Extra volumes for Bucketweb pods.
     # @default -- []
     extraVolumes: []
@@ -940,6 +944,10 @@ compactor:
   # -- Extra labels applied to Compactor resources.
   # @default -- {}
   labels: {}
+
+  # -- Extra labels applied to Compactor pods (e.g. for workload identity).
+  # @default -- {}
+  podLabels: {}
 
   # -- Extra volumes for Compactor pods.
   # @default -- []
@@ -1298,6 +1306,10 @@ query:
   # @default -- {}
   labels: {}
 
+  # -- Extra labels applied to Query pods (e.g. for workload identity).
+  # @default -- {}
+  podLabels: {}
+
   # Prometheus Operator ServiceMonitor configuration for the Query component.
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for Query.
@@ -1574,6 +1586,10 @@ queryFrontend:
   # -- Extra labels applied to Query Frontend resources.
   # @default -- {}
   labels: {}
+
+  # -- Extra labels applied to Query Frontend pods (e.g. for workload identity).
+  # @default -- {}
+  podLabels: {}
 
   # Prometheus Operator ServiceMonitor configuration for the Query Frontend.
   serviceMonitor:
@@ -1957,6 +1973,10 @@ storegateway:
   # -- Extra labels applied to Store Gateway resources.
   # @default -- {}
   labels: {}
+
+  # -- Extra labels applied to Store Gateway pods (e.g. for workload identity).
+  # @default -- {}
+  podLabels: {}
 
   # Prometheus Operator ServiceMonitor configuration for the Store Gateway.
   serviceMonitor:
@@ -2385,6 +2405,12 @@ receive:
   # @default -- {}
   labels: {}
 
+  # -- Extra labels applied to Receive pods (e.g. for workload identity).
+  # In split mode this applies to the Ingester; set `receive.ingester.podLabels`
+  # and `receive.router.podLabels` to target each workload independently.
+  # @default -- {}
+  podLabels: {}
+
   # Prometheus Operator ServiceMonitor configuration for the Receive component.
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for Receive.
@@ -2443,6 +2469,8 @@ receive:
   # Example (split mode):
   # ingester:
   #   replicaCount: 3
+  #   podLabels:
+  #     azure.workload.identity/use: "true"
   #   tsdb:
   #     retention: 24h
   #     walCompression: true
@@ -2721,6 +2749,10 @@ receive:
     # -- Extra labels applied to Router resources.
     # @default -- {}
     labels: {}
+
+    # -- Extra labels applied to Router pods (e.g. for workload identity).
+    # @default -- {}
+    podLabels: {}
 
     # Prometheus Operator ServiceMonitor configuration for the Router.
     serviceMonitor:
@@ -3056,6 +3088,10 @@ ruler:
   # -- Extra labels applied to Ruler resources.
   # @default -- {}
   labels: {}
+
+  # -- Extra labels applied to Ruler pods (e.g. for workload identity).
+  # @default -- {}
+  podLabels: {}
 
   # Prometheus Operator ServiceMonitor configuration for the Ruler component.
   serviceMonitor:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a `podLabels` value to **every workload component** so users can attach extra labels to the pods themselves, independently of the existing resource-level `labels`. The main driver is workload identity (e.g. `azure.workload.identity/use: "true"`), which must be set on the pod template rather than the workload metadata.

Covers: bucketweb, compactor, query, query-frontend, store gateway, receive (ingester) + router, and ruler.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

No tracking issue. Extends the approach from #112 (compactor + store gateway only) to all components.

#### Special notes for your reviewer:

- Labels are rendered into `spec.template.metadata.labels` via a new shared `thanos.podLabels` helper that reuses the existing `root`/`key`/`parent` fallback pattern (same as `thanos.podSC` / `thanos.containerSC`).
- In split-mode Receive, `receive.ingester.podLabels` and `receive.router.podLabels` target each workload, falling back to `receive.podLabels` when unset — consistent with how `podSecurityContext`, `affinity`, etc. already resolve.
- `values.schema.json` is hand-maintained in this repo; updated by hand (property + `required` for the detailed components; `ingester`/`router` are already permissive generic objects).
- Verified: `helm lint` clean and `helm unittest` green (648 tests, incl. new per-component pod-label tests covering standalone, split ingester own-value, ingester fallback, and router).

Example:

```yaml
compactor:
  podLabels:
    azure.workload.identity/use: "true"

receive:
  mode: split
  ingester:
    podLabels:
      azure.workload.identity/use: "true"
  router:
    podLabels:
      azure.workload.identity/use: "true"
```

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md