### PR TITLE
feat(thanos): support existingClaim for all statefulset component persistence

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.23.1
+version: 0.24.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.36.0
+version: 0.37.0
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -616,6 +616,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.pdb.minAvailable | int or string | `""` | Minimum available Compactor pods during a disruption. |
 | compactor.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | compactor.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Compactor working directory. |
+| compactor.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | compactor.persistence.size | string | `"10Gi"` | Storage capacity for the Compactor PVC (used as a scratch space during compaction). |
 | compactor.persistence.storageClass | string | `""` | StorageClass name for the Compactor PVC. Empty uses the cluster default. |
 | compactor.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Compactor PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
@@ -969,6 +970,11 @@ The table below documents all available values. Top-level keys group settings by
 | receive.httpRoute.matches | list | [] | Gateway matches for the Receive HTTPRoute rules. |
 | receive.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Receive HTTPRoute. |
 | receive.ingester | object | {} | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. |
+| receive.ingester.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ingester TSDB WAL. |
+| receive.ingester.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
+| receive.ingester.persistence.size | string | `"10Gi"` | Storage capacity for the Ingester PVC. Should be sized to hold at least `tsdb.retention` worth of data. |
+| receive.ingester.persistence.storageClass | string | `""` | StorageClass name for the Ingester PVC. Empty uses the cluster default. |
+| receive.ingester.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ingester PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
 | receive.ingress.annotations | object | {} | Deprecated. Use `receive.ingress.http.annotations` instead. |
 | receive.ingress.className | string | `""` | Deprecated. Use `receive.ingress.http.className` instead. |
 | receive.ingress.enabled | bool | `false` | Deprecated. Use `receive.ingress.http.enabled` instead. |
@@ -1006,6 +1012,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.pdb.minAvailable | int or string | `""` | Minimum available Receive pods during a disruption. |
 | receive.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | receive.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Receive TSDB WAL. |
+| receive.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | receive.persistence.size | string | `"10Gi"` | Storage capacity for the Receive PVC. Should be sized to hold at least `tsdb.retention` worth of data. |
 | receive.persistence.storageClass | string | `""` | StorageClass name for the Receive PVC. Empty uses the cluster default. |
 | receive.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Receive PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
@@ -1193,6 +1200,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.pdb.minAvailable | int or string | `""` | Minimum available Ruler pods during a disruption. |
 | ruler.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | ruler.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ruler data directory. |
+| ruler.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | ruler.persistence.size | string | `"10Gi"` | Storage capacity for the Ruler PVC. |
 | ruler.persistence.storageClass | string | `""` | StorageClass name for the Ruler PVC. Empty uses the cluster default. |
 | ruler.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ruler PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
@@ -1308,6 +1316,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.pdb.minAvailable | int or string | `""` | Minimum available Store Gateway pods during a disruption. |
 | storegateway.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storegateway.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Store Gateway index cache and chunk store. |
+| storegateway.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. Not compatible with sharded mode — each shard requires its own PVC, use the default volumeClaimTemplates instead. |
 | storegateway.persistence.size | string | `"10Gi"` | Storage capacity for the Store Gateway PVC. |
 | storegateway.persistence.storageClass | string | `""` | StorageClass name for the Store Gateway PVC. Empty uses the cluster default. |
 | storegateway.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Store Gateway PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -702,6 +702,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.pdb.minAvailable | int or string | `""` | Minimum available Compactor pods during a disruption. |
 | compactor.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | compactor.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Compactor working directory. |
+| compactor.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | compactor.persistence.size | string | `"10Gi"` | Storage capacity for the Compactor PVC (used as a scratch space during compaction). |
 | compactor.persistence.storageClass | string | `""` | StorageClass name for the Compactor PVC. Empty uses the cluster default. |
 | compactor.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Compactor PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
@@ -1080,6 +1081,11 @@ The table below documents all available values. Top-level keys group settings by
 | receive.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Receive HTTPRoute. |
 | receive.httpRoute.timeouts | object | {} | Timeouts for the Receive HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | receive.ingester | object | {} | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. |
