### PR TITLE
feat: add namespace support and naming overrides for Thanos chart

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.25.1
+version: 0.26.0
 appVersion: "v0.42.2"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.41.0](https://img.shields.io/badge/AppVersion-v0.41.0-informational?style=flat-square)
+![Version: 0.25.1](https://img.shields.io/badge/Version-0.25.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.2](https://img.shields.io/badge/AppVersion-v0.42.2-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -46,7 +46,7 @@ Kubernetes: `>= 1.30.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.rustfs.com/ | rustfs | 0.8.0 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 87.0.1 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 87.14.0 |
 
 ## Component Overview
 
@@ -672,6 +672,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.vpa.minAllowed.memory | string | `"512Mi"` | Minimum memory resource enforced by the Compactor VPA. |
 | compactor.vpa.targetKind | string | `"StatefulSet"` | Kubernetes workload kind targeted by the Compactor VPA. |
 | compactor.vpa.updateMode | string | `"Auto"` | VPA update mode for the Compactor. One of Auto, Off, or Initial. |
+| fullnameOverride | string | `""` | Fully override the generated resource name (`thanos.fullname`). Empty uses `<release>-<chart>`. |
 | global.affinity | object | {} | Affinity rules applied to every pod by default. |
 | global.clusterDomain | string | `"cluster.local"` | Cluster DNS domain, used when constructing in-cluster endpoints. |
 | global.commonLabels | object | {} | Extra labels merged into every Kubernetes resource created by this chart. |
@@ -763,6 +764,8 @@ The table below documents all available values. Top-level keys group settings by
 | global.tolerations | list | [] | Toleration rules applied to every pod by default. |
 | global.topologySpreadConstraints | list | [] | Topology spread constraints applied to every pod by default. |
 | kube-prometheus-stack.enabled | bool | `false` | Enable the kube-prometheus-stack subchart. Deploys Prometheus Operator and associated components into the same namespace as Thanos. |
+| nameOverride | string | `""` | Partially override the chart name used to build resource names. Empty uses the chart name. |
+| namespaceOverride | string | `""` | Namespace to deploy all chart resources into. Empty uses the release namespace (`.Release.Namespace`). |
 | query.affinity | object | {} | Affinity rules for Query pod scheduling. |
 | query.annotations | object | {} | Extra annotations applied to Query resources. |
 | query.autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler for the Query component. |

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -15,6 +15,14 @@
 {{- end -}}
 {{- end -}}
 
+{{- /*
+Resolve the namespace all chart resources are deployed into.
+Defaults to the release namespace unless `.Values.namespaceOverride` overrides it.
+*/ -}}
+{{- define "thanos.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
 {{- define "thanos.compName" -}}
 {{- $root := index . 0 -}}
 {{- $comp := index . 1 -}}
@@ -690,7 +698,7 @@ same helper produces a valid hashring for both standalone and split modes.
 {{- $vals := include "thanos.receive.cfg" . | fromYaml -}}
 {{- $grpcPort := int (dig "service" "grpcPort" 10901 $vals) -}}
 {{- $rc := int (default 1 $vals.replicaCount) -}}
-{{- $ns := .Release.Namespace -}}
+{{- $ns := include "thanos.namespace" . -}}
 {{- $domain := .Values.global.clusterDomain | default "cluster.local" -}}
 
 {{- if and (hasKey $vals "hashrings") (hasKey $vals.hashrings "static") (gt (len $vals.hashrings.static) 0) -}}
@@ -843,7 +851,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "thanos.compName" (list $root $comp) }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ include "thanos.namespace" $root }}
   labels:
     {{- include "thanos.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $comp }}
@@ -888,7 +896,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: {{ include "thanos.compName" (list $root $comp) }}-grpc
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ include "thanos.namespace" $root }}
   labels:
     {{- include "thanos.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $comp }}

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.bucket.bucketweb.labels }}

--- a/charts/thanos/templates/bucket/hpa.yaml
+++ b/charts/thanos/templates/bucket/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/bucket/ingress.yaml
+++ b/charts/thanos/templates/bucket/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/bucket/networkpolicy.yaml
+++ b/charts/thanos/templates/bucket/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/bucket/pdb.yaml
+++ b/charts/thanos/templates/bucket/pdb.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/bucket/secret-objstore.yaml
+++ b/charts/thanos/templates/bucket/secret-objstore.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.global.objstore.secretName }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/bucket/service.yaml
+++ b/charts/thanos/templates/bucket/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: bucketweb
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/bucket/servicemonitor.yaml
+++ b/charts/thanos/templates/bucket/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.bucket.bucketweb.serviceMonitor.labels }}{{ toYaml .Values.bucket.bucketweb.serviceMonitor.labels | nindent 4 }}{{- end }}
@@ -11,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/compactor/ingress.yaml
+++ b/charts/thanos/templates/compactor/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/compactor/networkpolicy.yaml
+++ b/charts/thanos/templates/compactor/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: compactor
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/compactor/pdb.yaml
+++ b/charts/thanos/templates/compactor/pdb.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/compactor/service.yaml
+++ b/charts/thanos/templates/compactor/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: compactor
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/compactor/servicemonitor.yaml
+++ b/charts/thanos/templates/compactor/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.compactor.serviceMonitor.labels }}{{ toYaml .Values.compactor.serviceMonitor.labels | nindent 4 }}{{- end }}
@@ -11,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.compactor.labels }}

