### PR TITLE
fix(servicemonitor): honour nameOverride in selectors and rule labels

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.33.0
+version: 0.33.1
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.33.1](https://img.shields.io/badge/Version-0.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -46,7 +46,7 @@ Kubernetes: `>= 1.30.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.rustfs.com/ | rustfs | 0.12.0 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 88.0.1 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 88.2.0 |
 
 ## Component Overview
 

--- a/charts/thanos/templates/bucket/servicemonitor.yaml
+++ b/charts/thanos/templates/bucket/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: bucketweb
   endpoints:

--- a/charts/thanos/templates/compactor/servicemonitor.yaml
+++ b/charts/thanos/templates/compactor/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: compactor
   endpoints:

--- a/charts/thanos/templates/prometheusrule/rule.yaml
+++ b/charts/thanos/templates/prometheusrule/rule.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "thanos.fullname" . }}-rules
   namespace: {{ include "thanos.namespace" . }}
   labels:
-    app.kubernetes.io/name: thanos
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/part-of: thanos
     {{- with $tr.labels }}

--- a/charts/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/charts/thanos/templates/query-frontend/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query-frontend
   endpoints:

--- a/charts/thanos/templates/query/servicemonitor.yaml
+++ b/charts/thanos/templates/query/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query
   endpoints:

--- a/charts/thanos/templates/receive/servicemonitor.yaml
+++ b/charts/thanos/templates/receive/servicemonitor.yaml
@@ -17,7 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: receive
   endpoints:

--- a/charts/thanos/templates/receive/split/router-servicemonitor.yaml
+++ b/charts/thanos/templates/receive/split/router-servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: receive-router
   endpoints:

--- a/charts/thanos/templates/ruler/servicemonitor.yaml
+++ b/charts/thanos/templates/ruler/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: ruler
   endpoints:

--- a/charts/thanos/templates/storegateway/servicemonitor.yaml
+++ b/charts/thanos/templates/storegateway/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: thanos
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: storegateway
   endpoints:

--- a/charts/thanos/tests/naming_test.yaml
+++ b/charts/thanos/tests/naming_test.yaml
@@ -537,6 +537,39 @@ tests:
           path: metadata.labels["app.kubernetes.io/name"]
           value: mythanos
 
+  - it: uses nameOverride in the ServiceMonitor selector so it still matches the Service
+    template: query/servicemonitor.yaml
+    set:
+      nameOverride: mythanos
+      query.enabled: true
+      query.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: mythanos
+
+  - it: uses nameOverride in the receive router ServiceMonitor selector
+    template: receive/split/router-servicemonitor.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      nameOverride: mythanos
+      receive.router.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: mythanos
+
+  - it: uses nameOverride for the PrometheusRule name label
+    template: prometheusrule/rule.yaml
+    set:
+      nameOverride: mythanos
+      global.thanosRules.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: mythanos
+
   - it: lets fullnameOverride win over nameOverride for resource names
     template: query/service.yaml
     set:


### PR DESCRIPTION
#### What this PR does / why we need it:

Every ServiceMonitor selected Services on the **literal** `app.kubernetes.io/name: thanos`, while the Services label themselves from the `thanos.name` helper — which `nameOverride` changes. Setting `nameOverride` therefore left each ServiceMonitor matching nothing, silently stopping all Thanos scraping.

This renders the label from `thanos.name` in the eight ServiceMonitor selectors and in the PrometheusRule metadata labels, so they match the Services and the rest of the chart.

#### Which issue this PR fixes

None — found while scoping #197. It is a prerequisite for that work: #197 makes selector labels configurable, and these hardcoded literals would have to be reconciled either way.

#### Special notes for your reviewer:

- Output is **byte-identical** when `nameOverride` is unset (`thanos.name` falls back to the chart name), so this is a no-op for every existing install that does not set it.
- No upgrade hazard: ServiceMonitor selectors and PrometheusRule labels are mutable, unlike the workload selectors in #197.
- `prometheusrule/rule.yaml` is a metadata label rather than a selector; it is included so the rule is labelled consistently with everything else the chart renders.
- Tests: 3 new cases in `naming_test.yaml` (ServiceMonitor selector, receive-router ServiceMonitor selector, PrometheusRule label). `helm unittest -f tests/naming_test.yaml -f tests/prometheusrule_test.yaml` → 83/83.
- The README diff includes pre-existing drift on master: the version badge was stale at `0.32.0` and the kube-prometheus-stack row at `88.0.1`. `helm-docs` corrects both.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (0.33.0 → 0.33.1)
- [x] Variables are documented in the README.md (no new values)