### PR TITLE
fix: add missing thanos chart version bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,14 @@
       "labels": [
         "renovate",
         "thanos"
+      ],
+      "bumpVersions": [
+        {
+          "name": "Bump chart version on Thanos updates",
+          "filePatterns": ["charts/*/Chart.yaml"],
+          "matchStrings": ["^version:\\s+(?<version>[^\\s]+)"],
+          "bumpType": "minor"
+        }
       ]
     },
     {


### PR DESCRIPTION
<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fixes Renovate so that a Thanos version update also bumps the Helm chart `version`.

Previously, `bumpVersion` was only configured under the `helmv3` manager, which
only reacts to updates of the chart's `dependencies:` (kube-prometheus-stack,
rustfs). Thanos updates, however, are applied by two *other* managers — the
custom regex manager (`appVersion` in `Chart.yaml`) and the helm-values manager
(the image tag in `values.yaml`). Neither triggers the helmv3 `bumpVersion`, so
Thanos update PRs opened without any bump to the chart `version`.

This adds a `bumpVersions` entry scoped inside the existing Thanos `packageRule`,
so a chart `version` minor bump now happens whenever Thanos is updated — while
leaving the existing `helmv3.bumpVersion` behavior for helm dependencies
untouched.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [ ] Chart Version bumped (if the pr is an update to an existing chart)
- [ ] Variables are documented in the README.md