--- a/charts/thanos/templates/compactor/vpa.yaml
+++ b/charts/thanos/templates/compactor/vpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/prometheusrule/rule.yaml
+++ b/charts/thanos/templates/prometheusrule/rule.yaml
@@ -15,6 +15,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "thanos.fullname" . }}-rules
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/name: thanos
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/query-frontend/configmap-cache.yaml
+++ b/charts/thanos/templates/query-frontend/configmap-cache.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}-cache
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.queryFrontend.labels }}

--- a/charts/thanos/templates/query-frontend/hpa.yaml
+++ b/charts/thanos/templates/query-frontend/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/query-frontend/ingress.yaml
+++ b/charts/thanos/templates/query-frontend/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/query-frontend/networkpolicy.yaml
+++ b/charts/thanos/templates/query-frontend/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/query-frontend/pdb.yaml
+++ b/charts/thanos/templates/query-frontend/pdb.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/query-frontend/service.yaml
+++ b/charts/thanos/templates/query-frontend/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: query-frontend
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/charts/thanos/templates/query-frontend/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.queryFrontend.serviceMonitor.labels }}{{ toYaml .Values.queryFrontend.serviceMonitor.labels | nindent 4 }}{{- end }}
@@ -11,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.query.labels }}
@@ -45,13 +46,13 @@ spec:
         {{- if .Values.query.endpoints.autogen.enabled }}
           {{- if .Values.storegateway.enabled }}
             # - --endpoint={{ include "thanos.compName" (list . "storegateway") }}:{{ .Values.storegateway.service.grpcPort }}
-            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "storegateway") }}.{{ include "thanos.namespace" . }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
           {{- if .Values.receive.enabled }}
-            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.receiveHeadless" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.receiveHeadless" . }}.{{ include "thanos.namespace" . }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
           {{- if .Values.ruler.enabled }}
-            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "ruler") }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "thanos.compName" (list . "ruler") }}-headless.{{ include "thanos.namespace" . }}.svc.{{ .Values.global.clusterDomain }}
           {{- end }}
         {{- end }}
           {{- range .Values.query.endpoints.static }}

