### PR TITLE
feat: add ServiceAccount support for Thanos components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ charts/*/requirements.lock
 .vscode/settings.json
 charts/**/*/local/**/*
 .claude/scheduled_tasks.lock
+.claude/settings.json

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.31.0
+version: 0.32.0
 appVersion: "v0.42.4"
 keywords:
   - thanos
@@ -52,4 +52,4 @@ annotations:
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
     - kind: added
-      description: Option to disable automountServiceAccountToken for all Thanos components if not desired
+      description: Per-component ServiceAccounts, each rendered from its own templates/<component>/serviceaccount.yaml with its own name, annotations (IRSA / Workload Identity) and token automount. Opt in per component with <component>.serviceAccount.create or for all components at once with global.serviceAccount.perComponent; the chart-wide ServiceAccount stays the default and is toggled by global.serviceAccount.create

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -442,6 +442,54 @@ ruler:
     labelSelector: {}
 ```
 
+### ServiceAccounts
+
+By default every component runs as a single chart-wide ServiceAccount named `<release>-thanos-thanos`, created when `global.serviceAccount.create` is true:
+
+```yaml
+global:
+  serviceAccount:
+    create: true            # toggle the chart-wide ServiceAccount
+    name: ""                # empty derives <release>-thanos-thanos
+    annotations: {}         # applied to every ServiceAccount, shared and per-component
+    automountServiceAccountToken: true
+```
+
+Cloud identity (AWS IRSA, GKE Workload Identity, Azure Workload Identity) is granted per ServiceAccount, so a single shared account forces every component to share one set of object store permissions. Give a component its own ServiceAccount — rendered from `templates/<component>/serviceaccount.yaml` and named `<release>-thanos-<component>` — to scope those permissions:
+
+```yaml
+compactor:
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-compactor
+
+storegateway:
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-store
+```
+
+Component settings always take precedence over `global.serviceAccount`. To split every component out at once, and drop the then-unused shared account:
+
+```yaml
+global:
+  serviceAccount:
+    create: false           # nothing left to share
+    perComponent: true      # <release>-thanos-<component> for every component
+```
+
+`<component>.serviceAccount` is available on `bucket.bucketweb`, `compactor`, `query`, `queryFrontend`, `storegateway`, `ruler` and `receive` — in split mode on `receive.ingester` and `receive.router` instead of `receive`. All Store Gateway shards share the component ServiceAccount.
+
+To run a component as a ServiceAccount managed outside the chart, set its `name` without `create`:
+
+```yaml
+ruler:
+  serviceAccount:
+    name: my-externally-managed-sa
+```
+
 ### Monitoring (ServiceMonitor)
 
 Enable Prometheus scraping for each component by enabling its `serviceMonitor`:
@@ -570,6 +618,10 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.service.labels | object | {} | Extra labels for the Bucketweb Service. |
 | bucket.bucketweb.service.port | int | `10902` | HTTP port exposed by the Bucketweb Service. |
 | bucket.bucketweb.service.type | string | `"ClusterIP"` | Kubernetes Service type for Bucketweb. |
+| bucket.bucketweb.serviceAccount.annotations | object | {} | Extra annotations for the Bucketweb ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Bucketweb. Requires `create`. |
+| bucket.bucketweb.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Bucketweb pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| bucket.bucketweb.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Bucketweb instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| bucket.bucketweb.serviceAccount.name | string | `""` | Name of the ServiceAccount Bucketweb pods run as. Empty derives `<fullname>-bucketweb` when Bucketweb has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Bucketweb as a ServiceAccount managed outside this chart. |
 | bucket.bucketweb.serviceMonitor.annotations | object | {} | Extra annotations for the Bucketweb ServiceMonitor. |
 | bucket.bucketweb.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Bucketweb. |
 | bucket.bucketweb.serviceMonitor.interval | string | `""` | Scrape interval for Bucketweb. Empty uses the Prometheus operator default. |
@@ -654,6 +706,10 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.service.labels | object | {} | Extra labels for the Compactor Service. |
 | compactor.service.port | int | `10902` | HTTP port exposed by the Compactor Service. |
 | compactor.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Compactor HTTP endpoint. |
+| compactor.serviceAccount.annotations | object | {} | Extra annotations for the Compactor ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Compactor. Requires `create`. |
+| compactor.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Compactor pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| compactor.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Compactor instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| compactor.serviceAccount.name | string | `""` | Name of the ServiceAccount Compactor pods run as. Empty derives `<fullname>-compactor` when Compactor has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Compactor as a ServiceAccount managed outside this chart. |
 | compactor.serviceMonitor.annotations | object | {} | Extra annotations for the Compactor ServiceMonitor. |
 | compactor.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for the Compactor. |
 | compactor.serviceMonitor.interval | string | `""` | Scrape interval for the Compactor. Empty uses the Prometheus operator default. |
@@ -706,10 +762,11 @@ The table below documents all available values. Top-level keys group settings by
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |
-| global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount. |
+| global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount, including the per-component ones (e.g. a shared IRSA or Workload Identity annotation). |
 | global.serviceAccount.automountServiceAccountToken | bool | `true` | Mount the ServiceAccount token into pods by default. Set to false to disable automounting the token for all components. |
-| global.serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount for each component. |
-| global.serviceAccount.name | string | `""` | Name override for all ServiceAccounts. Empty means auto-generate per-component names based on the release name. |
+| global.serviceAccount.create | bool | `true` | Create the chart-wide ServiceAccount. Components without a dedicated ServiceAccount run as it. Set to false to run them as an existing ServiceAccount (`global.serviceAccount.name`) or as the namespace `default` one. Turn it off together with `perComponent` to avoid an unused chart-wide ServiceAccount. |
+| global.serviceAccount.name | string | `""` | Name of the chart-wide ServiceAccount. Empty derives `<fullname>-thanos` from the release name. |
+| global.serviceAccount.perComponent | bool | `false` | Give every component its own ServiceAccount named `<fullname>-<component>` instead of the chart-wide one. Equivalent to setting `<component>.serviceAccount.create` on every component, and overridden by it per component. |
 | global.serviceMonitor.annotations | object | {} | Extra annotations merged into every ServiceMonitor resource. |
 | global.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for every component. Individual components can override this with their own serviceMonitor.enabled. |
 | global.serviceMonitor.interval | string | `""` | Scrape interval. Empty string uses the Prometheus operator default. |
@@ -857,6 +914,10 @@ The table below documents all available values. Top-level keys group settings by
 | query.service.httpPort | int | `9090` | HTTP/PromQL port exposed by the Query Service. |
 | query.service.labels | object | {} | Extra labels for the Query Service. |
 | query.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Query component. |
+| query.serviceAccount.annotations | object | {} | Extra annotations for the Query ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Query. Requires `create`. |
+| query.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Query pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| query.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Query instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| query.serviceAccount.name | string | `""` | Name of the ServiceAccount Query pods run as. Empty derives `<fullname>-query` when Query has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Query as a ServiceAccount managed outside this chart. |
 | query.serviceMonitor.annotations | object | {} | Extra annotations for the Query ServiceMonitor. |
 | query.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Query. |
 | query.serviceMonitor.interval | string | `""` | Scrape interval for Query. Empty uses the Prometheus operator default. |
@@ -937,6 +998,10 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.service.labels | object | {} | Extra labels for the Query Frontend Service. |
 | queryFrontend.service.port | int | `9090` | HTTP port exposed by the Query Frontend Service. |
 | queryFrontend.service.type | string | `"ClusterIP"` | Kubernetes Service type for Query Frontend. |
+| queryFrontend.serviceAccount.annotations | object | {} | Extra annotations for the Query Frontend ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Query Frontend. Requires `create`. |
+| queryFrontend.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Query Frontend pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| queryFrontend.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Query Frontend instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| queryFrontend.serviceAccount.name | string | `""` | Name of the ServiceAccount Query Frontend pods run as. Empty derives `<fullname>-query-frontend` when Query Frontend has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Query Frontend as a ServiceAccount managed outside this chart. |
 | queryFrontend.serviceMonitor.annotations | object | {} | Extra annotations for the Query Frontend ServiceMonitor. |
 | queryFrontend.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Query Frontend. |
 | queryFrontend.serviceMonitor.interval | string | `""` | Scrape interval for Query Frontend. Empty uses the Prometheus operator default. |
@@ -1111,6 +1176,10 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.service.labels | object | {} | Extra labels for the Router Service. |
 | receive.router.service.remoteWritePort | int | `10908` | Remote-write ingestion port exposed by the Router Service. |
 | receive.router.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Router component. |
+| receive.router.serviceAccount.annotations | object | {} | Extra annotations for the Router ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Router. Requires `create`. |
+| receive.router.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Router pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| receive.router.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Router instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| receive.router.serviceAccount.name | string | `""` | Name of the ServiceAccount Router pods run as. Empty derives `<fullname>-receive-router` when Router has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Router as a ServiceAccount managed outside this chart. |
 | receive.router.serviceMonitor.annotations | object | {} | Extra annotations for the Router ServiceMonitor. |
 | receive.router.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Router. |
 | receive.router.serviceMonitor.interval | string | `""` | Scrape interval for Router. Empty uses the Prometheus operator default. |
@@ -1135,6 +1204,10 @@ The table below documents all available values. Top-level keys group settings by
 | receive.service.labels | object | {} | Extra labels for the Receive Service. |
 | receive.service.remoteWritePort | int | `10908` | Remote-write ingestion port exposed by the Receive Service. |
 | receive.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Receive component. |
+| receive.serviceAccount.annotations | object | {} | Extra annotations for the Receive ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Receive. Requires `create`. |
+| receive.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Receive pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| receive.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Receive instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| receive.serviceAccount.name | string | `""` | Name of the ServiceAccount Receive pods run as. Empty derives `<fullname>-receive` when Receive has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Receive as a ServiceAccount managed outside this chart. |
 | receive.serviceMonitor.annotations | object | {} | Extra annotations for the Receive ServiceMonitor. |
 | receive.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for Receive. |
 | receive.serviceMonitor.interval | string | `""` | Scrape interval for Receive. Empty uses the Prometheus operator default. |
@@ -1236,6 +1309,10 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.service.httpPort | int | `10902` | HTTP port exposed by the Ruler Service. |
 | ruler.service.labels | object | {} | Extra labels for the Ruler Service. |
 | ruler.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Ruler component. |
+| ruler.serviceAccount.annotations | object | {} | Extra annotations for the Ruler ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Ruler. Requires `create`. |
+| ruler.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Ruler pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| ruler.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Ruler instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| ruler.serviceAccount.name | string | `""` | Name of the ServiceAccount Ruler pods run as. Empty derives `<fullname>-ruler` when Ruler has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Ruler as a ServiceAccount managed outside this chart. |
 | ruler.serviceMonitor.annotations | object | {} | Extra annotations for the Ruler ServiceMonitor. |
 | ruler.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for the Ruler. |
 | ruler.serviceMonitor.interval | string | `""` | Scrape interval for the Ruler. Empty uses the Prometheus operator default. |
@@ -1349,6 +1426,10 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.service.httpPort | int | `10902` | HTTP port exposed by the Store Gateway Service. |
 | storegateway.service.labels | object | {} | Extra labels for the Store Gateway Service. |
 | storegateway.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Store Gateway. |
+| storegateway.serviceAccount.annotations | object | {} | Extra annotations for the Store Gateway ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Store Gateway. Requires `create`. |
+| storegateway.serviceAccount.automountServiceAccountToken | string | `null` (inherit `global.serviceAccount.automountServiceAccountToken`) | Mount the ServiceAccount token into Store Gateway pods. Null inherits `global.serviceAccount.automountServiceAccountToken`. Requires `create`. |
+| storegateway.serviceAccount.create | string | `null` (inherit `global.serviceAccount.perComponent`) | Create a ServiceAccount for Store Gateway instead of sharing the chart-wide one. Null inherits `global.serviceAccount.perComponent`. |
+| storegateway.serviceAccount.name | string | `""` | Name of the ServiceAccount Store Gateway pods run as. Empty derives `<fullname>-storegateway` when Store Gateway has a dedicated ServiceAccount, and the chart-wide ServiceAccount name otherwise. Setting it without `create` runs Store Gateway as a ServiceAccount managed outside this chart. |
 | storegateway.serviceMonitor.annotations | object | {} | Extra annotations for the Store Gateway ServiceMonitor. |
 | storegateway.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for the Store Gateway. |
 | storegateway.serviceMonitor.interval | string | `""` | Scrape interval for the Store Gateway. Empty uses the Prometheus operator default. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -430,6 +430,54 @@ ruler:
     labelSelector: {}
 ```
 