+| receive.ingester.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ingester TSDB WAL. |
+| receive.ingester.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
+| receive.ingester.persistence.size | string | `"10Gi"` | Storage capacity for the Ingester PVC. Should be sized to hold at least `tsdb.retention` worth of data. |
+| receive.ingester.persistence.storageClass | string | `""` | StorageClass name for the Ingester PVC. Empty uses the cluster default. |
+| receive.ingester.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ingester PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
 | receive.ingress.annotations | object | {} | Deprecated. Use `receive.ingress.http.annotations` instead. |
 | receive.ingress.className | string | `""` | Deprecated. Use `receive.ingress.http.className` instead. |
 | receive.ingress.enabled | bool | `false` | Deprecated. Use `receive.ingress.http.enabled` instead. |
@@ -1117,6 +1123,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.pdb.minAvailable | int or string | `""` | Minimum available Receive pods during a disruption. |
 | receive.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | receive.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Receive TSDB WAL. |
+| receive.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | receive.persistence.size | string | `"10Gi"` | Storage capacity for the Receive PVC. Should be sized to hold at least `tsdb.retention` worth of data. |
 | receive.persistence.storageClass | string | `""` | StorageClass name for the Receive PVC. Empty uses the cluster default. |
 | receive.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Receive PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
@@ -1318,6 +1325,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.pdb.minAvailable | int or string | `""` | Minimum available Ruler pods during a disruption. |
 | ruler.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | ruler.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ruler data directory. |
+| ruler.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | ruler.persistence.size | string | `"10Gi"` | Storage capacity for the Ruler PVC. |
 | ruler.persistence.storageClass | string | `""` | StorageClass name for the Ruler PVC. Empty uses the cluster default. |
 | ruler.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ruler PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |
@@ -1439,6 +1447,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.pdb.minAvailable | int or string | `""` | Minimum available Store Gateway pods during a disruption. |
 | storegateway.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storegateway.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Store Gateway index cache and chunk store. |