--- a/charts/thanos/templates/query/hpa.yaml
+++ b/charts/thanos/templates/query/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/query/ingress.yaml
+++ b/charts/thanos/templates/query/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
   name: {{ include "thanos.compName" (list $ (printf "query%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
+  namespace: {{ include "thanos.namespace" $ }}
 spec:
   {{- with $ingress.className }}
   ingressClassName: {{ . }}

--- a/charts/thanos/templates/query/networkpolicy.yaml
+++ b/charts/thanos/templates/query/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: query
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/query/pdb.yaml
+++ b/charts/thanos/templates/query/pdb.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/query/service.yaml
+++ b/charts/thanos/templates/query/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: query
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/query/servicemonitor.yaml
+++ b/charts/thanos/templates/query/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "query") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.query.serviceMonitor.labels }}{{ toYaml .Values.query.serviceMonitor.labels | nindent 4 }}{{- end }}
@@ -11,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/receive/configmap-hashrings.yaml
+++ b/charts/thanos/templates/receive/configmap-hashrings.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.receive.hashringsConfigMapName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/receive/ingress.yaml
+++ b/charts/thanos/templates/receive/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
   name: {{ include "thanos.compName" (list $ (printf "receive%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
+  namespace: {{ include "thanos.namespace" $ }}
 spec:
   {{- with $ingress.className }}
   ingressClassName: {{ . }}

--- a/charts/thanos/templates/receive/networkpolicy.yaml
+++ b/charts/thanos/templates/receive/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: receive
   name: {{ include "thanos.receive.workloadName" . }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/receive/pdb.yaml
+++ b/charts/thanos/templates/receive/pdb.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.receive.workloadName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.receive.workloadName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}
@@ -32,6 +33,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.receiveHeadless" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/receive/servicemonitor.yaml
+++ b/charts/thanos/templates/receive/servicemonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.receive.workloadName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if $sm.labels }}{{ toYaml $sm.labels | nindent 4 }}{{- end }}
@@ -13,7 +14,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: receive-router

--- a/charts/thanos/templates/receive/split/router-httproute.yaml
+++ b/charts/thanos/templates/receive/split/router-httproute.yaml
@@ -6,7 +6,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "thanos.receive.routerName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: receive-router

--- a/charts/thanos/templates/receive/split/router-ingress.yaml
+++ b/charts/thanos/templates/receive/split/router-ingress.yaml
@@ -18,6 +18,7 @@ metadata:
     {{- include "thanos.labels" $ | nindent 4 }}
     app.kubernetes.io/component: receive-router
   name: {{ include "thanos.compName" (list $ (printf "receive-router%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
+  namespace: {{ include "thanos.namespace" $ }}
 spec:
   {{- with $ingress.className }}
   ingressClassName: {{ . }}

--- a/charts/thanos/templates/receive/split/router-networkpolicy.yaml
+++ b/charts/thanos/templates/receive/split/router-networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: receive-router
   name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/receive/split/router-pdb.yaml
+++ b/charts/thanos/templates/receive/split/router-pdb.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: receive-router

--- a/charts/thanos/templates/receive/split/router-service.yaml
+++ b/charts/thanos/templates/receive/split/router-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: receive-router
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/receive/split/router-servicemonitor.yaml
+++ b/charts/thanos/templates/receive/split/router-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if $sm.labels }}{{ toYaml $sm.labels | nindent 4 }}{{- end }}
@@ -12,7 +13,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/receive/split/router-vpa.yaml
+++ b/charts/thanos/templates/receive/split/router-vpa.yaml
@@ -4,6 +4,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "thanos.receive.routerName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: receive-router

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "thanos.receive.workloadName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with $cfg.labels }}

--- a/charts/thanos/templates/receive/vpa.yaml
+++ b/charts/thanos/templates/receive/vpa.yaml
@@ -5,6 +5,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "thanos.receive.workloadName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
+++ b/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-am
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/ruler/configmap-auto-import-prometheus-rules.yaml
+++ b/charts/thanos/templates/ruler/configmap-auto-import-prometheus-rules.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
+  namespace: {{ include "thanos.namespace" . }}
 data:
   import.sh: |
     set -e

--- a/charts/thanos/templates/ruler/configmap-query.yaml
+++ b/charts/thanos/templates/ruler/configmap-query.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-query
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/ruler/configmaprules.yaml
+++ b/charts/thanos/templates/ruler/configmaprules.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-rules
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/ruler/ingress.yaml
+++ b/charts/thanos/templates/ruler/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/ruler/networkpolicy.yaml
+++ b/charts/thanos/templates/ruler/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: ruler
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/ruler/pdb.yaml
+++ b/charts/thanos/templates/ruler/pdb.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/ruler/rbac.yaml
+++ b/charts/thanos/templates/ruler/rbac.yaml
@@ -30,5 +30,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "thanos.namespace" . }}
 {{- end }}

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   ports:
     - name: http
@@ -38,6 +39,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "thanos.compName" (list . "ruler") }}-headless
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/charts/thanos/templates/ruler/servicemonitor.yaml
+++ b/charts/thanos/templates/ruler/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.ruler.serviceMonitor.labels }}{{ toYaml .Values.ruler.serviceMonitor.labels | nindent 4 }}{{- end }}
@@ -11,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with .Values.ruler.labels }}