+### ServiceAccounts
+
+By default every component runs as a single chart-wide ServiceAccount named `<release>-thanos-thanos`, created when `global.serviceAccount.create` is true:
+
+```yaml
+global:
+  serviceAccount:
+    create: true            # toggle the chart-wide ServiceAccount
+    name: ""                # empty derives <release>-thanos-thanos
+    annotations: {}         # applied to every ServiceAccount, shared and per-component
+    automountServiceAccountToken: true
+```
+
+Cloud identity (AWS IRSA, GKE Workload Identity, Azure Workload Identity) is granted per ServiceAccount, so a single shared account forces every component to share one set of object store permissions. Give a component its own ServiceAccount — rendered from `templates/<component>/serviceaccount.yaml` and named `<release>-thanos-<component>` — to scope those permissions:
+
+```yaml
+compactor:
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-compactor
+
+storegateway:
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-store
+```
+
+Component settings always take precedence over `global.serviceAccount`. To split every component out at once, and drop the then-unused shared account:
+
+```yaml
+global:
+  serviceAccount:
+    create: false           # nothing left to share
+    perComponent: true      # <release>-thanos-<component> for every component
+```
+
+`<component>.serviceAccount` is available on `bucket.bucketweb`, `compactor`, `query`, `queryFrontend`, `storegateway`, `ruler` and `receive` — in split mode on `receive.ingester` and `receive.router` instead of `receive`. All Store Gateway shards share the component ServiceAccount.
+
+To run a component as a ServiceAccount managed outside the chart, set its `name` without `create`:
+
+```yaml
+ruler:
+  serviceAccount:
+    name: my-externally-managed-sa
+```
+
 ### Monitoring (ServiceMonitor)
 
 Enable Prometheus scraping for each component by enabling its `serviceMonitor`:

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -813,18 +813,128 @@ shards (hashmod on __block_id). Either dimension may be used on its own.
 {{- end }}
 {{- end -}}
 