+| storegateway.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. Not compatible with sharded mode — each shard requires its own PVC, use the default volumeClaimTemplates instead. |
 | storegateway.persistence.size | string | `"10Gi"` | Storage capacity for the Store Gateway PVC. |
 | storegateway.persistence.storageClass | string | `""` | StorageClass name for the Store Gateway PVC. Empty uses the cluster default. |
 | storegateway.persistence.volumeAttributesClassName | string | `""` | [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Store Gateway PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster. |

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.36.0](https://img.shields.io/badge/Version-0.36.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.37.0](https://img.shields.io/badge/Version-0.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -441,6 +441,39 @@ ruler:
     enabled: true
     labelSelector: {}
 ```
+
+### Persistence
+
+Compactor, Receive (the Ingester in split mode), Ruler and Store Gateway are StatefulSets and provision their own PersistentVolumeClaims from a `volumeClaimTemplate`:
+
+```yaml
+compactor:
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""            # empty uses the cluster default StorageClass
+    accessModes:
+      - ReadWriteOnce
+```
+
+Set `persistence.enabled: false` on a component to run it on an `emptyDir` instead. Everything is then lost on restart, which is fine for a scratch Compactor but not for Receive.
+
+#### Using a pre-provisioned claim
+
+`persistence.existingClaim` mounts a PVC you created yourself and skips the `volumeClaimTemplate` entirely, which is what you want when the volume is managed outside the chart — restored from a snapshot, provisioned by Terraform, or shared with another tool:
+
+```yaml
+ruler:
+  persistence:
+    enabled: true
+    existingClaim: thanos-ruler-data   # size, storageClass and accessModes are ignored
+```
+
+Three things to keep in mind:
+
+- The claim is mounted by **every replica** of the StatefulSet, unlike a `volumeClaimTemplate`, which gives each pod its own claim. Only use `existingClaim` on a single-replica component, or with an access mode that genuinely supports concurrent writers — Thanos does not expect two processes writing the same TSDB or index cache directory.
+- `persistence.enabled: false` wins. With persistence off the component gets an `emptyDir` and `existingClaim` is ignored.
+- A **sharded** Store Gateway falls back to `volumeClaimTemplates` and ignores `existingClaim`, because each shard needs its own volume and a single claim cannot be split across them.
 
 ### ServiceAccounts
 
@@ -1080,7 +1113,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.httpRoute.matches | list | [] | Gateway matches for the Receive HTTPRoute rules. |
 | receive.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Receive HTTPRoute. |
 | receive.httpRoute.timeouts | object | {} | Timeouts for the Receive HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
-| receive.ingester | object | {} | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. |
+| receive.ingester | object | see `receive.ingester.persistence.*` below | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. Only `persistence` is defaulted by the chart. |
 | receive.ingester.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for the Ingester TSDB WAL. |
 | receive.ingester.persistence.existingClaim | string | `""` | Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes. |
 | receive.ingester.persistence.size | string | `"10Gi"` | Storage capacity for the Ingester PVC. Should be sized to hold at least `tsdb.retention` worth of data. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -430,6 +430,39 @@ ruler:
     labelSelector: {}
 ```
 
+### Persistence
+
+Compactor, Receive (the Ingester in split mode), Ruler and Store Gateway are StatefulSets and provision their own PersistentVolumeClaims from a `volumeClaimTemplate`:
+
+```yaml
+compactor:
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""            # empty uses the cluster default StorageClass
+    accessModes:
+      - ReadWriteOnce
+```
+
+Set `persistence.enabled: false` on a component to run it on an `emptyDir` instead. Everything is then lost on restart, which is fine for a scratch Compactor but not for Receive.
+
+#### Using a pre-provisioned claim
+
+`persistence.existingClaim` mounts a PVC you created yourself and skips the `volumeClaimTemplate` entirely, which is what you want when the volume is managed outside the chart — restored from a snapshot, provisioned by Terraform, or shared with another tool:
+
+```yaml
+ruler:
+  persistence:
+    enabled: true
+    existingClaim: thanos-ruler-data   # size, storageClass and accessModes are ignored
+```
+
+Three things to keep in mind:
+
+- The claim is mounted by **every replica** of the StatefulSet, unlike a `volumeClaimTemplate`, which gives each pod its own claim. Only use `existingClaim` on a single-replica component, or with an access mode that genuinely supports concurrent writers — Thanos does not expect two processes writing the same TSDB or index cache directory.
+- `persistence.enabled: false` wins. With persistence off the component gets an `emptyDir` and `existingClaim` is ignored.
+- A **sharded** Store Gateway falls back to `volumeClaimTemplates` and ignores `existingClaim`, because each shard needs its own volume and a single claim cannot be split across them.
+
 ### ServiceAccounts
 
 By default every component runs as a single chart-wide ServiceAccount named `<release>-thanos-thanos`, created when `global.serviceAccount.create` is true:

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -95,8 +95,13 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and .Values.compactor.persistence.enabled .Values.compactor.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.compactor.persistence.existingClaim }}
+        {{- end }}
         {{- include "thanos.extraVolumeItems" (dict "root" . "key" "compactor") | nindent 8 }}
