### PR TITLE
fix(vpa): use the right container names

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.18.1
+version: 0.18.2
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/templates/compactor/vpa.yaml
+++ b/charts/thanos/templates/compactor/vpa.yaml
@@ -16,7 +16,7 @@ spec:
     updateMode: {{ .Values.compactor.vpa.updateMode | default "Auto" }}
   resourcePolicy:
     containerPolicies:
-      - containerName: thanos
+      - containerName: compactor
         mode: Auto
         controlledResources: ["cpu", "memory"]
         minAllowed:

--- a/charts/thanos/templates/receive/vpa.yaml
+++ b/charts/thanos/templates/receive/vpa.yaml
@@ -18,7 +18,7 @@ spec:
     updateMode: {{ $vpa.updateMode | default "Auto" }}
   resourcePolicy:
     containerPolicies:
-      - containerName: thanos
+      - containerName: receive
         mode: Auto
         controlledResources:
           - cpu


### PR DESCRIPTION
#### What this PR does / why we need it:
It fixes an incorrect value for the field `.spec.resourcePolicy.containerPolicies[0].containerName` from `thanos` to the name of the targeted component, either `compactor` or `receive`.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