-{{/*
-Resolve the ServiceAccount name.
-- When global.serviceAccount.create is true, defaults to "<fullname>-thanos"
-  unless global.serviceAccount.name overrides it.
-- When create is false, uses global.serviceAccount.name if provided, otherwise
-  falls back to the namespace "default" ServiceAccount.
-*/}}
-{{- define "thanos.serviceAccountName" -}}
-{{- if .Values.global.serviceAccount.create -}}
-{{- default (printf "%s-%s" (include "thanos.fullname" .) "thanos") .Values.global.serviceAccount.name -}}
+{{- /* ============================== */ -}}
+{{- /* ServiceAccount helpers         */ -}}
+{{- /* ============================== */ -}}
+
+{{- /*
+Name of the chart-wide ServiceAccount, shared by every component that does not
+declare one of its own: `global.serviceAccount.name` when set,
+`<fullname>-thanos` otherwise.
+*/ -}}
+{{- define "thanos.sharedServiceAccountName" -}}
+{{- $g := .Values.global.serviceAccount | default dict -}}
+{{- if $g.name -}}
+{{- $g.name -}}
 {{- else -}}
-{{- default "default" .Values.global.serviceAccount.name -}}
+{{- printf "%s-%s" (include "thanos.fullname" .) "thanos" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+Resolve the ServiceAccount of a single component. Returns a YAML dict; consume
+it with `fromYaml`:
+
+  {{- $sa := include "thanos.serviceAccount" (dict "root" . "component" "compactor") | fromYaml }}
+
+Keys:
+  name        ServiceAccount name for the pod spec (never empty)
+  dedicated   true when the chart renders a ServiceAccount for this component
+              alone (`templates/<component>/serviceaccount.yaml`), false when
+              the component falls back to the chart-wide ServiceAccount
+  annotations annotations of the dedicated ServiceAccount
+              (`global.serviceAccount.annotations` + component annotations)
+  automountServiceAccountToken  token automount of the dedicated ServiceAccount
+
+A component is dedicated when `<component>.serviceAccount.create` is set, and
+inherits `global.serviceAccount.perComponent` when it is null.
+
+Name resolution — component settings always take precedence over global ones:
+  1. `<component>.serviceAccount.name`
+  2. `<fullname>-<component>`                       when the component is dedicated
+  3. `global.serviceAccount.name`
+  4. `<fullname>-thanos`                            when `global.serviceAccount.create` is true
+  5. `default`                                      (the namespace default ServiceAccount)
+
+A `<component>.serviceAccount.name` without `create` therefore points the
+component at a ServiceAccount managed outside this chart.
+*/ -}}
+{{- define "thanos.serviceAccount" -}}
+{{- $root := .root -}}
+{{- $comp := .component -}}
+{{- $v := $root.Values -}}
+{{- $g := $v.global.serviceAccount | default dict -}}
+{{- $bucket := $v.bucket | default dict -}}
+{{- $receive := $v.receive | default dict -}}
+{{- $owners := dict
+      "bucketweb" ($bucket.bucketweb | default dict)
+      "compactor" ($v.compactor | default dict)
+      "query" ($v.query | default dict)
+      "query-frontend" ($v.queryFrontend | default dict)
+      "storegateway" ($v.storegateway | default dict)
+      "receive" $receive
+      "receive-ingester" ($receive.ingester | default dict)
+      "receive-router" ($receive.router | default dict)
+      "ruler" ($v.ruler | default dict) -}}
+{{- if not (hasKey $owners $comp) -}}
+{{- fail (printf "thanos.serviceAccount: unknown component %q" $comp) -}}
+{{- end -}}
+{{- $cfg := (index $owners $comp).serviceAccount | default dict -}}
+{{- $dedicated := $g.perComponent | default false -}}
+{{- if not (kindIs "invalid" $cfg.create) -}}
+{{- $dedicated = $cfg.create -}}
+{{- end -}}
+{{- $name := "" -}}
+{{- if $cfg.name -}}
+{{- $name = $cfg.name -}}
+{{- else if $dedicated -}}
+{{- $name = include "thanos.compName" (list $root $comp) -}}
+{{- else if or $g.name $g.create -}}
+{{- $name = include "thanos.sharedServiceAccountName" $root -}}
+{{- else -}}
+{{- $name = "default" -}}
+{{- end -}}
+{{- $automount := $g.automountServiceAccountToken -}}
+{{- if not (kindIs "invalid" $cfg.automountServiceAccountToken) -}}
+{{- $automount = $cfg.automountServiceAccountToken -}}
+{{- end -}}
+{{- if kindIs "invalid" $automount -}}
+{{- $automount = true -}}
+{{- end -}}
+{{- $annotations := merge (deepCopy ($cfg.annotations | default dict)) ($g.annotations | default dict) -}}
+{{- dict "name" $name "dedicated" $dedicated "annotations" $annotations "automountServiceAccountToken" $automount | toYaml -}}
+{{- end -}}
+
+{{- /*
+ServiceAccount name a component's pods run as.
+Usage: {{ include "thanos.serviceAccountName" (dict "root" . "component" "compactor") }}
+*/ -}}
+{{- define "thanos.serviceAccountName" -}}
+{{- (include "thanos.serviceAccount" . | fromYaml).name -}}
+{{- end -}}
+
+{{- /*
+Render the dedicated ServiceAccount of a component, or nothing when the
+component shares the chart-wide ServiceAccount. Backs the per-component
+`templates/<component>/serviceaccount.yaml` files.
+Usage: {{ include "thanos.componentServiceAccount" (dict "root" . "component" "compactor") }}
+*/ -}}
+{{- define "thanos.componentServiceAccount" -}}
+{{- $root := .root -}}
+{{- $comp := .component -}}
+{{- $sa := include "thanos.serviceAccount" . | fromYaml -}}
+{{- if $sa.dedicated -}}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ $sa.automountServiceAccountToken }}
+metadata:
+  name: {{ $sa.name }}
+  namespace: {{ include "thanos.namespace" $root }}
+  labels:
+    {{- include "thanos.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $comp }}
+  annotations:
+    {{- toYaml $sa.annotations | nindent 4 }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" "bucketweb") }}
       {{- include "thanos.affinity" (dict "Values" $ctx.Values "component" "bucketweb") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" $ctx "key" "bucketweb") | nindent 6 }}

--- a/charts/thanos/templates/bucket/serviceaccount.yaml
+++ b/charts/thanos/templates/bucket/serviceaccount.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.bucket.enabled .Values.bucket.bucketweb.enabled -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "bucketweb") -}}
+{{- end }}

--- a/charts/thanos/templates/compactor/serviceaccount.yaml
+++ b/charts/thanos/templates/compactor/serviceaccount.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.compactor.enabled -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "compactor") -}}
+{{- end }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" "compactor") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "compactor") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "compactor") | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" "query-frontend") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "queryFrontend") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "queryFrontend") | nindent 6 }}