-  {{- if .Values.compactor.persistence.enabled }}
+  {{- if and .Values.compactor.persistence.enabled (not .Values.compactor.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -96,8 +96,13 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and .Values.compactor.persistence.enabled .Values.compactor.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.compactor.persistence.existingClaim }}
+        {{- end }}
         {{- include "thanos.extraVolumeItems" (dict "root" . "key" "compactor") | nindent 8 }}
-  {{- if .Values.compactor.persistence.enabled }}
+  {{- if and .Values.compactor.persistence.enabled (not .Values.compactor.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -135,13 +135,21 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and $cfg.persistence.enabled $cfg.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ $cfg.persistence.existingClaim }}
+        {{- end }}
         {{- include "thanos.extraVolumeItems" (dict "root" . "key" "ingester" "parent" "receive") | nindent 8 }}
-  {{- if $cfg.persistence.enabled }}
+  {{- if and $cfg.persistence.enabled (not $cfg.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
-        accessModes: ["ReadWriteOnce"]
+        accessModes:
+        {{- range $cfg.persistence.accessModes | default (list "ReadWriteOnce") }}
+          - {{ . | quote }}
+        {{- end }}
         {{- if $cfg.persistence.storageClass }}
         storageClassName: {{ $cfg.persistence.storageClass }}
         {{- end }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -136,8 +136,13 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and $cfg.persistence.enabled $cfg.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ $cfg.persistence.existingClaim }}
+        {{- end }}
         {{- include "thanos.extraVolumeItems" (dict "root" . "key" "ingester" "parent" "receive") | nindent 8 }}
-  {{- if $cfg.persistence.enabled }}
+  {{- if and $cfg.persistence.enabled (not $cfg.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -145,7 +150,10 @@ spec:
           {{- include "thanos.labels" $ | nindent 10 }}
           app.kubernetes.io/component: receive
       spec:
-        accessModes: ["ReadWriteOnce"]
+        accessModes:
+        {{- range $cfg.persistence.accessModes | default (list "ReadWriteOnce") }}
+          - {{ . | quote }}
+        {{- end }}
         {{- if $cfg.persistence.storageClass }}
         storageClassName: {{ $cfg.persistence.storageClass }}
         {{- end }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -147,10 +147,15 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and .Values.ruler.persistence.enabled .Values.ruler.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.ruler.persistence.existingClaim }}
+        {{- end }}
 
         {{- include "thanos.extraVolumeItems" (dict "root" . "key" "ruler") | nindent 8 }}
 
-  {{- if .Values.ruler.persistence.enabled }}
+  {{- if and .Values.ruler.persistence.enabled (not .Values.ruler.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -149,10 +149,15 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and .Values.ruler.persistence.enabled .Values.ruler.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.ruler.persistence.existingClaim }}
+        {{- end }}
 
         {{- include "thanos.extraVolumeItems" (dict "root" . "key" "ruler") | nindent 8 }}
 
-  {{- if .Values.ruler.persistence.enabled }}
+  {{- if and .Values.ruler.persistence.enabled (not .Values.ruler.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -124,8 +124,13 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and $.Values.storegateway.persistence.enabled $.Values.storegateway.persistence.existingClaim (not $shard.isSharded) }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ $.Values.storegateway.persistence.existingClaim }}
+        {{- end }}
         {{- include "thanos.extraVolumeItems" (dict "root" $ "key" "storegateway") | nindent 8 }}
-  {{- if $.Values.storegateway.persistence.enabled }}
+  {{- if and $.Values.storegateway.persistence.enabled (or $shard.isSharded (not $.Values.storegateway.persistence.existingClaim)) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -125,8 +125,13 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if and $.Values.storegateway.persistence.enabled $.Values.storegateway.persistence.existingClaim (not $shard.isSharded) }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ $.Values.storegateway.persistence.existingClaim }}
+        {{- end }}
         {{- include "thanos.extraVolumeItems" (dict "root" $ "key" "storegateway") | nindent 8 }}
-  {{- if $.Values.storegateway.persistence.enabled }}
+  {{- if and $.Values.storegateway.persistence.enabled (or $shard.isSharded (not $.Values.storegateway.persistence.existingClaim)) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/thanos/tests/_split_defaults.yaml
+++ b/charts/thanos/tests/_split_defaults.yaml
@@ -63,6 +63,7 @@ receive:
         memory: 8Gi
     persistence:
       enabled: true
+      existingClaim: ""
       size: 10Gi
       storageClass: ""
       accessModes:

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -197,6 +197,43 @@ tests:
             name: data
             emptyDir: {}
 
+  - it: mounts existing PVC when existingClaim is set
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.existingClaim: compactor-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: compactor-existing-pvc
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: creates volumeClaimTemplates when existingClaim is empty
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.existingClaim: ""
+      compactor.persistence.size: 50Gi
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 50Gi
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ""
+          any: true
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/compactor_test.yaml
+++ b/charts/thanos/tests/compactor_test.yaml
@@ -234,6 +234,28 @@ tests:
               claimName: ""
           any: true
 
+  - it: ignores existingClaim when persistence is disabled
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: false
+      compactor.persistence.existingClaim: compactor-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: compactor-existing-pvc
+          any: true
+      - notExists:
+          path: spec.volumeClaimTemplates
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -148,6 +148,94 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.volumeAttributesClassName
           value: supported
 
+  - it: uses emptyDir when persistence is disabled
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: mounts existing PVC when existingClaim is set
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: true
+      receive.persistence.existingClaim: receive-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: receive-existing-pvc
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: creates volumeClaimTemplates when existingClaim is empty
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: true
+      receive.persistence.existingClaim: ""
+      receive.persistence.size: 20Gi
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 20Gi
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ""
+          any: true
+
+  - it: mounts existing PVC in split mode when ingester existingClaim is set
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.persistence.enabled: true
+      receive.ingester.persistence.existingClaim: ingester-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ingester-existing-pvc
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: creates volumeClaimTemplates in split mode when ingester existingClaim is empty
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.persistence.enabled: true
+      receive.ingester.persistence.existingClaim: ""
+      receive.ingester.persistence.size: 20Gi
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 20Gi
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ""
+          any: true
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -236,6 +236,41 @@ tests:
               claimName: ""
           any: true
 
+  - it: honours receive.persistence.accessModes on the generated claim
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: true
+      receive.persistence.accessModes:
+        - ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.accessModes
+          value:
+            - ReadWriteMany
+
+  - it: ignores existingClaim when persistence is disabled
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: false
+      receive.persistence.existingClaim: receive-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: receive-existing-pvc
+          any: true
+      - notExists:
+          path: spec.volumeClaimTemplates
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -122,6 +122,43 @@ tests:
             name: data
             emptyDir: {}
 
+  - it: mounts existing PVC when existingClaim is set
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.persistence.enabled: true
+      ruler.persistence.existingClaim: ruler-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ruler-existing-pvc
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: creates volumeClaimTemplates when existingClaim is empty
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.persistence.enabled: true
+      ruler.persistence.existingClaim: ""
+      ruler.persistence.size: 25Gi
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 25Gi
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ""
+          any: true
+
   - it: configures object storage from global objstore secret
     template: ruler/statefulset.yaml
     set:

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -141,6 +141,43 @@ tests:
             name: data
             emptyDir: {}
 
+  - it: mounts existing PVC when existingClaim is set
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.persistence.enabled: true
+      ruler.persistence.existingClaim: ruler-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ruler-existing-pvc
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: creates volumeClaimTemplates when existingClaim is empty
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.persistence.enabled: true
+      ruler.persistence.existingClaim: ""
+      ruler.persistence.size: 25Gi
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 25Gi
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ""
+          any: true
+
   - it: configures object storage from global objstore secret
     template: ruler/statefulset.yaml
     set:

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -128,6 +128,55 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.volumeAttributesClassName
           value: supported
 
+  - it: uses emptyDir when persistence is disabled
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: mounts existing PVC when existingClaim is set
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      storegateway.persistence.existingClaim: storegateway-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: storegateway-existing-pvc
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: creates volumeClaimTemplates when existingClaim is empty
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      storegateway.persistence.existingClaim: ""
+      storegateway.persistence.size: 50Gi
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 50Gi
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ""
+          any: true
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component labels
@@ -1413,6 +1462,41 @@ tests:
               regex: team-a
               source_labels:
               - __meta_tenant
+
+  - it: falls back to volumeClaimTemplates in sharded mode even when existingClaim is set
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+      storegateway.persistence.enabled: true
+      storegateway.persistence.existingClaim: storegateway-existing-pvc
+      storegateway.persistence.size: 50Gi
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+        documentIndex: 0
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+        documentIndex: 1
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: storegateway-existing-pvc
+          any: true
+        documentIndex: 0
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: storegateway-existing-pvc
+          any: true
+        documentIndex: 1
 
   # -- Sharding: Service -------------------------------------------------
 

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -1221,6 +1221,13 @@
               "required": [],
               "title": "volumeAttributesClassName",
               "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
+              "type": "string"
             }
           },
           "required": [
@@ -4606,6 +4613,72 @@
           "additionalProperties": true,
           "default": {},
           "description": "Ingester StatefulSet config. Required (and must mirror the top-level `receive.*` shape) when `receive.mode` is `split`; ignored in `standalone` mode.",
+          "properties": {
+            "persistence": {
+              "additionalProperties": true,
+              "description": "PersistentVolumeClaim configuration for the Ingester TSDB WAL.",
+              "properties": {
+                "accessModes": {
+                  "description": "Access modes for the Ingester PVC.",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "required": [],
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "required": [],
+                  "title": "accessModes",
+                  "type": "array"
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Enable a PersistentVolumeClaim for the Ingester TSDB WAL.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "size": {
+                  "default": "10Gi",
+                  "description": "Storage capacity for the Ingester PVC.\nShould be sized to hold at least `tsdb.retention` worth of data.",
+                  "required": [],
+                  "title": "size",
+                  "type": "string"
+                },
+                "storageClass": {
+                  "default": "",
+                  "description": "StorageClass name for the Ingester PVC. Empty uses the cluster default.",
+                  "required": [],
+                  "title": "storageClass",
+                  "type": "string"
+                },
+                "volumeAttributesClassName": {
+                  "default": "",
+                  "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ingester PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
+                  "required": [],
+                  "title": "volumeAttributesClassName",
+                  "type": "string"
+                },
+                "existingClaim": {
+                  "default": "",
+                  "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+                  "required": [],
+                  "title": "existingClaim",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled",
+                "size",
+                "storageClass",
+                "accessModes"
+              ],
+              "title": "persistence",
+              "type": "object"
+            }
+          },
           "required": [],
           "title": "ingester",
           "type": "object"
@@ -5161,6 +5234,13 @@
               "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Receive PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
               "required": [],
               "title": "volumeAttributesClassName",
+              "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
               "type": "string"
             }
           },
@@ -6273,6 +6353,13 @@
               "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ruler PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
               "required": [],
               "title": "volumeAttributesClassName",
+              "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
               "type": "string"
             }
           },
@@ -7554,6 +7641,13 @@
               "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Store Gateway PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
               "required": [],
               "title": "volumeAttributesClassName",
+              "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
               "type": "string"
             }
           },

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -1316,6 +1316,13 @@
               "required": [],
               "title": "volumeAttributesClassName",
               "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
+              "type": "string"
             }
           },
           "required": [
@@ -4939,6 +4946,72 @@
           "additionalProperties": true,
           "default": {},
           "description": "Ingester StatefulSet config. Required (and must mirror the top-level `receive.*` shape) when `receive.mode` is `split`; ignored in `standalone` mode.",
+          "properties": {
+            "persistence": {
+              "additionalProperties": true,
+              "description": "PersistentVolumeClaim configuration for the Ingester TSDB WAL.",
+              "properties": {
+                "accessModes": {
+                  "description": "Access modes for the Ingester PVC.",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "required": [],
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "required": [],
+                  "title": "accessModes",
+                  "type": "array"
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Enable a PersistentVolumeClaim for the Ingester TSDB WAL.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "size": {
+                  "default": "10Gi",
+                  "description": "Storage capacity for the Ingester PVC.\nShould be sized to hold at least `tsdb.retention` worth of data.",
+                  "required": [],
+                  "title": "size",
+                  "type": "string"
+                },
+                "storageClass": {
+                  "default": "",
+                  "description": "StorageClass name for the Ingester PVC. Empty uses the cluster default.",
+                  "required": [],
+                  "title": "storageClass",
+                  "type": "string"
+                },
+                "volumeAttributesClassName": {
+                  "default": "",
+                  "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ingester PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
+                  "required": [],
+                  "title": "volumeAttributesClassName",
+                  "type": "string"
+                },
+                "existingClaim": {
+                  "default": "",
+                  "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+                  "required": [],
+                  "title": "existingClaim",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled",
+                "size",
+                "storageClass",
+                "accessModes"
+              ],
+              "title": "persistence",
+              "type": "object"
+            }
+          },
           "required": [],
           "title": "ingester",
           "type": "object"
@@ -5494,6 +5567,13 @@
               "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Receive PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
               "required": [],
               "title": "volumeAttributesClassName",
+              "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
               "type": "string"
             }
           },
@@ -6686,6 +6766,13 @@
               "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ruler PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
               "required": [],
               "title": "volumeAttributesClassName",
+              "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
               "type": "string"
             }
           },
