### PR TITLE
feat(thanos): add `global.storageClass` for PVCs

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.18.0
+version: 0.19.0
 appVersion: "v0.41.0"
 keywords:
   - thanos

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.37.0
+version: 0.38.0
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -696,6 +696,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.podAnnotations | object | {} | Annotations added to every pod by default. Component-level annotations are merged on top. |
 | global.podSecurityContext | object | {} | Pod-level security context applied to every pod. Component-level values override this. |
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
+| global.storageClass | string | `""` | Default StorageClass name to use for PersistentVolumeClaims. When empty (`""`), components fall back to their own storageClass behavior. When a component storageClass is also empty, the cluster default StorageClass applies. Component-level `persistence.storageClass` values override `global.storageClass`. |
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |
 | global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount. |

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -828,6 +828,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.podAnnotations | object | {} | Annotations added to every pod by default. Component-level annotations are merged on top. |
 | global.podSecurityContext | object | {} | Pod-level security context applied to every pod. Component-level values override this. |
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
+| global.storageClass | string | `""` | Default StorageClass name to use for PersistentVolumeClaims. When empty (`""`), components fall back to their own storageClass behavior. When a component storageClass is also empty, the cluster default StorageClass applies. Component-level `persistence.storageClass` values override `global.storageClass`. |
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |
 | global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount, including the per-component ones (e.g. a shared IRSA or Workload Identity annotation). |

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.37.0](https://img.shields.io/badge/Version-0.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.38.0](https://img.shields.io/badge/Version-0.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -221,6 +221,10 @@ global:
   resources: {}
   nodeSelector: {}
   tolerations: []
+
+  # Fallback StorageClass for every PVC the chart creates. A component's own
+  # persistence.storageClass wins; empty on both means the cluster default.
+  storageClass: ""
 ```
 
 ### Query
@@ -451,12 +455,27 @@ compactor:
   persistence:
     enabled: true
     size: 10Gi
-    storageClass: ""            # empty uses the cluster default StorageClass
+    storageClass: ""            # falls back to global.storageClass, then the cluster default
     accessModes:
       - ReadWriteOnce
 ```
 
 Set `persistence.enabled: false` on a component to run it on an `emptyDir` instead. Everything is then lost on restart, which is fine for a scratch Compactor but not for Receive.
+
+#### Choosing a StorageClass
+
+`persistence.storageClass` is resolved per component, with `global.storageClass` as the chart-wide fallback:
+
+```yaml
+global:
+  storageClass: fast-ssd       # used by every PVC the chart creates
+
+storegateway:
+  persistence:
+    storageClass: bulk-hdd     # except this one, which wins locally
+```
+
+When both are empty no `storageClassName` is rendered at all and the cluster default StorageClass applies, which is the behaviour of an install that sets neither. `storageClass` is ignored entirely when `existingClaim` is set — the pre-provisioned claim already has one.
 
 #### Using a pre-provisioned claim
 
@@ -575,6 +594,43 @@ helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
 
 > [!WARNING]
 > Registry now lives in `global.image.registry`, repository must be the path without the registry host, and tag defaults to the chart `appVersion`.
+
+### Upgrading to 0.38.0 — `global.storageClass`
+
+`global.storageClass` is new in 0.38.0 and is used as the fallback `storageClassName` for every PersistentVolumeClaim the chart creates — Compactor, Receive, Ruler and Store Gateway. A component's own `persistence.storageClass` still wins, and when both are empty nothing is rendered, so an install that never set either keeps using the cluster default StorageClass and is unaffected.
+
+The one case that needs attention is an umbrella chart. `global` values propagate into subcharts, so if the parent chart already sets `global.storageClass` for another dependency, Thanos now picks it up and renders a `storageClassName` on StatefulSets that previously had none. `volumeClaimTemplates` are immutable, so the API server rejects the upgrade with `field is immutable`.
+
+Check before upgrading:
+
+```bash
+helm get values thanos --namespace monitoring --all | grep -A1 '^global:'
+kubectl get statefulset --namespace monitoring \
+  --selector app.kubernetes.io/part-of=thanos \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.volumeClaimTemplates[*].spec.storageClassName}{"\n"}{end}'
+```
+
+If a `global.storageClass` is in play and the existing claims render a different class (or none), either pin the previous behaviour per component:
+
+```yaml
+compactor:
+  persistence:
+    storageClass: ""   # and the same for receive, ruler, storegateway
+```
+
+or recreate the StatefulSets once, which leaves the pods and PVCs running:
+
+```bash
+kubectl delete statefulset --namespace monitoring \
+  --selector app.kubernetes.io/part-of=thanos,app.kubernetes.io/instance=thanos \
+  --cascade=orphan
+
+helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
+  --namespace monitoring \
+  -f values.yaml
+```
+
+Recreating the StatefulSet only changes the template. Existing PVCs are never touched by a StatefulSet, so the new class applies to claims created from then on; move existing data with a restore or a volume clone if you actually want it on the new class.
 
 ### Upgrading to 0.36.0 — selector labels
 
@@ -828,7 +884,6 @@ The table below documents all available values. Top-level keys group settings by
 | global.podAnnotations | object | {} | Annotations added to every pod by default. Component-level annotations are merged on top. |
 | global.podSecurityContext | object | {} | Pod-level security context applied to every pod. Component-level values override this. |
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
-| global.storageClass | string | `""` | Default StorageClass name to use for PersistentVolumeClaims. When empty (`""`), components fall back to their own storageClass behavior. When a component storageClass is also empty, the cluster default StorageClass applies. Component-level `persistence.storageClass` values override `global.storageClass`. |
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |
 | global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount, including the per-component ones (e.g. a shared IRSA or Workload Identity annotation). |
@@ -846,6 +901,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.serviceMonitor.scheme | string | `""` | Scrape scheme: http or https. |
 | global.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout. Empty string uses the Prometheus operator default. |
 | global.serviceMonitor.tlsConfig | object | {} | TLS configuration for scraping when scheme is https. |
+| global.storageClass | string | `""` | Default StorageClass name for every PersistentVolumeClaim the chart creates (Compactor, Receive, Ruler and Store Gateway). A component's own `persistence.storageClass` takes precedence; when both are empty no `storageClassName` is rendered and the cluster default StorageClass applies. |
 | global.thanosRules.additionalRuleGroupAnnotations | object | {} | Annotations added to every alert rule across all groups. Applied on top of the rule's default annotations (summary, description, runbook_url). |
 | global.thanosRules.additionalRuleGroupLabels | object | {} | Labels added to every alert rule across all groups. Applied on top of the rule's default labels (severity). Useful for routing alerts to specific Alertmanager receivers (e.g. team, tenant). |
 | global.thanosRules.alertOverrides | object | {} | Per-alert label overrides. Keys are alert names; values are dicts of labels to merge into that alert's labels block. Useful for routing specific alerts to different receivers or adding custom metadata. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -209,6 +209,10 @@ global:
   resources: {}
   nodeSelector: {}
   tolerations: []
+
+  # Fallback StorageClass for every PVC the chart creates. A component's own
+  # persistence.storageClass wins; empty on both means the cluster default.
+  storageClass: ""
 ```
 
 ### Query
@@ -439,12 +443,27 @@ compactor:
   persistence:
     enabled: true
     size: 10Gi
-    storageClass: ""            # empty uses the cluster default StorageClass
+    storageClass: ""            # falls back to global.storageClass, then the cluster default
     accessModes:
       - ReadWriteOnce
 ```
 
 Set `persistence.enabled: false` on a component to run it on an `emptyDir` instead. Everything is then lost on restart, which is fine for a scratch Compactor but not for Receive.
+
+#### Choosing a StorageClass
+
+`persistence.storageClass` is resolved per component, with `global.storageClass` as the chart-wide fallback:
+
+```yaml
+global:
+  storageClass: fast-ssd       # used by every PVC the chart creates
+
+storegateway:
+  persistence:
+    storageClass: bulk-hdd     # except this one, which wins locally
+```
+
+When both are empty no `storageClassName` is rendered at all and the cluster default StorageClass applies, which is the behaviour of an install that sets neither. `storageClass` is ignored entirely when `existingClaim` is set — the pre-provisioned claim already has one.
 
 #### Using a pre-provisioned claim
 
@@ -563,6 +582,43 @@ helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
 
 > [!WARNING]
 > Registry now lives in `global.image.registry`, repository must be the path without the registry host, and tag defaults to the chart `appVersion`.
+
+### Upgrading to 0.38.0 — `global.storageClass`
+
+`global.storageClass` is new in 0.38.0 and is used as the fallback `storageClassName` for every PersistentVolumeClaim the chart creates — Compactor, Receive, Ruler and Store Gateway. A component's own `persistence.storageClass` still wins, and when both are empty nothing is rendered, so an install that never set either keeps using the cluster default StorageClass and is unaffected.
+
+The one case that needs attention is an umbrella chart. `global` values propagate into subcharts, so if the parent chart already sets `global.storageClass` for another dependency, Thanos now picks it up and renders a `storageClassName` on StatefulSets that previously had none. `volumeClaimTemplates` are immutable, so the API server rejects the upgrade with `field is immutable`.
+
+Check before upgrading:
+
+```bash
+helm get values thanos --namespace monitoring --all | grep -A1 '^global:'
+kubectl get statefulset --namespace monitoring \
+  --selector app.kubernetes.io/part-of=thanos \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.volumeClaimTemplates[*].spec.storageClassName}{"\n"}{end}'
+```
+
+If a `global.storageClass` is in play and the existing claims render a different class (or none), either pin the previous behaviour per component:
+
+```yaml
+compactor:
+  persistence:
+    storageClass: ""   # and the same for receive, ruler, storegateway
+```
+
+or recreate the StatefulSets once, which leaves the pods and PVCs running:
+
+```bash
+kubectl delete statefulset --namespace monitoring \
+  --selector app.kubernetes.io/part-of=thanos,app.kubernetes.io/instance=thanos \
+  --cascade=orphan
+
+helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
+  --namespace monitoring \
+  -f values.yaml
+```
+
+Recreating the StatefulSet only changes the template. Existing PVCs are never touched by a StatefulSet, so the new class applies to claims created from then on; move existing data with a restore or a volume clone if you actually want it on the new class.
 
 ### Upgrading to 0.36.0 — selector labels
 

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -293,6 +293,22 @@ volumeAttributesClassName: {{ . | quote }}
 {{- end }}
 
 {{- /*
+Render the storage-class fields of a PVC spec: `storageClassName`, taken from the
+component's own `persistence.storageClass` and falling back to the chart-wide
+`global.storageClass` when it is empty, followed by `volumeAttributesClassName`.
+Renders nothing when neither is set, so the cluster default StorageClass applies.
+Usage:
+  {{ include "thanos.storageClass" (dict "root" . "key" "compactor" "persistence" .Values.compactor.persistence) }}
+*/ -}}
+{{- define "thanos.storageClass" }}
+{{- $sc := .persistence.storageClass | default .root.Values.global.storageClass }}
+{{- with $sc }}
+storageClassName: {{ . | quote }}
+{{- end }}
+{{- include "thanos.volumeAttributesClassName" (dict "root" .root "key" .key "persistence" .persistence) }}
+{{- end }}
+
+{{- /*
 Render extra volume entries (concatenated) from global, optional parent, then component.
 Usage:
   {{ include "thanos.extraVolumeItems" (dict "root" . "key" "compactor") }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -105,8 +105,9 @@ spec:
         {{- range .Values.compactor.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if .Values.compactor.persistence.storageClass }}
-        storageClassName: {{ .Values.compactor.persistence.storageClass }}
+        {{- $sc := default .Values.global.storageClass .Values.compactor.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         resources:
           requests:

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -114,11 +114,7 @@ spec:
         {{- range .Values.compactor.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- $sc := default .Values.global.storageClass .Values.compactor.persistence.storageClass }}
-        {{- if $sc }}
-        storageClassName: {{ $sc | quote }}
-        {{- end }}
-        {{- include "thanos.volumeAttributesClassName" (dict "root" . "key" "compactor" "persistence" .Values.compactor.persistence) | indent 8 }}
+        {{- include "thanos.storageClass" (dict "root" . "key" "compactor" "persistence" .Values.compactor.persistence) | indent 8 }}
         resources:
           requests:
             storage: {{ .Values.compactor.persistence.size }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -114,8 +114,9 @@ spec:
         {{- range .Values.compactor.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if .Values.compactor.persistence.storageClass }}
-        storageClassName: {{ .Values.compactor.persistence.storageClass }}
+        {{- $sc := default .Values.global.storageClass .Values.compactor.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         {{- include "thanos.volumeAttributesClassName" (dict "root" . "key" "compactor" "persistence" .Values.compactor.persistence) | indent 8 }}
         resources:

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -142,8 +142,9 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
-        {{- if $cfg.persistence.storageClass }}
-        storageClassName: {{ $cfg.persistence.storageClass }}
+        {{- $sc := default .Values.global.storageClass $cfg.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         resources:
           requests:

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -154,8 +154,9 @@ spec:
         {{- range $cfg.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if $cfg.persistence.storageClass }}
-        storageClassName: {{ $cfg.persistence.storageClass }}
+        {{- $sc := default .Values.global.storageClass $cfg.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         {{- include "thanos.volumeAttributesClassName" (dict "root" . "key" "receive" "persistence" $cfg.persistence) | indent 8 }}
         resources:

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -154,11 +154,7 @@ spec:
         {{- range $cfg.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- $sc := default .Values.global.storageClass $cfg.persistence.storageClass }}
-        {{- if $sc }}
-        storageClassName: {{ $sc | quote }}
-        {{- end }}
-        {{- include "thanos.volumeAttributesClassName" (dict "root" . "key" "receive" "persistence" $cfg.persistence) | indent 8 }}
+        {{- include "thanos.storageClass" (dict "root" . "key" "receive" "persistence" $cfg.persistence) | indent 8 }}
         resources:
           requests:
             storage: {{ $cfg.persistence.size }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -156,8 +156,9 @@ spec:
         {{- range .Values.ruler.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if .Values.ruler.persistence.storageClass }}
-        storageClassName: {{ .Values.ruler.persistence.storageClass }}
+        {{- $sc := default .Values.global.storageClass .Values.ruler.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         resources:
           requests:

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -169,8 +169,9 @@ spec:
         {{- range .Values.ruler.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if .Values.ruler.persistence.storageClass }}
-        storageClassName: {{ .Values.ruler.persistence.storageClass }}
+        {{- $sc := default .Values.global.storageClass .Values.ruler.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         {{- include "thanos.volumeAttributesClassName" (dict "root" . "key" "ruler" "persistence" .Values.ruler.persistence) | indent 8 }}
         resources:

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -169,11 +169,7 @@ spec:
         {{- range .Values.ruler.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- $sc := default .Values.global.storageClass .Values.ruler.persistence.storageClass }}
-        {{- if $sc }}
-        storageClassName: {{ $sc | quote }}
-        {{- end }}
-        {{- include "thanos.volumeAttributesClassName" (dict "root" . "key" "ruler" "persistence" .Values.ruler.persistence) | indent 8 }}
+        {{- include "thanos.storageClass" (dict "root" . "key" "ruler" "persistence" .Values.ruler.persistence) | indent 8 }}
         resources:
           requests:
             storage: {{ .Values.ruler.persistence.size }}

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -134,8 +134,9 @@ spec:
         {{- range $.Values.storegateway.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if $.Values.storegateway.persistence.storageClass }}
-        storageClassName: {{ $.Values.storegateway.persistence.storageClass }}
+        {{- $sc := default $.Values.global.storageClass $.Values.storegateway.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         resources:
           requests:

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -146,8 +146,9 @@ spec:
         {{- range $.Values.storegateway.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- if $.Values.storegateway.persistence.storageClass }}
-        storageClassName: {{ $.Values.storegateway.persistence.storageClass }}
+        {{- $sc := default $.Values.global.storageClass $.Values.storegateway.persistence.storageClass }}
+        {{- if $sc }}
+        storageClassName: {{ $sc | quote }}
         {{- end }}
         {{- include "thanos.volumeAttributesClassName" (dict "root" $ "key" "storegateway" "persistence" $.Values.storegateway.persistence) | indent 8 }}
         resources:

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -146,11 +146,7 @@ spec:
         {{- range $.Values.storegateway.persistence.accessModes | default (list "ReadWriteOnce") }}
           - {{ . | quote }}
         {{- end }}
-        {{- $sc := default $.Values.global.storageClass $.Values.storegateway.persistence.storageClass }}
-        {{- if $sc }}
-        storageClassName: {{ $sc | quote }}
-        {{- end }}
-        {{- include "thanos.volumeAttributesClassName" (dict "root" $ "key" "storegateway" "persistence" $.Values.storegateway.persistence) | indent 8 }}
+        {{- include "thanos.storageClass" (dict "root" $ "key" "storegateway" "persistence" $.Values.storegateway.persistence) | indent 8 }}
         resources:
           requests:
             storage: {{ $.Values.storegateway.persistence.size }}

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -271,3 +271,52 @@ tests:
     asserts:
       - notExists:
           path: spec.template.metadata.annotations.placeholder
+
+  # -- global.storageClass behavior tests ---------------------------------
+
+  - it: uses cluster-default storageClass when both global.storageClass and component storageClass are empty for compactor
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.storageClass: ""
+      global.storageClass: ""
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+
+  - it: uses global.storageClass for compactor PVC when global is set and component empty
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      global.storageClass: my-global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: my-global-sc
+
+  - it: uses component storageClass when global.storageClass is empty for compactor
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.storageClass: comp-sc
+      global.storageClass: ""
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: comp-sc
+
+  - it: component storageClass overrides global for compactor
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.storageClass: comp-sc
+      global.storageClass: my-global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: comp-sc
+

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -296,3 +296,51 @@ tests:
     asserts:
       - notExists:
           path: spec.template.metadata.annotations.placeholder
+
+  # -- global.storageClass behavior tests ---------------------------------
+
+  - it: uses cluster-default storageClass when both global.storageClass and component storageClass are empty for compactor
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.storageClass: ""
+      global.storageClass: ""
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+
+  - it: uses global.storageClass for compactor PVC when global is set and component empty
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      global.storageClass: my-global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: my-global-sc
+
+  - it: uses component storageClass when global.storageClass is empty for compactor
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.storageClass: comp-sc
+      global.storageClass: ""
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: comp-sc
+
+  - it: component storageClass overrides global for compactor
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      compactor.persistence.enabled: true
+      compactor.persistence.storageClass: comp-sc
+      global.storageClass: my-global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: comp-sc

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -297,50 +297,104 @@ tests:
       - notExists:
           path: spec.template.metadata.annotations.placeholder
 
-  # -- global.storageClass behavior tests ---------------------------------
+  # -- global.storageClass -----------------------------------------------
 
-  - it: uses cluster-default storageClass when both global.storageClass and component storageClass are empty for compactor
-    template: compactor/statefulset.yaml
+  - it: renders no storageClassName when neither global nor component sets one
+    templates:
+      - compactor/statefulset.yaml
+      - receive/statefulset.yaml
+      - ruler/statefulset.yaml
+      - storegateway/statefulset.yaml
     set:
-      compactor.enabled: true
-      compactor.persistence.enabled: true
-      compactor.persistence.storageClass: ""
-      global.storageClass: ""
+      receive.enabled: true
+      ruler.enabled: true
     asserts:
       - notExists:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
 
-  - it: uses global.storageClass for compactor PVC when global is set and component empty
-    template: compactor/statefulset.yaml
+  - it: falls back to global.storageClass on every PVC-producing component
+    templates:
+      - compactor/statefulset.yaml
+      - receive/statefulset.yaml
+      - ruler/statefulset.yaml
+      - storegateway/statefulset.yaml
     set:
-      compactor.enabled: true
-      compactor.persistence.enabled: true
-      global.storageClass: my-global-sc
+      receive.enabled: true
+      ruler.enabled: true
+      global.storageClass: global-sc
     asserts:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
-          value: my-global-sc
+          value: global-sc
 
-  - it: uses component storageClass when global.storageClass is empty for compactor
-    template: compactor/statefulset.yaml
+  - it: lets the component storageClass win over global.storageClass
+    templates:
+      - compactor/statefulset.yaml
+      - receive/statefulset.yaml
+      - ruler/statefulset.yaml
+      - storegateway/statefulset.yaml
     set:
-      compactor.enabled: true
-      compactor.persistence.enabled: true
-      compactor.persistence.storageClass: comp-sc
-      global.storageClass: ""
+      receive.enabled: true
+      ruler.enabled: true
+      global.storageClass: global-sc
+      compactor.persistence.storageClass: compactor-sc
+      receive.persistence.storageClass: receive-sc
+      ruler.persistence.storageClass: ruler-sc
+      storegateway.persistence.storageClass: storegateway-sc
     asserts:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
-          value: comp-sc
+          value: compactor-sc
+        template: compactor/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: receive-sc
+        template: receive/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ruler-sc
+        template: ruler/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: storegateway-sc
+        template: storegateway/statefulset.yaml
 
-  - it: component storageClass overrides global for compactor
+  - it: keeps volumeAttributesClassName alongside the global storageClass
     template: compactor/statefulset.yaml
     set:
-      compactor.enabled: true
-      compactor.persistence.enabled: true
-      compactor.persistence.storageClass: comp-sc
-      global.storageClass: my-global-sc
+      global.storageClass: global-sc
+      compactor.persistence.volumeAttributesClassName: gold
+    capabilities:
+      apiVersions:
+        - storage.k8s.io/v1/VolumeAttributesClass
     asserts:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
-          value: comp-sc
+          value: global-sc
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.volumeAttributesClassName
+          value: gold
+
+  - it: does not render storageClassName when persistence is disabled
+    template: compactor/statefulset.yaml
+    set:
+      global.storageClass: global-sc
+      compactor.persistence.enabled: false
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: ignores global.storageClass when a component mounts an existing claim
+    template: compactor/statefulset.yaml
+    set:
+      global.storageClass: global-sc
+      compactor.persistence.existingClaim: compactor-existing-pvc
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: compactor-existing-pvc

--- a/charts/thanos/tests/receive_test.yaml
+++ b/charts/thanos/tests/receive_test.yaml
@@ -271,6 +271,52 @@ tests:
       - notExists:
           path: spec.volumeClaimTemplates
 
+  - it: falls back to global.storageClass when receive sets none
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: true
+      global.storageClass: global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+
+  - it: lets receive.persistence.storageClass win over global.storageClass
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.persistence.enabled: true
+      global.storageClass: global-sc
+      receive.persistence.storageClass: receive-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: receive-sc
+
+  - it: falls back to global.storageClass on the ingester in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      global.storageClass: global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+
+  - it: lets receive.ingester.persistence.storageClass win in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      global.storageClass: global-sc
+      receive.ingester.persistence.storageClass: ingester-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ingester-sc
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component annotations

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -129,6 +129,29 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
           value: 10Gi
 
+  - it: falls back to global.storageClass when ruler sets none
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.persistence.enabled: true
+      global.storageClass: global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+
+  - it: lets ruler.persistence.storageClass win over global.storageClass
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+      ruler.persistence.enabled: true
+      global.storageClass: global-sc
+      ruler.persistence.storageClass: ruler-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ruler-sc
+
   - it: uses emptyDir when persistence is disabled
     template: ruler/statefulset.yaml
     set:

--- a/charts/thanos/tests/storegateway_test.yaml
+++ b/charts/thanos/tests/storegateway_test.yaml
@@ -177,6 +177,91 @@ tests:
               claimName: ""
           any: true
 
+  - it: falls back to global.storageClass when storegateway sets none
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      global.storageClass: global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+
+  - it: lets storegateway.persistence.storageClass win over global.storageClass
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      global.storageClass: global-sc
+      storegateway.persistence.storageClass: storegateway-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: storegateway-sc
+
+  - it: falls back to global.storageClass on every shard when sharded
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 3
+      global.storageClass: global-sc
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+        documentIndex: 0
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+        documentIndex: 1
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+        documentIndex: 2
+
+  - it: lets storegateway.persistence.storageClass win on every shard
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+      global.storageClass: global-sc
+      storegateway.persistence.storageClass: storegateway-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: storegateway-sc
+        documentIndex: 0
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: storegateway-sc
+        documentIndex: 1
+
+  - it: still renders the shard storageClass when existingClaim is set and ignored
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.persistence.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+      storegateway.persistence.existingClaim: storegateway-existing-pvc
+      global.storageClass: global-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+        documentIndex: 0
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: global-sc
+        documentIndex: 1
+
   # -- Annotations and labels -----------------------------------------
 
   - it: applies component labels

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2074,6 +2074,13 @@
           "title": "priorityClassName",
           "type": "string"
         },
+        "storageClass": {
+          "default": "",
+          "description": "Default StorageClass name to use for PersistentVolumeClaims. When empty, components fall back to their own storageClass behavior, which means the cluster default StorageClass will apply when the component storageClass is also empty.",
+          "required": [],
+          "title": "storageClass",
+          "type": "string"
+        },
         "rbac": {
           "additionalProperties": true,
           "description": "RBAC and ServiceAccount defaults.\nRBAC configuration applied globally across all components.",

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2247,6 +2247,13 @@
           "title": "priorityClassName",
           "type": "string"
         },
+        "storageClass": {
+          "default": "",
+          "description": "Default StorageClass name to use for PersistentVolumeClaims. When empty, components fall back to their own storageClass behavior, which means the cluster default StorageClass will apply when the component storageClass is also empty.",
+          "required": [],
+          "title": "storageClass",
+          "type": "string"
+        },
         "rbac": {
           "additionalProperties": true,
           "description": "RBAC and ServiceAccount defaults.\nRBAC configuration applied globally across all components.",

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2247,13 +2247,6 @@
           "title": "priorityClassName",
           "type": "string"
         },
-        "storageClass": {
-          "default": "",
-          "description": "Default StorageClass name to use for PersistentVolumeClaims. When empty, components fall back to their own storageClass behavior, which means the cluster default StorageClass will apply when the component storageClass is also empty.",
-          "required": [],
-          "title": "storageClass",
-          "type": "string"
-        },
         "rbac": {
           "additionalProperties": true,
           "description": "RBAC and ServiceAccount defaults.\nRBAC configuration applied globally across all components.",
@@ -2422,6 +2415,13 @@
           ],
           "title": "serviceMonitor",
           "type": "object"
+        },
+        "storageClass": {
+          "default": "",
+          "description": "Default StorageClass name for every PersistentVolumeClaim the chart creates. A component's own `persistence.storageClass` takes precedence; when both are empty nothing is rendered and the cluster default StorageClass applies.",
+          "required": [],
+          "title": "storageClass",
+          "type": "string"
         },
         "thanosRules": {
           "additionalProperties": true,

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -95,6 +95,14 @@ global:
   # -- Priority class name applied to every pod by default.
   priorityClassName: ""
 
+  # -- Default StorageClass name to use for PersistentVolumeClaims.
+  # When set, components use this unless their own
+  # `persistence.storageClass` is configured.
+  # When empty (`""`), components fall back to their own storageClass behavior,
+  # which means the cluster default StorageClass will apply when the component
+  # storageClass is also empty.
+  storageClass: ""
+
   # -- Extra environment variables injected into every main container by default.
   # @default -- []
   extraEnv: []

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -107,12 +107,10 @@ global:
   # -- Priority class name applied to every pod by default.
   priorityClassName: ""
 
-  # -- Default StorageClass name to use for PersistentVolumeClaims.
-  # When set, components use this unless their own
-  # `persistence.storageClass` is configured.
-  # When empty (`""`), components fall back to their own storageClass behavior,
-  # which means the cluster default StorageClass will apply when the component
-  # storageClass is also empty.
+  # -- Default StorageClass name for every PersistentVolumeClaim the chart
+  # creates (Compactor, Receive, Ruler and Store Gateway). A component's own
+  # `persistence.storageClass` takes precedence; when both are empty no
+  # `storageClassName` is rendered and the cluster default StorageClass applies.
   storageClass: ""
 
   # -- Extra environment variables injected into every main container by default.

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -107,6 +107,14 @@ global:
   # -- Priority class name applied to every pod by default.
   priorityClassName: ""
 
+  # -- Default StorageClass name to use for PersistentVolumeClaims.
+  # When set, components use this unless their own
+  # `persistence.storageClass` is configured.
+  # When empty (`""`), components fall back to their own storageClass behavior,
+  # which means the cluster default StorageClass will apply when the component
+  # storageClass is also empty.
+  storageClass: ""
+
   # -- Extra environment variables injected into every main container by default.
   # @default -- []
   extraEnv: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `global.storageClass` as a chart-wide fallback for every PersistentVolumeClaim the chart creates: Compactor, Receive (the Ingester in split mode), Ruler and Store Gateway.

A component's own `persistence.storageClass` still wins. When both are empty nothing is rendered, so an install that never set either keeps using the cluster default StorageClass — the rendered output for a default install is byte-for-byte unchanged.

#### Special notes for your reviewer:

- The fallback lives in a `thanos.storageClass` helper rather than being repeated in four templates. It takes the same `(dict "root" . "key" <component> "persistence" <block>)` shape as the other PVC helpers and absorbs the `thanos.volumeAttributesClassName` include it used to sit next to, so each `volumeClaimTemplate` renders its storage fields from a single include.
- **Scope sweep:** `volumeClaimTemplates` only exist in `compactor/`, `receive/`, `ruler/` and `storegateway/statefulset.yaml`; nothing else in the chart creates a PVC. Query, Query Frontend and BucketWeb are Deployments with no persistence block — BucketWeb reads blocks straight from the object store on each request — so there is no PVC for the fallback to reach. All four PVC-producing components are covered.
- Tests: `global_test.yaml` runs the unset / global-fallback / component-override matrix against all four components at once; each component suite adds its own fallback and override case; Receive covers split mode, where persistence resolves from `receive.ingester.persistence`; Store Gateway covers real sharded rendering via `sharded.hashPartitioning.shards` and asserts every shard picks the class up. `volumeAttributesClassName` is asserted alongside a global `storageClass` since the same helper now renders both.
- Interaction with #164: `global.storageClass` is ignored when a component mounts an `existingClaim`, and a sharded Store Gateway that sets `existingClaim` still resolves the class on the `volumeClaimTemplates` it falls back to. Both are pinned down by tests.
- Docs: the upgrade note and a `Choosing a StorageClass` subsection live in `README.md.gotmpl`, which is what helm-docs generates `README.md` from, so they survive the next `helm-docs` run.

#### Upgrade note

`global` values propagate into subcharts. An umbrella chart that already sets `global.storageClass` for another dependency will now have Thanos render a `storageClassName` on StatefulSets that previously had none, and `volumeClaimTemplates` are immutable, so the upgrade is rejected with `field is immutable`. The README documents how to check for this and the two ways out (pin `persistence.storageClass: ""` per component, or recreate the StatefulSets with `--cascade=orphan`).

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