--- a/charts/thanos/templates/query-frontend/serviceaccount.yaml
+++ b/charts/thanos/templates/query-frontend/serviceaccount.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.queryFrontend.enabled -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "query-frontend") -}}
+{{- end }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" "query") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "query") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "query") | nindent 6 }}

--- a/charts/thanos/templates/query/serviceaccount.yaml
+++ b/charts/thanos/templates/query/serviceaccount.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.query.enabled -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "query") -}}
+{{- end }}

--- a/charts/thanos/templates/receive/serviceaccount.yaml
+++ b/charts/thanos/templates/receive/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- /*
+Receive ServiceAccount. Configured through `receive.serviceAccount` in
+standalone mode and `receive.ingester.serviceAccount` in split mode, matching
+where the rest of the workload configuration lives.
+*/ -}}
+{{- if .Values.receive.enabled -}}
+{{- $isSplit := eq (include "thanos.receive.isSplit" .) "true" -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" (ternary "receive-ingester" "receive" $isSplit)) -}}
+{{- end }}

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- $_ := set $anns "checksum/hashrings" (include "thanos.receive.hashrings" . | sha256sum) -}}
         {{- toYaml $anns | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" "receive-router") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "router" "parent" "receive") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "router" "parent" "receive") | nindent 6 }}

--- a/charts/thanos/templates/receive/split/router-serviceaccount.yaml
+++ b/charts/thanos/templates/receive/split/router-serviceaccount.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.receive.enabled (eq (include "thanos.receive.isSplit" .) "true") -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "receive-router") -}}
+{{- end }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- $_ := set $anns "checksum/objstore-configuration" (.Values.global.objstore.config | sha256sum) -}}
         {{- toYaml $anns | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" (ternary "receive-ingester" "receive" $isSplit)) }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "ingester" "parent" "receive") | nindent 6 }}

--- a/charts/thanos/templates/ruler/rbac.yaml
+++ b/charts/thanos/templates/ruler/rbac.yaml
@@ -29,6 +29,6 @@ roleRef:
   name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
 subjects:
   - kind: ServiceAccount
-    name: {{ include "thanos.serviceAccountName" . }}
+    name: {{ include "thanos.serviceAccountName" (dict "root" . "component" "ruler") }}
     namespace: {{ include "thanos.namespace" . }}
 {{- end }}

--- a/charts/thanos/templates/ruler/serviceaccount.yaml
+++ b/charts/thanos/templates/ruler/serviceaccount.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.ruler.enabled -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "ruler") -}}
+{{- end }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" . }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" . "component" "ruler") }}
       {{- include "thanos.affinity" (dict "Values" .Values "component" "ruler") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" . "key" "ruler") | nindent 6 }}

--- a/charts/thanos/templates/serviceaccount.yaml
+++ b/charts/thanos/templates/serviceaccount.yaml
@@ -1,9 +1,16 @@
+{{- /*
+Chart-wide ServiceAccount, shared by every component that does not declare a
+dedicated one in `templates/<component>/serviceaccount.yaml`.
+Toggled by `global.serviceAccount.create`; `global.rbac.create` gates it as
+well, as it has since this template was the chart's only ServiceAccount.
+Per-component ServiceAccounts are independent of `global.rbac.create`.
+*/ -}}
 {{- if and .Values.global.serviceAccount.create .Values.global.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.global.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ include "thanos.serviceAccountName" . }}
+  name: {{ include "thanos.sharedServiceAccountName" . }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}

--- a/charts/thanos/templates/storegateway/serviceaccount.yaml
+++ b/charts/thanos/templates/storegateway/serviceaccount.yaml
@@ -1,0 +1,4 @@
+{{- /* All Store Gateway shards share the component ServiceAccount. */ -}}
+{{- if .Values.storegateway.enabled -}}
+{{- include "thanos.componentServiceAccount" (dict "root" . "component" "storegateway") -}}
+{{- end }}

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "thanos.serviceAccountName" $ }}
+      serviceAccountName: {{ include "thanos.serviceAccountName" (dict "root" $ "component" "storegateway") }}
       {{- include "thanos.affinity" (dict "Values" $.Values "component" "storegateway") | nindent 6 }}
       {{- include "thanos.imagePullSecrets" $ | nindent 6 }}
       {{- include "thanos.podSC" (dict "root" $ "key" "storegateway") | nindent 6 }}