@@ -8038,6 +8125,13 @@
               "description": "[Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Store Gateway PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.",
               "required": [],
               "title": "volumeAttributesClassName",
+              "type": "string"
+            },
+            "existingClaim": {
+              "default": "",
+              "description": "Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.",
+              "required": [],
+              "title": "existingClaim",
               "type": "string"
             }
           },

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -705,6 +705,10 @@ compactor:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Compactor working directory.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+    # is created and the named PVC is mounted directly. Takes precedence over
+    # size, storageClass and accessModes.
+    existingClaim: ""
     # -- Storage capacity for the Compactor PVC (used as a scratch space during compaction).
     size: 10Gi
     # -- StorageClass name for the Compactor PVC. Empty uses the cluster default.
@@ -1842,6 +1846,11 @@ storegateway:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Store Gateway index cache and chunk store.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the
+    # named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.
+    # Not compatible with sharded mode — each shard requires its own PVC, use the default
+    # volumeClaimTemplates instead.
+    existingClaim: ""
     # -- Storage capacity for the Store Gateway PVC.
     size: 10Gi
     # -- StorageClass name for the Store Gateway PVC. Empty uses the cluster default.
@@ -2279,6 +2288,10 @@ receive:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Receive TSDB WAL.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+    # is created and the named PVC is mounted directly. Takes precedence over
+    # size, storageClass and accessModes.
+    existingClaim: ""
     # -- Storage capacity for the Receive PVC.
     # Should be sized to hold at least `tsdb.retention` worth of data.
     size: 10Gi