--- a/charts/thanos/templates/rustfs/init-bucket.yaml
+++ b/charts/thanos/templates/rustfs/init-bucket.yaml
@@ -7,6 +7,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "thanos.compName" (list . "init-bucket") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
 spec:

--- a/charts/thanos/templates/serviceaccount.yaml
+++ b/charts/thanos/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "thanos.serviceAccountName" . }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/storegateway/configmap-caching.yaml
+++ b/charts/thanos/templates/storegateway/configmap-caching.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}-caching
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/storegateway/hpa.yaml
+++ b/charts/thanos/templates/storegateway/hpa.yaml
@@ -8,6 +8,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $shard.name }}
+  namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/storegateway/ingress.yaml
+++ b/charts/thanos/templates/storegateway/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
   name: {{ include "thanos.compName" (list $ (printf "storegateway%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
+  namespace: {{ include "thanos.namespace" $ }}
 spec:
   {{- with $ingress.className }}
   ingressClassName: {{ . }}

--- a/charts/thanos/templates/storegateway/networkpolicy.yaml
+++ b/charts/thanos/templates/storegateway/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
   name: {{ include "thanos.compName" (list . "storegateway") }}
+  namespace: {{ include "thanos.namespace" . }}
 spec:
   egress:
     - {}

--- a/charts/thanos/templates/storegateway/pdb.yaml
+++ b/charts/thanos/templates/storegateway/pdb.yaml
@@ -10,6 +10,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $shard.name }}
+  namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
   annotations:

--- a/charts/thanos/templates/storegateway/service.yaml
+++ b/charts/thanos/templates/storegateway/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     app.kubernetes.io/component: storegateway
     {{- include "thanos.labels" . | nindent 4 }}
@@ -45,6 +46,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $shard.name }}
+  namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
     thanos.io/storegateway-shard: {{ $shard.index | quote }}

--- a/charts/thanos/templates/storegateway/servicemonitor.yaml
+++ b/charts/thanos/templates/storegateway/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
+  namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.storegateway.serviceMonitor.labels }}{{ toYaml .Values.storegateway.serviceMonitor.labels | nindent 4 }}{{- end }}
@@ -11,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -8,6 +8,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ $shard.name }}
+  namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
     {{- with $.Values.storegateway.labels }}

