### PR TITLE
fix: query duplicate storeEndpoints for ruler

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.23.1
+version: 0.23.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.23.2](https://img.shields.io/badge/Version-0.23.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -845,6 +845,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.replicaCount | int | `2` | Number of Query pod replicas. Two or more is recommended for HA. |
 | query.replicaLabels[0] | string | `"prometheus_replica"` |  |
 | query.replicaLabels[1] | string | `"receive_replica"` |  |
+| query.replicaLabels[2] | string | `"ruler_replica"` |  |
 | query.resources | object | {} | Resource requests and limits for the Query container. |
 | query.service.annotations | object | {} | Extra annotations for the Query Service. |
 | query.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Query Service. |

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -50,6 +50,7 @@ spec:
             - --data-dir=/var/thanos/ruler
             - --objstore.config-file=/etc/thanos/objstore.yml
             - --rule-file=/etc/thanos/rules/*.yaml
+            - --label=ruler_replica="$(POD_NAME)"
           {{- if .Values.ruler.autoImportPrometheusRules.enabled }}
             - --rule-file=/etc/thanos/rules/generated/*.yaml
           {{- end }}
@@ -61,7 +62,12 @@ spec:
           {{- range .Values.ruler.extraArgs }}
             - {{ . | quote }}
           {{- end }}
-          {{- include "thanos.extraEnvBlock" (dict "Values" .Values "component" "ruler") | nindent 10 }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- include "thanos.extraEnvItems" (dict "Values" .Values "component" "ruler") | nindent 12 }}
           {{- include "thanos.extraEnvFromBlock" (dict "Values" .Values "component" "ruler") | nindent 10 }}
           ports:
             - name: http

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1187,6 +1187,7 @@ query:
   replicaLabels:
     - prometheus_replica
     - receive_replica
+    - ruler_replica
 
   # Additional CLI arguments appended to the `thanos query` command.
   extraArgs:


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

My thanos-query pod was spamming this warning:

```console
ts=2026-05-26T16:20:55.525251751Z caller=endpointset.go:434 level=warn component=endpointset msg="found duplicate storeEndpoints producer (sidecar or ruler). This is not advised as it will malform data in in the same bucket" address=10.234.68.233:10901 extLset= duplicates=2
```

The IP address included in the log was for a ruler pod.
Adding the `ruler_replica` label argument for ruler pods, to be set to a pods name for each instance, and adding the `query.replica-label=ruler_replica` argument for query pods solved the warning logs from getting spammed.
Maybe I am missing something here, let me know if this should be an issue instead to figure out if this is specific to my environment setup.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