--- a/charts/thanos/tests/serviceaccount_test.yaml
+++ b/charts/thanos/tests/serviceaccount_test.yaml
@@ -1,0 +1,400 @@
+suite: service accounts
+
+tests:
+  # -- Chart-wide ServiceAccount (templates/serviceaccount.yaml) ---------
+  # The default configuration must keep rendering exactly one shared
+  # ServiceAccount, `<fullname>-thanos`, used by every component.
+
+  - it: renders the chart-wide serviceaccount by default
+    template: serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-thanos
+      - notExists:
+          path: metadata.labels["app.kubernetes.io/component"]
+
+  - it: renders the chart-wide serviceaccount into the overridden namespace
+    template: serviceaccount.yaml
+    set:
+      namespaceOverride: custom-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: names the chart-wide serviceaccount from global.serviceAccount.name
+    template: serviceaccount.yaml
+    set:
+      global.serviceAccount.name: shared-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: shared-sa
+
+  - it: does not render the chart-wide serviceaccount when create is false
+    template: serviceaccount.yaml
+    set:
+      global.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: keeps the chart-wide serviceaccount when only some components are dedicated
+    template: serviceaccount.yaml
+    set:
+      global.serviceAccount.perComponent: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # -- Per-component ServiceAccounts -------------------------------------
+
+  - it: does not render a component serviceaccount by default
+    templates:
+      - bucket/serviceaccount.yaml
+      - compactor/serviceaccount.yaml
+      - query/serviceaccount.yaml
+      - query-frontend/serviceaccount.yaml
+      - receive/serviceaccount.yaml
+      - ruler/serviceaccount.yaml
+      - storegateway/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders one serviceaccount per component when perComponent is true
+    template: compactor/serviceaccount.yaml
+    set:
+      global.serviceAccount.perComponent: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-compactor
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: compactor
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: names each component serviceaccount after its component
+    templates:
+      - bucket/serviceaccount.yaml
+      - query/serviceaccount.yaml
+      - query-frontend/serviceaccount.yaml
+      - receive/serviceaccount.yaml
+      - ruler/serviceaccount.yaml
+      - storegateway/serviceaccount.yaml
+    set:
+      global.serviceAccount.perComponent: true
+      bucket.bucketweb.enabled: true
+      queryFrontend.enabled: true
+      ruler.enabled: true
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^RELEASE-NAME-thanos-(bucketweb|query|query-frontend|receive|ruler|storegateway)$
+      - exists:
+          path: metadata.labels["app.kubernetes.io/component"]
+
+  - it: renders a component serviceaccount for a single opted-in component
+    template: storegateway/serviceaccount.yaml
+    set:
+      storegateway.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-storegateway
+
+  - it: leaves the other components on the chart-wide serviceaccount
+    templates:
+      - compactor/serviceaccount.yaml
+      - query/serviceaccount.yaml
+    set:
+      storegateway.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: lets a component opt out while perComponent is true
+    template: query/serviceaccount.yaml
+    set:
+      global.serviceAccount.perComponent: true
+      query.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a component serviceaccount even when the chart-wide one is disabled
+    template: ruler/serviceaccount.yaml
+    set:
+      global.serviceAccount.create: false
+      ruler.enabled: true
+      ruler.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-ruler
+
+  - it: does not render a component serviceaccount for a disabled component
+    template: bucket/serviceaccount.yaml
+    set:
+      global.serviceAccount.perComponent: true
+      bucket.bucketweb.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses the component name override for the component serviceaccount
+    template: compactor/serviceaccount.yaml
+    set:
+      compactor.serviceAccount.create: true
+      compactor.serviceAccount.name: compactor-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: compactor-sa
+
+  - it: does not create a serviceaccount for a component name without create
+    template: compactor/serviceaccount.yaml
+    set:
+      compactor.serviceAccount.name: external-compactor-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # -- Annotations -------------------------------------------------------
+
+  - it: merges component annotations on top of the global ones
+    template: compactor/serviceaccount.yaml
+    set:
+      compactor.serviceAccount.create: true
+      global.serviceAccount.annotations:
+        shared: global-value
+        overridden: global-value
+      compactor.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-compactor
+        overridden: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations.shared
+          value: global-value
+      - equal:
+          path: metadata.annotations.overridden
+          value: component-value
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/thanos-compactor
+
+  - it: keeps component annotations off the chart-wide serviceaccount
+    template: serviceaccount.yaml
+    set:
+      compactor.serviceAccount.create: true
+      compactor.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-compactor
+    asserts:
+      - notExists:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+
+  # -- Token automounting ------------------------------------------------
+
+  - it: mounts the component serviceaccount token by default
+    template: compactor/serviceaccount.yaml
+    set:
+      compactor.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: inherits the global automount setting on component serviceaccounts
+    template: compactor/serviceaccount.yaml
+    set:
+      compactor.serviceAccount.create: true
+      global.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: overrides the global automount setting per component
+    template: compactor/serviceaccount.yaml
+    set:
+      compactor.serviceAccount.create: true
+      global.serviceAccount.automountServiceAccountToken: false
+      compactor.serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  # -- Pod wiring --------------------------------------------------------
+
+  - it: points every workload at its own serviceaccount when perComponent is true
+    set:
+      global.serviceAccount.perComponent: true
+      bucket.bucketweb.enabled: true
+      queryFrontend.enabled: true
+      ruler.enabled: true
+    templates:
+      - bucket/deployment.yaml
+      - compactor/statefulset.yaml
+      - query/deployment.yaml
+      - query-frontend/deployment.yaml
+      - receive/statefulset.yaml
+      - ruler/statefulset.yaml
+      - storegateway/statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.serviceAccountName
+          pattern: ^RELEASE-NAME-thanos-(bucketweb|compactor|query|query-frontend|receive|ruler|storegateway)$
+
+  - it: points a single opted-in workload at its own serviceaccount
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-thanos-storegateway
+
+  - it: keeps the other workloads on the chart-wide serviceaccount
+    templates:
+      - compactor/statefulset.yaml
+      - query/deployment.yaml
+    set:
+      storegateway.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-thanos-thanos
+
+  - it: runs a workload as an externally managed serviceaccount
+    template: compactor/statefulset.yaml
+    set:
+      compactor.serviceAccount.name: external-compactor-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: external-compactor-sa
+
+  - it: shares one serviceaccount across all store gateway shards
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.serviceAccount.create: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-thanos-storegateway
+
+  # -- Receive split mode ------------------------------------------------
+
+  - it: renders an ingester serviceaccount in split mode
+    template: receive/serviceaccount.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.ingester.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-ingester
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: receive-ingester
+
+  - it: renders a router serviceaccount in split mode
+    template: receive/split/router-serviceaccount.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-receive-router
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: receive-router
+
+  - it: does not render a router serviceaccount in standalone mode
+    template: receive/split/router-serviceaccount.yaml
+    set:
+      global.serviceAccount.perComponent: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: points the split-mode workloads at their own serviceaccounts
+    values:
+      - _split_defaults.yaml
+    set:
+      global.serviceAccount.perComponent: true
+    templates:
+      - receive/statefulset.yaml
+      - receive/split/router-deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.serviceAccountName
+          pattern: ^RELEASE-NAME-thanos-receive-(ingester|router)$
+
+  - it: ignores the standalone receive serviceaccount settings in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.serviceAccount.create: true
+      receive.serviceAccount.name: standalone-only-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-thanos-thanos
+
+  # -- Ruler RBAC binding ------------------------------------------------
+
+  - it: binds the ruler rule-importer to the dedicated ruler serviceaccount
+    template: ruler/rbac.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+      ruler.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-thanos-ruler
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+
+  - it: binds the ruler rule-importer to the chart-wide serviceaccount by default
+    template: ruler/rbac.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-thanos-thanos

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -779,6 +779,52 @@
               "required": [],
               "title": "dnsConfig",
               "type": "object"
+            },
+            "serviceAccount": {
+              "additionalProperties": true,
+              "description": "ServiceAccount used by Bucketweb pods. Unset fields inherit `global.serviceAccount`.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": true,
+                  "description": "Extra annotations for the Bucketweb ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Bucketweb. Requires `create`.",
+                  "required": [],
+                  "title": "annotations",
+                  "type": "object"
+                },
+                "automountServiceAccountToken": {
+                  "default": "null",
+                  "description": "Mount the ServiceAccount token into Bucketweb pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+                  "required": [],
+                  "title": "automountServiceAccountToken",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "create": {
+                  "default": "null",
+                  "description": "Create a ServiceAccount for Bucketweb instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+                  "required": [],
+                  "title": "create",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "default": "",
+                  "description": "Name of the ServiceAccount Bucketweb pods run as. Empty derives\n`<fullname>-bucketweb` when Bucketweb has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Bucketweb as a ServiceAccount managed outside this chart.",
+                  "required": [],
+                  "title": "name",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "annotations"
+              ],
+              "title": "serviceAccount",
+              "type": "object"
             }
           },
           "required": [
@@ -810,7 +856,8 @@
             "extraVolumes",
             "extraVolumeMounts",
             "serviceMonitor",
-            "pdb"
+            "pdb",
+            "serviceAccount"
           ],
           "title": "bucketweb",
           "type": "object"
@@ -1744,6 +1791,52 @@
           "required": [],
           "title": "dnsConfig",
           "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": true,