@@ -2473,7 +2486,26 @@ receive:
   # -- Ingester StatefulSet config. Required when `receive.mode` is `split`;
   # ignored in `standalone` mode.
   # @default -- {}
-  ingester: {}
+  ingester:
+    # PersistentVolumeClaim configuration for the Ingester TSDB WAL.
+    persistence:
+      # -- Enable a PersistentVolumeClaim for the Ingester TSDB WAL.
+      enabled: true
+      # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+      # is created and the named PVC is mounted directly. Takes precedence over
+      # size, storageClass and accessModes.
+      existingClaim: ""
+      # -- Storage capacity for the Ingester PVC.
+      # Should be sized to hold at least `tsdb.retention` worth of data.
+      size: 10Gi
+      # -- StorageClass name for the Ingester PVC. Empty uses the cluster default.
+      storageClass: ""
+      # -- [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ingester PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.
+      volumeAttributesClassName: ""
+      # Access modes for the Ingester PVC.
+      accessModes:
+        - ReadWriteOnce
+
   # Example (split mode):
   # ingester:
   #   replicaCount: 3
@@ -2884,6 +2916,10 @@ ruler:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Ruler data directory.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+    # is created and the named PVC is mounted directly. Takes precedence over
+    # size, storageClass and accessModes.
+    existingClaim: ""
     # -- Storage capacity for the Ruler PVC.
     size: 10Gi
     # -- StorageClass name for the Ruler PVC. Empty uses the cluster default.

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -762,6 +762,10 @@ compactor:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Compactor working directory.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+    # is created and the named PVC is mounted directly. Takes precedence over
+    # size, storageClass and accessModes.
+    existingClaim: ""
     # -- Storage capacity for the Compactor PVC (used as a scratch space during compaction).
     size: 10Gi
     # -- StorageClass name for the Compactor PVC. Empty uses the cluster default.