--- a/charts/thanos/tests/naming_test.yaml
+++ b/charts/thanos/tests/naming_test.yaml
@@ -1,0 +1,567 @@
+suite: chart naming and namespace placement
+
+# Covers the three top-level naming values and the `thanos.namespace` helper:
+#   nameOverride       -> thanos.name
+#   fullnameOverride   -> thanos.fullname (and every thanos.compName derived name)
+#   namespaceOverride  -> metadata.namespace on every namespaced resource,
+#                         plus every in-chart cross-reference to that namespace
+#                         (DNS endpoints, hashrings, ServiceMonitor selectors,
+#                         ClusterRoleBinding subjects).
+
+tests:
+  # -- namespaceOverride: default behaviour -------------------------------
+
+  - it: defaults metadata.namespace to the release namespace
+    template: bucket/service.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-release-ns
+
+  - it: ignores an empty namespaceOverride and falls back to the release namespace
+    template: bucket/service.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      namespaceOverride: ""
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-release-ns
+
+  - it: overrides the release namespace when namespaceOverride is set
+    template: bucket/service.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      namespaceOverride: custom-ns
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # -- namespaceOverride: workload kinds ----------------------------------
+
+  - it: sets the namespace on a Deployment
+    template: query/deployment.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a StatefulSet
+    template: compactor/statefulset.yaml
+    set:
+      namespaceOverride: custom-ns
+      compactor.enabled: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a Job
+    template: rustfs/init-bucket.yaml
+    set:
+      namespaceOverride: custom-ns
+      rustfs.enabled: true
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # -- namespaceOverride: resources rendered inside a range ---------------
+  # These templates loop (shards / per-port ingresses) so the helper must be
+  # called with `$` rather than `.`; a wrong root renders an empty namespace.
+
+  - it: sets the namespace on every sharded storegateway StatefulSet
+    template: storegateway/statefulset.yaml
+    set:
+      namespaceOverride: custom-ns
+      storegateway.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 3
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on the per-shard storegateway Services
+    template: storegateway/service.yaml
+    set:
+      namespaceOverride: custom-ns
+      storegateway.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on an Ingress rendered per port
+    template: query/ingress.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      query.ingress.enabled: true
+      query.ingress.hosts:
+        - host: query.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # -- namespaceOverride: remaining namespaced kinds ----------------------
+
+  - it: sets the namespace on a Service
+    template: query/service.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on both the receive Service and its headless Service
+    template: receive/service.yaml
+    set:
+      namespaceOverride: custom-ns
+      receive.enabled: true
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a ConfigMap
+    template: receive/configmap-hashrings.yaml
+    set:
+      namespaceOverride: custom-ns
+      receive.enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a Secret
+    template: bucket/secret-objstore.yaml
+    set:
+      namespaceOverride: custom-ns
+      bucket.enabled: true
+      global.objstore.createSecret: true
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a HorizontalPodAutoscaler
+    template: query/hpa.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      query.autoscaling.enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a PodDisruptionBudget
+    template: query/pdb.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      query.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a VerticalPodAutoscaler
+    template: compactor/vpa.yaml
+    capabilities:
+      apiVersions:
+        - autoscaling.k8s.io/v1/VerticalPodAutoscaler
+    set:
+      namespaceOverride: custom-ns
+      compactor.enabled: true
+      compactor.vpa.enabled: true
+    asserts:
+      - isKind:
+          of: VerticalPodAutoscaler
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a NetworkPolicy
+    template: query/networkpolicy.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a ServiceMonitor
+    template: query/servicemonitor.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      global.serviceMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on the ServiceAccount
+    template: serviceaccount.yaml
+    set:
+      namespaceOverride: custom-ns
+      global.serviceAccount.create: true
+      global.rbac.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on the PrometheusRule
+    template: prometheusrule/rule.yaml
+    set:
+      namespaceOverride: custom-ns
+      global.thanosRules.enabled: true
+    asserts:
+      - isKind:
+          of: PrometheusRule
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # -- namespaceOverride: Gateway API routes (rendered via helpers) -------
+
+  - it: sets the namespace on an HTTPRoute rendered by the shared helper
+    template: query/httproute.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on a GRPCRoute rendered by the shared helper
+    template: query/grpcroute.yaml
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      query.grpcRoute.enabled: true
+      query.grpcRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - isKind:
+          of: GRPCRoute
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # -- namespaceOverride: split-mode receive ------------------------------
+
+  - it: sets the namespace on the split-mode router Deployment
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      namespaceOverride: custom-ns
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: sets the namespace on the split-mode router HTTPRoute
+    template: receive/split/router-httproute.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      namespaceOverride: custom-ns
+      receive.router.httpRoute.enabled: true
+      receive.router.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # -- namespaceOverride: cluster-scoped resources are exempt -------------
+
+  - it: does not set a namespace on the cluster-scoped ClusterRole
+    template: ruler/rbac.yaml
+    documentIndex: 0
+    set:
+      namespaceOverride: custom-ns
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - notExists:
+          path: metadata.namespace
+
+  - it: does not set a namespace on the cluster-scoped ClusterRoleBinding
+    template: ruler/rbac.yaml
+    documentIndex: 1
+    set:
+      namespaceOverride: custom-ns
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - notExists:
+          path: metadata.namespace
+
+  # -- namespaceOverride: in-chart cross-references follow the override ---
+  # A resource landing in the right namespace is not enough: everything that
+  # *points at* those resources must resolve to the same namespace too.
+
+  - it: points the ClusterRoleBinding subject at the override namespace
+    template: ruler/rbac.yaml
+    documentIndex: 1
+    release:
+      namespace: my-release-ns
+    set:
+      namespaceOverride: custom-ns
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: custom-ns
+
+  - it: resolves query autogen DNS endpoints in the override namespace
+    template: query/deployment.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      query.endpoints.autogen.enabled: true
+      storegateway.enabled: true
+      receive.enabled: true
+      ruler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-storegateway.custom-ns.svc.cluster.local
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-receive-headless.custom-ns.svc.cluster.local
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.RELEASE-NAME-thanos-ruler-headless.custom-ns.svc.cluster.local
+
+  - it: resolves receive hashring endpoints in the override namespace
+    template: receive/configmap-hashrings.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      namespaceOverride: custom-ns
+      receive.enabled: true
+      receive.replicaCount: 2
+      receive.hashrings.autogen.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: RELEASE-NAME-thanos-receive-0\.RELEASE-NAME-thanos-receive-headless\.custom-ns\.svc\.cluster\.local:10901
+
+  - it: scopes the ServiceMonitor namespaceSelector to the override namespace
+    template: query/servicemonitor.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      namespaceOverride: custom-ns
+      query.enabled: true
+      global.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: custom-ns
+
+  # -- fullnameOverride ---------------------------------------------------
+
+  - it: defaults resource names to <release>-<chart>-<component>
+    template: query/service.yaml
+    set:
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-query
+
+  - it: fully overrides the generated name on a Service
+    template: query/service.yaml
+    set:
+      fullnameOverride: my-thanos
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-query
+
+  - it: fully overrides the generated name on a StatefulSet
+    template: compactor/statefulset.yaml
+    set:
+      fullnameOverride: my-thanos
+      compactor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-compactor
+
+  - it: applies fullnameOverride to the receive headless Service name
+    template: receive/service.yaml
+    documentIndex: 1
+    set:
+      fullnameOverride: my-thanos
+      receive.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-receive-headless
+
+  - it: applies fullnameOverride to the ServiceAccount name and its pod reference
+    template: serviceaccount.yaml
+    set:
+      fullnameOverride: my-thanos
+      global.serviceAccount.create: true
+      global.rbac.create: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-thanos
+
+  - it: applies fullnameOverride to the cluster-scoped ClusterRole name
+    template: ruler/rbac.yaml
+    documentIndex: 0
+    set:
+      fullnameOverride: my-thanos
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      global.rbac.create: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-ruler-rule-importer
+
+  - it: applies fullnameOverride to autogen DNS endpoints
+    template: query/deployment.yaml
+    set:
+      fullnameOverride: my-thanos
+      query.enabled: true
+      query.endpoints.autogen.enabled: true
+      storegateway.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --endpoint=dnssrv+_grpc._tcp.my-thanos-storegateway.NAMESPACE.svc.cluster.local
+
+  # -- nameOverride -------------------------------------------------------
+
+  - it: uses nameOverride in the generated resource name
+    template: query/service.yaml
+    set:
+      nameOverride: mythanos
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mythanos-query
+
+  - it: uses nameOverride for the app.kubernetes.io/name label
+    template: query/service.yaml
+    set:
+      nameOverride: mythanos
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: mythanos
+
+  - it: lets fullnameOverride win over nameOverride for resource names
+    template: query/service.yaml
+    set:
+      nameOverride: mythanos
+      fullnameOverride: my-thanos
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-query
+
+  # -- combined -----------------------------------------------------------
+
+  - it: applies fullnameOverride and namespaceOverride together
+    template: query/deployment.yaml
+    release:
+      namespace: my-release-ns
+    set:
+      fullnameOverride: my-thanos
+      namespaceOverride: custom-ns
+      query.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-thanos-query
+      - equal:
+          path: metadata.namespace
+          value: custom-ns

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
     "bucket": {
       "additionalProperties": true,
       "description": "======================================================================\nBucket component\nRead-only web UI for inspecting object store blocks.\nOften disabled in production; useful for debugging compaction issues.\n======================================================================\nBucket component group. Contains the Bucketweb UI sub-chart.",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -7,6 +7,16 @@
 # ======================================================================
 
 # ======================================================================
+# Chart naming and placement
+# ======================================================================
+# -- Partially override the chart name used to build resource names. Empty uses the chart name.
+nameOverride: ""
+# -- Fully override the generated resource name (`thanos.fullname`). Empty uses `<release>-<chart>`.
+fullnameOverride: ""
+# -- Namespace to deploy all chart resources into. Empty uses the release namespace (`.Release.Namespace`).
+namespaceOverride: ""
+
+# ======================================================================
 # Global settings
 # Applied as sensible defaults to all components.
 # Each component can override with its own section if needed.


### PR DESCRIPTION
This pull request introduces several improvements to the Thanos Helm chart, focusing primarily on namespace management and documentation updates. The most significant change is the addition of a `namespaceOverride` value and associated helper, allowing users to deploy all Thanos resources into a custom namespace instead of the default release namespace. Additionally, the documentation and versioning have been updated, and several resource manifests have been modified to consistently use the new namespace logic.

**Namespace management improvements:**

* Added a `namespaceOverride` value and the `thanos.namespace` helper in `_helpers.tpl`, enabling deployment of all chart resources into a user-specified namespace instead of the default release namespace. All resource templates now use this helper for the `namespace` field. [[1]](diffhunk://#diff-a12b3d2485d8e1ed9458f8821b969e37ec9b42cafca7bbd9a1ce34d9cd470e48R18-R25) [[2]](diffhunk://#diff-a12b3d2485d8e1ed9458f8821b969e37ec9b42cafca7bbd9a1ce34d9cd470e48L693-R701) [[3]](diffhunk://#diff-a12b3d2485d8e1ed9458f8821b969e37ec9b42cafca7bbd9a1ce34d9cd470e48L846-R854) [[4]](diffhunk://#diff-a12b3d2485d8e1ed9458f8821b969e37ec9b42cafca7bbd9a1ce34d9cd470e48L891-R899) [[5]](diffhunk://#diff-738fda3ee7ab2f3e8e88256db4bb9a5aa1da8d4280ed627c9e7768bf165312d3R7) [[6]](diffhunk://#diff-d83ed522186d1af361bc09eed1a2c7111e55af515ecfe1059d0d9a85fed57b1eR6) [[7]](diffhunk://#diff-c1374c3cffda7ffa8e87454d15435e612ff919bad90624c791a158b70a83f92cR6) [[8]](diffhunk://#diff-a0c01df78e9bb5748f7364b0ef1f8f87ecf1c62e629a3abd56436b40d2eb22e2R9) [[9]](diffhunk://#diff-d39efadc5092ff5b8eb2a4dda2dfa960d459e06b9f56425e9aa53ef372b18ab9R8) [[10]](diffhunk://#diff-f48caf3f1abcb21cacc217ed217e79f36e4f997923c79cc7d3030e0f6ee78cbfR6) [[11]](diffhunk://#diff-cb0f296492ae810362f312f4d154347ef2ee046d78fd372980ecb94bacd91b1dR6) [[12]](diffhunk://#diff-e9b8bbfc096dca5ce4c620c470243b3a1df3f107d9aeeab2e7a89e77688e7530R6) [[13]](diffhunk://#diff-e9b8bbfc096dca5ce4c620c470243b3a1df3f107d9aeeab2e7a89e77688e7530L14-R15) [[14]](diffhunk://#diff-9b24d131b0437e0d0f28d8658907b81fa56914750c7ce14557bdc4003e5c8841R6) [[15]](diffhunk://#diff-f43a2c77f855b2a2f833dabca4cfa4f8dd30d7da3bcaa29a1897b9809e4472b7R9) [[16]](diffhunk://#diff-5a6645f7386d9ee0c501df56f3f2cea928408002f89647de1e6919ea18c662ccR8) [[17]](diffhunk://#diff-5f867eeaf762a939b787aacb9c357c108545fbb40fdcc79ac2b1c2c80265811aR6) [[18]](diffhunk://#diff-8e85f6fd78a8c969593b20fce5a8710cbb170f0c8a6abcd3d16f0e8b7debd992R6) [[19]](diffhunk://#diff-8e85f6fd78a8c969593b20fce5a8710cbb170f0c8a6abcd3d16f0e8b7debd992L14-R15) [[20]](diffhunk://#diff-58d7ede4b3a6bd5d533bd98e9991f1eeaa7312ccd67c5df06f10f7e4864c8093R6) [[21]](diffhunk://#diff-6eaf70bcffbffb6f4fd7568f30d2c4c1cff0facfe726e501d570141d9fe8d543R6) [[22]](diffhunk://#diff-7892c87aa86da94d71b0ac7e0c9b61733abe4cb106382254ffe8d8c722cd343dR18) [[23]](diffhunk://#diff-25ff198c00f102dfb92f71c520dfbefaebcca988ed2a605099e6738b9ba3fd26R6)

**Documentation and configuration updates:**

* Updated `README.md` to document the new `namespaceOverride`, `fullnameOverride`, and `nameOverride` values, and updated the kube-prometheus-stack subchart version and app version badges. [[1]](diffhunk://#diff-7c6f40aa6df870316f86aabc888b2e3f357ba7ac9b312b50a804a88af3678459L3-R3) [[2]](diffhunk://#diff-7c6f40aa6df870316f86aabc888b2e3f357ba7ac9b312b50a804a88af3678459L49-R49) [[3]](diffhunk://#diff-7c6f40aa6df870316f86aabc888b2e3f357ba7ac9b312b50a804a88af3678459R675) [[4]](diffhunk://#diff-7c6f40aa6df870316f86aabc888b2e3f357ba7ac9b312b50a804a88af3678459R767-R768)
* Bumped chart version to `0.26.0` in `Chart.yaml` to reflect these changes.- Added `namespace` field to various resources in the Thanos Helm chart templates to ensure they are deployed in the correct namespace.
- Introduced `nameOverride`, `fullnameOverride`, and `namespaceOverride` fields in `values.yaml` and `values.schema.json` to allow users to customize resource names and namespaces.
- Updated tests to validate the correct application of namespace and naming overrides across different resources.

<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