+          "description": "ServiceAccount used by Compactor pods. Unset fields inherit `global.serviceAccount`.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Compactor ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Compactor. Requires `create`.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "automountServiceAccountToken": {
+              "default": "null",
+              "description": "Mount the ServiceAccount token into Compactor pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "create": {
+              "default": "null",
+              "description": "Create a ServiceAccount for Compactor instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+              "required": [],
+              "title": "create",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ServiceAccount Compactor pods run as. Empty derives\n`<fullname>-compactor` when Compactor has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Compactor as a ServiceAccount managed outside this chart.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
         }
       },
       "required": [
@@ -1777,7 +1870,8 @@
         "extraVolumes",
         "extraVolumeMounts",
         "serviceMonitor",
-        "pdb"
+        "pdb",
+        "serviceAccount"
       ],
       "title": "compactor",
       "type": "object"
@@ -2125,11 +2219,11 @@
         },
         "serviceAccount": {
           "additionalProperties": true,
-          "description": "ServiceAccount configuration applied to every component by default.",
+          "description": "Chart-wide ServiceAccount, shared by every component that does not declare\nits own `<component>.serviceAccount`. Component settings always win over\nthe values below.",
           "properties": {
             "annotations": {
               "additionalProperties": true,
-              "description": "Extra annotations merged into every ServiceAccount.",
+              "description": "Extra annotations merged into every ServiceAccount, including the\nper-component ones (e.g. a shared IRSA or Workload Identity annotation).",
               "required": [],
               "title": "annotations",
               "type": "object"
@@ -2143,23 +2237,32 @@
             },
             "create": {
               "default": true,
-              "description": "Create a dedicated ServiceAccount for each component.",
+              "description": "Create the chart-wide ServiceAccount. Components without a dedicated\nServiceAccount run as it. Set to false to run them as an existing\nServiceAccount (`global.serviceAccount.name`) or as the namespace\n`default` one. Turn it off together with `perComponent` to avoid an\nunused chart-wide ServiceAccount.",
               "required": [],
               "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "",
-              "description": "Name override for all ServiceAccounts. Empty means auto-generate\nper-component names based on the release name.",
+              "description": "Name of the chart-wide ServiceAccount. Empty derives\n`<fullname>-thanos` from the release name.",
               "required": [],
               "title": "name",
               "type": "string"
+            },
+            "perComponent": {
+              "default": false,
+              "description": "Give every component its own ServiceAccount named\n`<fullname>-<component>` instead of the chart-wide one. Equivalent to\nsetting `<component>.serviceAccount.create` on every component, and\noverridden by it per component.",
+              "required": [],
+              "title": "perComponent",
+              "type": "boolean"
             }
           },
           "required": [
             "create",
             "annotations",
-            "name"
+            "name",
+            "perComponent",
+            "automountServiceAccountToken"
           ],
           "title": "serviceAccount",
           "type": "object"
@@ -3537,6 +3640,52 @@
           "required": [],
           "title": "dnsConfig",
           "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": true,
+          "description": "ServiceAccount used by Query pods. Unset fields inherit `global.serviceAccount`.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Query ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Query. Requires `create`.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "automountServiceAccountToken": {
+              "default": "null",
+              "description": "Mount the ServiceAccount token into Query pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "create": {
+              "default": "null",
+              "description": "Create a ServiceAccount for Query instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+              "required": [],
+              "title": "create",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ServiceAccount Query pods run as. Empty derives\n`<fullname>-query` when Query has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Query as a ServiceAccount managed outside this chart.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
         }
       },
       "required": [
@@ -3571,7 +3720,8 @@
         "labels",
         "podLabels",
         "serviceMonitor",
-        "pdb"
+        "pdb",
+        "serviceAccount"
       ],
       "title": "query",
       "type": "object"
@@ -4347,6 +4497,52 @@
           "required": [],
           "title": "dnsConfig",
           "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": true,
+          "description": "ServiceAccount used by Query Frontend pods. Unset fields inherit `global.serviceAccount`.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Query Frontend ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Query Frontend. Requires `create`.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "automountServiceAccountToken": {
+              "default": "null",
+              "description": "Mount the ServiceAccount token into Query Frontend pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "create": {
+              "default": "null",
+              "description": "Create a ServiceAccount for Query Frontend instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+              "required": [],
+              "title": "create",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ServiceAccount Query Frontend pods run as. Empty derives\n`<fullname>-query-frontend` when Query Frontend has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Query Frontend as a ServiceAccount managed outside this chart.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
         }
       },
       "required": [
@@ -4379,7 +4575,8 @@
         "labels",
         "podLabels",
         "serviceMonitor",
-        "pdb"
+        "pdb",
+        "serviceAccount"
       ],
       "title": "queryFrontend",
       "type": "object"
@@ -4535,7 +4732,7 @@
               "properties": {
                 "enabled": {
                   "default": true,
-                  "description": "Auto-generate a single default hashring whose endpoints are derived\nfrom the StatefulSet pod DNS names:\n`\u003cpod-0\u003e.\u003cheadless-svc\u003e:10901 ... \u003cpod-N\u003e.\u003cheadless-svc\u003e:10901`.",
+                  "description": "Auto-generate a single default hashring whose endpoints are derived\nfrom the StatefulSet pod DNS names:\n`<pod-0>.<headless-svc>:10901 ... <pod-N>.<headless-svc>:10901`.",
                   "required": [],
                   "title": "enabled",
                   "type": "boolean"
@@ -5741,6 +5938,52 @@
           "required": [],
           "title": "dnsConfig",
           "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": true,
+          "description": "ServiceAccount used by Receive pods. Unset fields inherit `global.serviceAccount`. Ignored in split mode: configure `receive.ingester.serviceAccount` and\n`receive.router.serviceAccount` instead.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Receive ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Receive. Requires `create`.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "automountServiceAccountToken": {
+              "default": "null",
+              "description": "Mount the ServiceAccount token into Receive pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "create": {
+              "default": "null",
+              "description": "Create a ServiceAccount for Receive instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+              "required": [],
+              "title": "create",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ServiceAccount Receive pods run as. Empty derives\n`<fullname>-receive` when Receive has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Receive as a ServiceAccount managed outside this chart.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
         }
       },
       "required": [
@@ -5779,7 +6022,8 @@
         "podLabels",
         "serviceMonitor",
         "pdb",
-        "router"
+        "router",
+        "serviceAccount"
       ],
       "allOf": [
         {
@@ -6761,6 +7005,52 @@
           "required": [],
           "title": "dnsConfig",
           "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": true,
+          "description": "ServiceAccount used by Ruler pods. Unset fields inherit `global.serviceAccount`.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Ruler ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Ruler. Requires `create`.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "automountServiceAccountToken": {
+              "default": "null",
+              "description": "Mount the ServiceAccount token into Ruler pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "create": {
+              "default": "null",
+              "description": "Create a ServiceAccount for Ruler instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+              "required": [],
+              "title": "create",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ServiceAccount Ruler pods run as. Empty derives\n`<fullname>-ruler` when Ruler has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Ruler as a ServiceAccount managed outside this chart.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
         }
       },
       "required": [
@@ -6797,7 +7087,8 @@
         "labels",
         "podLabels",
         "serviceMonitor",
-        "pdb"
+        "pdb",
+        "serviceAccount"
       ],
       "title": "ruler",
       "type": "object"
@@ -8062,6 +8353,52 @@
           "required": [],
           "title": "dnsConfig",
           "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": true,