@@ -2017,6 +2021,11 @@ storegateway:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Store Gateway index cache and chunk store.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate is created and the
+    # named PVC is mounted directly. Takes precedence over size, storageClass and accessModes.
+    # Not compatible with sharded mode — each shard requires its own PVC, use the default
+    # volumeClaimTemplates instead.
+    existingClaim: ""
     # -- Storage capacity for the Store Gateway PVC.
     size: 10Gi
     # -- StorageClass name for the Store Gateway PVC. Empty uses the cluster default.
@@ -2489,6 +2498,10 @@ receive:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Receive TSDB WAL.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+    # is created and the named PVC is mounted directly. Takes precedence over
+    # size, storageClass and accessModes.
+    existingClaim: ""
     # -- Storage capacity for the Receive PVC.
     # Should be sized to hold at least `tsdb.retention` worth of data.
     size: 10Gi
@@ -2705,7 +2718,26 @@ receive:
   # -- Ingester StatefulSet config. Required when `receive.mode` is `split`;
   # ignored in `standalone` mode.
   # @default -- {}
-  ingester: {}
+  ingester:
+    # PersistentVolumeClaim configuration for the Ingester TSDB WAL.
+    persistence:
+      # -- Enable a PersistentVolumeClaim for the Ingester TSDB WAL.
+      enabled: true
+      # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+      # is created and the named PVC is mounted directly. Takes precedence over
+      # size, storageClass and accessModes.
+      existingClaim: ""
+      # -- Storage capacity for the Ingester PVC.
+      # Should be sized to hold at least `tsdb.retention` worth of data.
+      size: 10Gi
+      # -- StorageClass name for the Ingester PVC. Empty uses the cluster default.
+      storageClass: ""
+      # -- [Volume attributes class](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) name for the Ingester PVC. Requires Kubernetes 1.31+ ([with feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)) or 1.36+. Chart will fail if provided but not supported by cluster.
+      volumeAttributesClassName: ""
+      # Access modes for the Ingester PVC.
+      accessModes:
+        - ReadWriteOnce
+
   # Example (split mode):
   # ingester:
   #   replicaCount: 3
