### PR TITLE
fix: apply security context to prometheus rule importer

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -115,6 +115,21 @@ Usage:
 {{- end }}
 
 {{- /*
+Render container security context for the Ruler PrometheusRule importer sidecar.
+It inherits the Ruler/global security context and defaults runAsUser to nobody
+because the kubectl image otherwise runs as root while runAsNonRoot is enabled.
+*/ -}}
+{{- define "thanos.ruler.autoImportPrometheusRules.containerSC" -}}
+{{- $base := dict "runAsUser" 65534 -}}
+{{- $csc := .Values.ruler.containerSecurityContext | default .Values.global.containerSecurityContext -}}
+{{- if $csc -}}
+{{- $base = mergeOverwrite $base (deepCopy $csc) -}}
+{{- end -}}
+securityContext:
+  {{- toYaml $base | nindent 2 }}
+{{- end }}
+
+{{- /*
 Render extra pod labels for a component with component → (optional parent) fallback.
 Returns the labels as YAML (no leading newline); empty when none are set.
 Usage:

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -107,6 +107,7 @@ spec:
               mountPath: /generated
             - name: rule-importer-script
               mountPath: /scripts
+          {{- include "thanos.containerSC" (dict "root" . "key" "ruler") | nindent 10 }}
         {{- end }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "ruler" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "ruler") | nindent 6 }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -107,7 +107,7 @@ spec:
               mountPath: /generated
             - name: rule-importer-script
               mountPath: /scripts
-          {{- include "thanos.containerSC" (dict "root" . "key" "ruler") | nindent 10 }}
+          {{- include "thanos.ruler.autoImportPrometheusRules.containerSC" . | nindent 10 }}
         {{- end }}
         {{- include "thanos.extraContainers" (dict "Values" .Values "component" "ruler" "root" .) | nindent 8 }}
       {{- include "thanos.dnsConfig" (dict "Values" .Values "component" "ruler") | nindent 6 }}

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -313,6 +313,35 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
 
+  - it: applies global container security context to prometheus-rule-importer sidecar
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: prometheus-rule-importer
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+
   - it: applies component container security context overriding global
     template: ruler/statefulset.yaml
     set:

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -341,6 +341,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].securityContext.runAsNonRoot
           value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 65534
 
   - it: applies component container security context overriding global
     template: ruler/statefulset.yaml
@@ -357,6 +360,28 @@ tests:
           value: false
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+
+  - it: applies component container security context to prometheus-rule-importer sidecar overriding global
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.containerSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      ruler.containerSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: prometheus-rule-importer
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
           value: 1001
 
   - it: applies pod security context


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR applies the existing Ruler container security context fallback to the `prometheus-rule-importer` sidecar created when `ruler.autoImportPrometheusRules.enabled=true`.

Previously, `global.containerSecurityContext` / `ruler.containerSecurityContext` was applied to the main `ruler` container, but not to the `prometheus-rule-importer` sidecar. This could cause the Ruler pod to be rejected in namespaces enforcing the Kubernetes `restricted` Pod Security Standard.

## Changes

- Render `securityContext` for the `prometheus-rule-importer` sidecar using the existing `thanos.containerSC` helper.
- Add a regression test to verify that `global.containerSecurityContext` is applied to the sidecar.

#### Which issue this PR fixes

- fixes #161 https://github.com/thanos-community/helm-charts/issues/161

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md