+          "description": "ServiceAccount used by Store Gateway pods. Unset fields inherit `global.serviceAccount`.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Extra annotations for the Store Gateway ServiceAccount, merged on top of\n`global.serviceAccount.annotations`. Use it to scope an IRSA or Workload\nIdentity binding to Store Gateway. Requires `create`.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "automountServiceAccountToken": {
+              "default": "null",
+              "description": "Mount the ServiceAccount token into Store Gateway pods. Null inherits\n`global.serviceAccount.automountServiceAccountToken`. Requires `create`.",
+              "required": [],
+              "title": "automountServiceAccountToken",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "create": {
+              "default": "null",
+              "description": "Create a ServiceAccount for Store Gateway instead of sharing the chart-wide one.\nNull inherits `global.serviceAccount.perComponent`.",
+              "required": [],
+              "title": "create",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ServiceAccount Store Gateway pods run as. Empty derives\n`<fullname>-storegateway` when Store Gateway has a dedicated ServiceAccount, and the\nchart-wide ServiceAccount name otherwise. Setting it without `create`\nruns Store Gateway as a ServiceAccount managed outside this chart.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "annotations"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
         }
       },
       "required": [
@@ -8097,7 +8434,8 @@
         "labels",
         "podLabels",
         "serviceMonitor",
-        "pdb"
+        "pdb",
+        "serviceAccount"
       ],
       "title": "storegateway",
       "type": "object"

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -172,18 +172,30 @@ global:
     # components that need cluster-level access (e.g. Ruler auto-import).
     create: true
 
-  # ServiceAccount configuration applied to every component by default.
+  # Chart-wide ServiceAccount, shared by every component that does not declare
+  # its own `<component>.serviceAccount`. Component settings always win over
+  # the values below.
   serviceAccount:
-    # -- Create a dedicated ServiceAccount for each component.
+    # -- Create the chart-wide ServiceAccount. Components without a dedicated
+    # ServiceAccount run as it. Set to false to run them as an existing
+    # ServiceAccount (`global.serviceAccount.name`) or as the namespace
+    # `default` one. Turn it off together with `perComponent` to avoid an
+    # unused chart-wide ServiceAccount.
     create: true
-    # -- Extra annotations merged into every ServiceAccount.
+    # -- Give every component its own ServiceAccount named
+    # `<fullname>-<component>` instead of the chart-wide one. Equivalent to
+    # setting `<component>.serviceAccount.create` on every component, and
+    # overridden by it per component.
+    perComponent: false
+    # -- Extra annotations merged into every ServiceAccount, including the
+    # per-component ones (e.g. a shared IRSA or Workload Identity annotation).
     # @default -- {}
     annotations: {}
     # -- Mount the ServiceAccount token into pods by default. Set to false to
     # disable automounting the token for all components.
     automountServiceAccountToken: true
-    # -- Name override for all ServiceAccounts. Empty means auto-generate
-    # per-component names based on the release name.
+    # -- Name of the chart-wide ServiceAccount. Empty derives
+    # `<fullname>-thanos` from the release name.
     name: ""
 
   # Built-in Thanos alerting rules deployed as PrometheusRule CRDs.
@@ -649,6 +661,26 @@ bucket:
     # -- Extra labels applied to Bucketweb pods (e.g. for workload identity).
     # @default -- {}
     podLabels: {}
+    # ServiceAccount used by Bucketweb pods. Unset fields inherit `global.serviceAccount`.
+    serviceAccount:
+      # -- Create a ServiceAccount for Bucketweb instead of sharing the chart-wide one.
+      # Null inherits `global.serviceAccount.perComponent`.
+      # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+      create: null
+      # -- Name of the ServiceAccount Bucketweb pods run as. Empty derives
+      # `<fullname>-bucketweb` when Bucketweb has a dedicated ServiceAccount, and the
+      # chart-wide ServiceAccount name otherwise. Setting it without `create`
+      # runs Bucketweb as a ServiceAccount managed outside this chart.
+      name: ""
+      # -- Extra annotations for the Bucketweb ServiceAccount, merged on top of
+      # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+      # Identity binding to Bucketweb. Requires `create`.
+      # @default -- {}
+      annotations: {}
+      # -- Mount the ServiceAccount token into Bucketweb pods. Null inherits
+      # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+      # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+      automountServiceAccountToken: null
 
     # -- Extra volumes for Bucketweb pods.
     # @default -- []
@@ -965,6 +997,26 @@ compactor:
   # -- Extra labels applied to Compactor pods (e.g. for workload identity).
   # @default -- {}
   podLabels: {}
+  # ServiceAccount used by Compactor pods. Unset fields inherit `global.serviceAccount`.
+  serviceAccount:
+    # -- Create a ServiceAccount for Compactor instead of sharing the chart-wide one.
+    # Null inherits `global.serviceAccount.perComponent`.
+    # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+    create: null
+    # -- Name of the ServiceAccount Compactor pods run as. Empty derives
+    # `<fullname>-compactor` when Compactor has a dedicated ServiceAccount, and the
+    # chart-wide ServiceAccount name otherwise. Setting it without `create`
+    # runs Compactor as a ServiceAccount managed outside this chart.
+    name: ""
+    # -- Extra annotations for the Compactor ServiceAccount, merged on top of
+    # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+    # Identity binding to Compactor. Requires `create`.
+    # @default -- {}
+    annotations: {}
+    # -- Mount the ServiceAccount token into Compactor pods. Null inherits
+    # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+    # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+    automountServiceAccountToken: null
 
   # -- Extra volumes for Compactor pods.
   # @default -- []
@@ -1327,6 +1379,26 @@ query:
   # -- Extra labels applied to Query pods (e.g. for workload identity).
   # @default -- {}
   podLabels: {}
+  # ServiceAccount used by Query pods. Unset fields inherit `global.serviceAccount`.
+  serviceAccount:
+    # -- Create a ServiceAccount for Query instead of sharing the chart-wide one.
+    # Null inherits `global.serviceAccount.perComponent`.
+    # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+    create: null
+    # -- Name of the ServiceAccount Query pods run as. Empty derives
+    # `<fullname>-query` when Query has a dedicated ServiceAccount, and the
+    # chart-wide ServiceAccount name otherwise. Setting it without `create`
+    # runs Query as a ServiceAccount managed outside this chart.
+    name: ""
+    # -- Extra annotations for the Query ServiceAccount, merged on top of
+    # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+    # Identity binding to Query. Requires `create`.
+    # @default -- {}
+    annotations: {}
+    # -- Mount the ServiceAccount token into Query pods. Null inherits
+    # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+    # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+    automountServiceAccountToken: null
 
   # Prometheus Operator ServiceMonitor configuration for the Query component.
   serviceMonitor:
@@ -1608,6 +1680,26 @@ queryFrontend:
   # -- Extra labels applied to Query Frontend pods (e.g. for workload identity).
   # @default -- {}
   podLabels: {}