@@ -3151,6 +3183,10 @@ ruler:
   persistence:
     # -- Enable a PersistentVolumeClaim for the Ruler data directory.
     enabled: true
+    # -- Use an existing PersistentVolumeClaim. When set, no volumeClaimTemplate
+    # is created and the named PVC is mounted directly. Takes precedence over
+    # size, storageClass and accessModes.
+    existingClaim: ""
     # -- Storage capacity for the Ruler PVC.
     size: 10Gi
     # -- StorageClass name for the Ruler PVC. Empty uses the cluster default.

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -2713,11 +2713,15 @@ receive:
   # extraInitContainers, extraContainers, probes, nodeSelector, tolerations,
   # affinity, topologySpreadConstraints, priorityClassName, extraVolumes,
   # extraVolumeMounts, annotations, labels, serviceMonitor, pdb, serviceAccount,
-  # tenancyHeader). Leave empty (`{}`) in standalone mode.
+  # tenancyHeader). Ignored entirely in standalone mode.
+  #
+  # `persistence` is the only sub-block with chart defaults, so that a split-mode
+  # install that does not care about storage still renders; every other field
+  # above has to be supplied.
   # ======================================================================
   # -- Ingester StatefulSet config. Required when `receive.mode` is `split`;
-  # ignored in `standalone` mode.
-  # @default -- {}
+  # ignored in `standalone` mode. Only `persistence` is defaulted by the chart.
+  # @default -- see `receive.ingester.persistence.*` below
   ingester:
     # PersistentVolumeClaim configuration for the Ingester TSDB WAL.
     persistence:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `persistence.existingClaim` to every StatefulSet component: `compactor`, `storegateway`, `ruler`, `receive` (standalone) and `receive.ingester` (split mode).

When set, the named PVC is mounted directly as the `data` volume and no `volumeClaimTemplate` is generated, which is what you want when the volume is managed outside the chart — restored from a snapshot, provisioned by Terraform, or shared with another tool. Defaults to `""`, so existing installs render exactly as before.

#### Special notes for your reviewer:

**Store Gateway sharding.** The `volumeClaimTemplates` guard is `(or $shard.isSharded (not ...existingClaim))`, so a sharded Store Gateway falls back to generated claims and ignores `existingClaim`; a single pre-provisioned PVC cannot be split across shards. Covered by a sharded test that asserts every shard still gets a `volumeClaimTemplate` and that no shard mounts the claim.

**Split mode.** In split mode persistence resolves from `receive.ingester.persistence`, not `receive.persistence`, so `receive.ingester.persistence` now carries real chart defaults (`enabled`, `existingClaim`, `size`, `storageClass`, `volumeAttributesClassName`, `accessModes`) instead of `ingester: {}`. This also satisfies the `persistence` entry that the schema's `mode: split` `allOf` already required, so a split-mode install no longer has to spell the block out. `_split_defaults.yaml` and the values-table docs are updated to match.

**Receive accessModes.** `receive/statefulset.yaml` hardcoded `accessModes: ["ReadWriteOnce"]`, silently ignoring `receive.persistence.accessModes`, which every other component honours. Fixed here because `existingClaim` is documented as taking precedence over `accessModes` and that has to mean something. Covered by its own test.

**values.schema.json.** `existingClaim` (`string`, default `""`) added under `compactor.persistence`, `receive.persistence`, `receive.ingester.persistence`, `ruler.persistence` and `storegateway.persistence`.

**Scope.** Query, Query Frontend and BucketWeb are stateless Deployments with no persistence block and no PVC — BucketWeb reads blocks straight from the object store on each request — so there is nothing for `existingClaim` to attach to. The five PVC-producing StatefulSet components are the full set.

**Docs.** A `Persistence` section in `README.md.gotmpl` covers generated claims, `existingClaim`, and the three caveats: the claim is mounted by *every* replica (unlike a `volumeClaimTemplate`), `persistence.enabled: false` wins, and sharded Store Gateway falls back to templates.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
