### PR TITLE
fix(ruler): add grpc port to the netpol

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.18.1
+version: 0.18.3
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/ruler/networkpolicy.yaml
+++ b/charts/thanos/templates/ruler/networkpolicy.yaml
@@ -11,6 +11,7 @@ spec:
     - {}
   ingress:
     - ports:
+        - port: grpc
         - port: http
   podSelector:
     matchLabels:

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -1364,3 +1364,11 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-thanos-ruler
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: grpc
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: http


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When `global.networkPolicies=true`, the Ruler NetworkPolicy only allowed ingress on the `http` port. Since Query can auto-discover Ruler as a StoreAPI endpoint over gRPC, this blocked Query from connecting to Ruler on the `grpc` port and caused endpoint update timeouts.

This PR updates the Ruler NetworkPolicy to allow ingress on both:

- `grpc`
- `http`

It also adds a regression test to ensure the rendered Ruler NetworkPolicy includes both ports.


#### Which issue this PR fixes

- fixes #https://github.com/thanos-community/helm-charts/issues/163

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