+  # ServiceAccount used by Query Frontend pods. Unset fields inherit `global.serviceAccount`.
+  serviceAccount:
+    # -- Create a ServiceAccount for Query Frontend instead of sharing the chart-wide one.
+    # Null inherits `global.serviceAccount.perComponent`.
+    # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+    create: null
+    # -- Name of the ServiceAccount Query Frontend pods run as. Empty derives
+    # `<fullname>-query-frontend` when Query Frontend has a dedicated ServiceAccount, and the
+    # chart-wide ServiceAccount name otherwise. Setting it without `create`
+    # runs Query Frontend as a ServiceAccount managed outside this chart.
+    name: ""
+    # -- Extra annotations for the Query Frontend ServiceAccount, merged on top of
+    # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+    # Identity binding to Query Frontend. Requires `create`.
+    # @default -- {}
+    annotations: {}
+    # -- Mount the ServiceAccount token into Query Frontend pods. Null inherits
+    # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+    # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+    automountServiceAccountToken: null
 
   # Prometheus Operator ServiceMonitor configuration for the Query Frontend.
   serviceMonitor:
@@ -1997,6 +2089,26 @@ storegateway:
   # -- Extra labels applied to Store Gateway pods (e.g. for workload identity).
   # @default -- {}
   podLabels: {}
+  # ServiceAccount used by Store Gateway pods. Unset fields inherit `global.serviceAccount`.
+  serviceAccount:
+    # -- Create a ServiceAccount for Store Gateway instead of sharing the chart-wide one.
+    # Null inherits `global.serviceAccount.perComponent`.
+    # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+    create: null
+    # -- Name of the ServiceAccount Store Gateway pods run as. Empty derives
+    # `<fullname>-storegateway` when Store Gateway has a dedicated ServiceAccount, and the
+    # chart-wide ServiceAccount name otherwise. Setting it without `create`
+    # runs Store Gateway as a ServiceAccount managed outside this chart.
+    name: ""
+    # -- Extra annotations for the Store Gateway ServiceAccount, merged on top of
+    # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+    # Identity binding to Store Gateway. Requires `create`.
+    # @default -- {}
+    annotations: {}
+    # -- Mount the ServiceAccount token into Store Gateway pods. Null inherits
+    # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+    # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+    automountServiceAccountToken: null
 
   # Prometheus Operator ServiceMonitor configuration for the Store Gateway.
   serviceMonitor:
@@ -2432,6 +2544,28 @@ receive:
   # and `receive.router.podLabels` to target each workload independently.
   # @default -- {}
   podLabels: {}
+  # ServiceAccount used by Receive pods. Unset fields inherit `global.serviceAccount`.
+  # Ignored in split mode: configure `receive.ingester.serviceAccount` and
+  # `receive.router.serviceAccount` instead.
+  serviceAccount:
+    # -- Create a ServiceAccount for Receive instead of sharing the chart-wide one.
+    # Null inherits `global.serviceAccount.perComponent`.
+    # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+    create: null
+    # -- Name of the ServiceAccount Receive pods run as. Empty derives
+    # `<fullname>-receive` when Receive has a dedicated ServiceAccount, and the
+    # chart-wide ServiceAccount name otherwise. Setting it without `create`
+    # runs Receive as a ServiceAccount managed outside this chart.
+    name: ""
+    # -- Extra annotations for the Receive ServiceAccount, merged on top of
+    # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+    # Identity binding to Receive. Requires `create`.
+    # @default -- {}
+    annotations: {}
+    # -- Mount the ServiceAccount token into Receive pods. Null inherits
+    # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+    # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+    automountServiceAccountToken: null
 
   # Prometheus Operator ServiceMonitor configuration for the Receive component.
   serviceMonitor:
@@ -2481,7 +2615,7 @@ receive:
   # containerSecurityContext, dnsConfig, extraEnv, extraEnvFrom,
   # extraInitContainers, extraContainers, probes, nodeSelector, tolerations,
   # affinity, topologySpreadConstraints, priorityClassName, extraVolumes,
-  # extraVolumeMounts, annotations, labels, serviceMonitor, pdb,
+  # extraVolumeMounts, annotations, labels, serviceMonitor, pdb, serviceAccount,
   # tenancyHeader). Leave empty (`{}`) in standalone mode.
   # ======================================================================
   # -- Ingester StatefulSet config. Required when `receive.mode` is `split`;
@@ -2775,6 +2909,26 @@ receive:
     # -- Extra labels applied to Router pods (e.g. for workload identity).
     # @default -- {}
     podLabels: {}
+    # ServiceAccount used by Router pods. Unset fields inherit `global.serviceAccount`.
+    serviceAccount:
+      # -- Create a ServiceAccount for Router instead of sharing the chart-wide one.
+      # Null inherits `global.serviceAccount.perComponent`.
+      # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+      create: null
+      # -- Name of the ServiceAccount Router pods run as. Empty derives
+      # `<fullname>-receive-router` when Router has a dedicated ServiceAccount, and the
+      # chart-wide ServiceAccount name otherwise. Setting it without `create`
+      # runs Router as a ServiceAccount managed outside this chart.
+      name: ""
+      # -- Extra annotations for the Router ServiceAccount, merged on top of
+      # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+      # Identity binding to Router. Requires `create`.
+      # @default -- {}
+      annotations: {}
+      # -- Mount the ServiceAccount token into Router pods. Null inherits
+      # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+      # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+      automountServiceAccountToken: null
 
     # Prometheus Operator ServiceMonitor configuration for the Router.
     serviceMonitor:
@@ -3122,6 +3276,26 @@ ruler:
   # -- Extra labels applied to Ruler pods (e.g. for workload identity).
   # @default -- {}
   podLabels: {}
+  # ServiceAccount used by Ruler pods. Unset fields inherit `global.serviceAccount`.
+  serviceAccount:
+    # -- Create a ServiceAccount for Ruler instead of sharing the chart-wide one.
+    # Null inherits `global.serviceAccount.perComponent`.
+    # @default -- `null` (inherit `global.serviceAccount.perComponent`)
+    create: null
+    # -- Name of the ServiceAccount Ruler pods run as. Empty derives
+    # `<fullname>-ruler` when Ruler has a dedicated ServiceAccount, and the
+    # chart-wide ServiceAccount name otherwise. Setting it without `create`
+    # runs Ruler as a ServiceAccount managed outside this chart.
+    name: ""
+    # -- Extra annotations for the Ruler ServiceAccount, merged on top of
+    # `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload
+    # Identity binding to Ruler. Requires `create`.
+    # @default -- {}
+    annotations: {}
+    # -- Mount the ServiceAccount token into Ruler pods. Null inherits
+    # `global.serviceAccount.automountServiceAccountToken`. Requires `create`.
+    # @default -- `null` (inherit `global.serviceAccount.automountServiceAccountToken`)
+    automountServiceAccountToken: null
 
   # Prometheus Operator ServiceMonitor configuration for the Ruler component.
   serviceMonitor:


### PR DESCRIPTION
- Introduced a shared ServiceAccount for Store Gateway shards.
- Updated StatefulSet templates to reference the new ServiceAccount structure.
- Added comprehensive tests for ServiceAccount rendering and behavior across all components.
- Enhanced values schema and default values for ServiceAccount configurations in `values.yaml`.
- Ensured compatibility with global ServiceAccount settings and per-component overrides.

<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
