### PR TITLE
fix(compactor): vpa maxAllowed field type

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -660,7 +660,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.tolerations | list | [] | Tolerations for Compactor pod scheduling. |
 | compactor.topologySpreadConstraints | list | [] | Topology spread constraints for Compactor pods. |
 | compactor.vpa.enabled | bool | `true` | Enable a VerticalPodAutoscaler for the Compactor. |
-| compactor.vpa.maxAllowed.cpu | int | `4` | Maximum CPU resource enforced by the Compactor VPA. |
+| compactor.vpa.maxAllowed.cpu | string | `"4"` | Maximum CPU resource enforced by the Compactor VPA. |
 | compactor.vpa.maxAllowed.memory | string | `"8Gi"` | Maximum memory resource enforced by the Compactor VPA. |
 | compactor.vpa.minAllowed.cpu | string | `"500m"` | Minimum CPU resource enforced by the Compactor VPA. |
 | compactor.vpa.minAllowed.memory | string | `"512Mi"` | Minimum memory resource enforced by the Compactor VPA. |

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -793,7 +793,7 @@ tests:
       compactor.vpa.enabled: true
       compactor.vpa.minAllowed.cpu: 500m
       compactor.vpa.minAllowed.memory: 512Mi
-      compactor.vpa.maxAllowed.cpu: 4
+      compactor.vpa.maxAllowed.cpu: "4"
       compactor.vpa.maxAllowed.memory: 8Gi
     asserts:
       - isKind:

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -1654,7 +1654,7 @@
                   "description": "Maximum CPU resource enforced by the Compactor VPA.",
                   "required": [],
                   "title": "cpu",
-                  "type": "integer"
+                  "type": "string"
                 },
                 "memory": {
                   "default": "8Gi",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -811,7 +811,7 @@ compactor:
     # Maximum resource limits enforced by the Compactor VPA.
     maxAllowed:
       # -- Maximum CPU resource enforced by the Compactor VPA.
-      cpu: 4
+      cpu: "4"
       # -- Maximum memory resource enforced by the Compactor VPA.
       memory: 8Gi
 


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR fixes a type inconsistency in the field `compactor.vpa.maxAllowed`, it should be `string`, like the other `minAllowed` and `maxAllowed` fields.


#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
