### PR TITLE
feat(thanos): Per component service accounts

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.23.1
+version: 0.24.0
 appVersion: "v0.41.0"
 keywords:
   - thanos
@@ -51,5 +51,5 @@ annotations:
     - name: Slack
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
-    - kind: added
-      description: Per-component podLabels to set extra labels on pods (e.g. for workload identity), rendered via a shared thanos.podLabels helper for all workloads (bucketweb, compactor, query, query-frontend, store gateway, receive, receive ingester/router, ruler)
+    - kind: changed
+      description: Each component now gets its own dedicated ServiceAccount named <fullname>-<component> instead of a single shared ServiceAccount. Set global.serviceAccount.name to use a shared SA.

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -796,17 +796,19 @@ shards (hashmod on __block_id). Either dimension may be used on its own.
 {{- end -}}
 
 {{/*
-Resolve the ServiceAccount name.
-- When global.serviceAccount.create is true, defaults to "<fullname>-thanos"
-  unless global.serviceAccount.name overrides it.
-- When create is false, uses global.serviceAccount.name if provided, otherwise
-  falls back to the namespace "default" ServiceAccount.
+Resolve the ServiceAccount name for a specific component.
+Usage: {{ include "thanos.componentServiceAccountName" (list . "compactor") }}
+- create=true, no name override: "<fullname>-<component>" (one SA per component)
+- create=true, name override set: the override name (single shared SA for all components)
+- create=false: name override if set, otherwise "default"
 */}}
-{{- define "thanos.serviceAccountName" -}}
-{{- if .Values.global.serviceAccount.create -}}
-{{- default (printf "%s-%s" (include "thanos.fullname" .) "thanos") .Values.global.serviceAccount.name -}}
+{{- define "thanos.componentServiceAccountName" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- if $root.Values.global.serviceAccount.create -}}
+{{- default (include "thanos.compName" (list $root $comp)) $root.Values.global.serviceAccount.name -}}
 {{- else -}}
-{{- default "default" .Values.global.serviceAccount.name -}}
+{{- default "default" $root.Values.global.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . "bucketweb") }}
       {{- include "thanos.affinity" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" $ctx "key" "bucketweb") | nindent 6 }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . "compactor") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "compactor") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "compactor") | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . "query-frontend") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "queryFrontend") | nindent 6 }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . "query") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "query") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "query") | nindent 6 }}

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- $_ := set $anns "checksum/hashrings" (include "thanos.receive.hashrings" . | sha256sum) -}}
         {{- toYaml $anns | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . "receive-router") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "router" "parent" "receive") | nindent 6 }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         {{- $_ := set $anns "checksum/objstore-configuration" (.Values.global.objstore.config | sha256sum) -}}
         {{- toYaml $anns | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . (ternary "receive-ingester" "receive" (eq (include "thanos.receive.isSplit" .) "true"))) }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "ingester" "parent" "receive") | nindent 6 }}

--- a/charts/thanos/templates/ruler/rbac.yaml
+++ b/charts/thanos/templates/ruler/rbac.yaml
@@ -29,6 +29,6 @@ roleRef:
   name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
 subjects:
   - kind: ServiceAccount
-    name: {{ include "thanos.serviceAccountName" . }}
+    name: {{ include "thanos.componentServiceAccountName" (list . "ruler") }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list . "ruler") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "ruler") | nindent 6 }}

--- a/charts/thanos/templates/serviceaccount.yaml
+++ b/charts/thanos/templates/serviceaccount.yaml
@@ -1,10 +1,141 @@
 {{- if and .Values.global.serviceAccount.create .Values.global.rbac.create -}}
+{{- if .Values.global.serviceAccount.name }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccountName" . }}
+  name: {{ .Values.global.serviceAccount.name }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+  {{- with .Values.global.serviceAccount.annotations }}
   annotations:
-    {{- toYaml .Values.global.serviceAccount.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- else }}
+{{- /* One SA per enabled component */ -}}
+{{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "bucketweb") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.compactor.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "compactor") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.query.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "query") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.queryFrontend.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "query-frontend") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.receive.enabled }}
+{{- if eq (include "thanos.receive.isSplit" .) "true" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "receive-ingester") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-ingester
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "receive-router") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive-router
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- else }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "receive") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.ruler.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "ruler") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.storegateway.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.compName" (list . "storegateway") }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" $ }}
+      serviceAccountName: {{ include "thanos.componentServiceAccountName" (list $ "storegateway") }}
       {{- include "thanos.affinity" (dict "Values" $.Values "component" "storegateway") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" $ | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" $ "key" "storegateway") | nindent 6 }}

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -11,6 +11,8 @@ tests:
     asserts:
       - isKind:
           of: ServiceAccount
+      - hasDocuments:
+          count: 4
 
   - it: does not render serviceaccount when create is false
     template: serviceaccount.yaml
@@ -42,11 +44,11 @@ tests:
           path: metadata.annotations.custom-annotation
           value: my-value
 
-  # -- ServiceAccount name resolution (thanos.serviceAccountName) --------
+  # -- ServiceAccount name resolution (thanos.componentServiceAccountName) --------
   # Exercises every branch of the helper through the pod spec, plus the
   # ClusterRoleBinding subject which must never resolve to an empty name.
 
-  - it: defaults the pod serviceAccountName to <fullname>-thanos when create is true
+  - it: defaults the pod serviceAccountName to <fullname>-<component> when create is true
     template: bucket/deployment.yaml
     set:
       bucket.enabled: true
@@ -55,7 +57,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-thanos-thanos
+          value: RELEASE-NAME-thanos-bucketweb
 
   - it: uses the name override for the pod serviceAccountName when create is true
     template: bucket/deployment.yaml
@@ -92,7 +94,7 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: custom-sa
 
-  - it: binds the ruler rule-importer to the resolved serviceaccount name
+  - it: binds the ruler rule-importer to the ruler serviceaccount name
     template: ruler/rbac.yaml
     documentIndex: 1
     set:
@@ -103,7 +105,7 @@ tests:
     asserts:
       - equal:
           path: subjects[0].name
-          value: RELEASE-NAME-thanos-thanos
+          value: RELEASE-NAME-thanos-ruler
 
   - it: binds the ruler rule-importer to the default serviceaccount when create is false
     template: ruler/rbac.yaml

--- a/charts/thanos/tests/ruler_test.yaml
+++ b/charts/thanos/tests/ruler_test.yaml
@@ -1365,7 +1365,7 @@ tests:
         documentIndex: 1
       - equal:
           path: subjects[0].name
-          value: RELEASE-NAME-thanos-thanos
+          value: RELEASE-NAME-thanos-ruler
         documentIndex: 1
 
   - it: does not render rbac when ruler is disabled


### PR DESCRIPTION
#### What this PR does / why we need it:
- Introduce per-component Kubernetes service account so cloud identity can be properly scoped to each component.

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
