### PR TITLE
feat(thanos): allow disabling automountServiceAccountToken

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.30.0
+version: 0.31.0
 appVersion: "v0.42.4"
 keywords:
   - thanos
@@ -52,4 +52,4 @@ annotations:
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
     - kind: added
-      description: Per-component podLabels to set extra labels on pods (e.g. for workload identity), rendered via a shared thanos.podLabels helper for all workloads (bucketweb, compactor, query, query-frontend, store gateway, receive, receive ingester/router, ruler)
+      description: Option to disable automountServiceAccountToken for all Thanos components if not desired

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.25.1](https://img.shields.io/badge/Version-0.25.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.2](https://img.shields.io/badge/AppVersion-v0.42.2-informational?style=flat-square)
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -45,8 +45,8 @@ Kubernetes: `>= 1.30.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.rustfs.com/ | rustfs | 0.8.0 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 87.14.0 |
+| https://charts.rustfs.com/ | rustfs | 0.12.0 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 88.0.1 |
 
 ## Component Overview
 
@@ -707,6 +707,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |
 | global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount. |
+| global.serviceAccount.automountServiceAccountToken | bool | `true` | Mount the ServiceAccount token into pods by default. Set to false to disable automounting the token for all components. |
 | global.serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount for each component. |
 | global.serviceAccount.name | string | `""` | Name override for all ServiceAccounts. Empty means auto-generate per-component names based on the release name. |
 | global.serviceMonitor.annotations | object | {} | Extra annotations merged into every ServiceMonitor resource. |

--- a/charts/thanos/templates/serviceaccount.yaml
+++ b/charts/thanos/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.global.serviceAccount.create .Values.global.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.global.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "thanos.serviceAccountName" . }}
   namespace: {{ include "thanos.namespace" . }}

--- a/charts/thanos/tests/global_test.yaml
+++ b/charts/thanos/tests/global_test.yaml
@@ -30,6 +30,22 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: mounts the serviceaccount token by default
+    template: serviceaccount.yaml
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: disables serviceaccount token automount when set to false
+    template: serviceaccount.yaml
+    set:
+      global.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
   - it: applies serviceaccount annotations
     template: serviceaccount.yaml
     set:

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2134,6 +2134,13 @@
               "title": "annotations",
               "type": "object"
             },
+            "automountServiceAccountToken": {
+              "default": true,
+              "description": "Mount the ServiceAccount token into pods by default. Set to false to\ndisable automounting the token for all components.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": "boolean"
+            },
             "create": {
               "default": true,
               "description": "Create a dedicated ServiceAccount for each component.",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -179,6 +179,9 @@ global:
     # -- Extra annotations merged into every ServiceAccount.
     # @default -- {}
     annotations: {}
+    # -- Mount the ServiceAccount token into pods by default. Set to false to
+    # disable automounting the token for all components.
+    automountServiceAccountToken: true
     # -- Name override for all ServiceAccounts. Empty means auto-generate
     # per-component names based on the release name.
     name: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a new value `global.serviceAccount.automountServiceAccountToken` (default `true`) that is rendered on the ServiceAccount. Since no component sets the field at pod level, all pods inherit it, so setting it to `false` disables mounting the ServiceAccount token chart-wide — useful for hardening deployments that don't need Kubernetes API access.

The default keeps current behavior unchanged (Kubernetes defaults the field to `true`).

Note: with the token unmounted, the Ruler's rule auto-import (which talks to the API server) will not work, so users enabling this need that feature disabled.

#### Special notes for your reviewer:

This might be conflicting with: https://github.com/thanos-community/helm-charts/pull/180

Unit tests added for both the default and the disabled case; `helm unittest` passes (668 tests). README regenerated with helm-docs v1.14.2 and `values.schema.json` updated.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
