### PR TITLE
feat(gateway-api): support timeouts on HTTPRoute rules

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.33.1
+version: 0.34.0
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.33.1](https://img.shields.io/badge/Version-0.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -575,6 +575,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.httpRoute.hostnames | list | [] | Hostnames to match. Empty matches all hostnames on the parent Gateway. |
 | bucket.bucketweb.httpRoute.matches | list | [] | Gateway matches HTTPRoute rules match conditions. |
 | bucket.bucketweb.httpRoute.parentRefs | list | [] | Gateway parentRefs the HTTPRoute should attach to. |
+| bucket.bucketweb.httpRoute.timeouts | object | {} | Timeouts for the Bucketweb HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | bucket.bucketweb.ingress.annotations | object | {} | Extra annotations for the Ingress resource. |
 | bucket.bucketweb.ingress.className | string | `""` | Ingress class name (e.g. nginx, traefik). |
 | bucket.bucketweb.ingress.enabled | bool | `false` | Enable a Kubernetes Ingress for Bucketweb. |
@@ -655,6 +656,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.httpRoute.hostnames | list | [] | Hostnames to match on the Compactor HTTPRoute. |
 | compactor.httpRoute.matches | list | [] | Gateway matches for the Compactor HTTPRoute rules. |
 | compactor.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Compactor HTTPRoute. |
+| compactor.httpRoute.timeouts | object | {} | Timeouts for the Compactor HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | compactor.ingress.className | string | `""` | Ingress class name for the Compactor (e.g. nginx, traefik). |
 | compactor.ingress.enabled | bool | `false` | Enable a Kubernetes Ingress for the Compactor HTTP endpoint. |
 | compactor.ingress.hosts[0].host | string | `"compactor.local"` |  |
@@ -854,6 +856,7 @@ The table below documents all available values. Top-level keys group settings by
 | query.httpRoute.hostnames | list | [] | Hostnames to match on the Query HTTPRoute. |
 | query.httpRoute.matches | list | [] | Gateway matches for the Query HTTPRoute rules. |
 | query.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Query HTTPRoute. |
+| query.httpRoute.timeouts | object | {} | Timeouts for the Query HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | query.ingress.annotations | object | {} | Deprecated. Use `query.ingress.http.annotations` instead. |
 | query.ingress.className | string | `""` | Deprecated. Use `query.ingress.http.className` instead. |
 | query.ingress.enabled | bool | `false` | Deprecated. Use `query.ingress.http.enabled` instead. |
@@ -956,6 +959,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.httpRoute.hostnames | list | [] | Hostnames to match on the Query Frontend HTTPRoute. |
 | queryFrontend.httpRoute.matches | list | [] | Gateway matches for the Query Frontend HTTPRoute rules. |
 | queryFrontend.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Query Frontend HTTPRoute. |
+| queryFrontend.httpRoute.timeouts | object | {} | Timeouts for the Query Frontend HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | queryFrontend.ingress.annotations | object | {} | Extra annotations for the Query Frontend Ingress. |
 | queryFrontend.ingress.className | string | `""` | Ingress class name for Query Frontend (e.g. nginx, traefik). |
 | queryFrontend.ingress.enabled | bool | `false` | Enable a Kubernetes Ingress for Query Frontend. |
@@ -1039,6 +1043,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.httpRoute.hostnames | list | [] | Hostnames to match on the Receive HTTPRoute. |
 | receive.httpRoute.matches | list | [] | Gateway matches for the Receive HTTPRoute rules. |
 | receive.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Receive HTTPRoute. |
+| receive.httpRoute.timeouts | object | {} | Timeouts for the Receive HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | receive.ingester | object | {} | Ingester StatefulSet config. Required when `receive.mode` is `split`; ignored in `standalone` mode. |
 | receive.ingress.annotations | object | {} | Deprecated. Use `receive.ingress.http.annotations` instead. |
 | receive.ingress.className | string | `""` | Deprecated. Use `receive.ingress.http.className` instead. |
@@ -1125,6 +1130,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.httpRoute.hostnames | list | [] | Hostnames to match on the Router HTTPRoute. |
 | receive.router.httpRoute.matches | list | [] | Gateway matches for the Router HTTPRoute rules. |
 | receive.router.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Router HTTPRoute. |
+| receive.router.httpRoute.timeouts | object | {} | Timeouts for the Router HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | receive.router.ingress.http.annotations | object | {} | Extra annotations for the Router HTTP Ingress. |
 | receive.router.ingress.http.className | string | `""` | Ingress class name for Router HTTP endpoint. |
 | receive.router.ingress.http.enabled | bool | `false` | Enable a Kubernetes Ingress for the Router HTTP endpoint. |
@@ -1257,6 +1263,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.httpRoute.hostnames | list | [] | Hostnames to match on the Ruler HTTPRoute. |
 | ruler.httpRoute.matches | list | [] | Gateway matches for the Ruler HTTPRoute rules. |
 | ruler.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Ruler HTTPRoute. |
+| ruler.httpRoute.timeouts | object | {} | Timeouts for the Ruler HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | ruler.ingress.annotations | object | {} | Extra annotations for the Ruler Ingress. |
 | ruler.ingress.className | string | `""` | Ingress class name for Ruler (e.g. nginx, traefik). |
 | ruler.ingress.enabled | bool | `false` | Enable a Kubernetes Ingress for the Ruler HTTP endpoint. |
@@ -1362,6 +1369,7 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.httpRoute.hostnames | list | [] | Hostnames to match on the Store Gateway HTTPRoute. |
 | storegateway.httpRoute.matches | list | [] | Gateway matches for the Store Gateway HTTPRoute rules. |
 | storegateway.httpRoute.parentRefs | list | [] | Gateway parentRefs for the Store Gateway HTTPRoute. |
+| storegateway.httpRoute.timeouts | object | {} | Timeouts for the Store Gateway HTTPRoute rule (Gateway API HTTPRouteTimeouts). |
 | storegateway.ingress.annotations | object | {} | Deprecated. Use `storegateway.ingress.http.annotations` instead. |
 | storegateway.ingress.className | string | `""` | Deprecated. Use `storegateway.ingress.http.className` instead. |
 | storegateway.ingress.enabled | bool | `false` | Deprecated. Use `storegateway.ingress.http.enabled` instead. |

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -988,6 +988,10 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $cfg.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- with $cfg.extraRules }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/thanos/tests/gateway_api_test.yaml
+++ b/charts/thanos/tests/gateway_api_test.yaml
@@ -112,6 +112,35 @@ tests:
           path: spec.rules[0].filters[0].requestRedirect.statusCode
           value: 301
 
+  - it: sets timeouts on query HTTPRoute
+    template: query/httproute.yaml
+    set:
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+      query.httpRoute.timeouts:
+        request: 300s
+        backendRequest: 295s
+    asserts:
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 300s
+      - equal:
+          path: spec.rules[0].timeouts.backendRequest
+          value: 295s
+
+  - it: omits timeouts on query HTTPRoute when unset
+    template: query/httproute.yaml
+    set:
+      query.enabled: true
+      query.httpRoute.enabled: true
+      query.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - notExists:
+          path: spec.rules[0].timeouts
+
   - it: sets extraRules with matches on query HTTPRoute
     template: query/httproute.yaml
     set:
@@ -538,6 +567,20 @@ tests:
       - equal:
           path: spec.rules[0].backendRefs[0].port
           value: 9090
+
+  - it: sets timeouts on query-frontend HTTPRoute
+    template: query-frontend/httproute.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.httpRoute.enabled: true
+      queryFrontend.httpRoute.parentRefs:
+        - name: my-gateway
+      queryFrontend.httpRoute.timeouts:
+        request: 0s
+    asserts:
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 0s
 
   - it: does not render query-frontend HTTPRoute when disabled
     template: query-frontend/httproute.yaml

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -197,6 +197,21 @@
                   "required": [],
                   "title": "parentRefs",
                   "type": "array"
+                },
+                "timeouts": {
+                  "additionalProperties": true,
+                  "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+                  "properties": {
+                    "backendRequest": {
+                      "type": "string"
+                    },
+                    "request": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "timeouts",
+                  "type": "object"
                 }
               },
               "required": [
@@ -1055,6 +1070,21 @@
               "required": [],
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "additionalProperties": true,
+              "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+              "properties": {
+                "backendRequest": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -2823,6 +2853,21 @@
               "required": [],
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "additionalProperties": true,
+              "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+              "properties": {
+                "backendRequest": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -3922,6 +3967,21 @@
               "required": [],
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "additionalProperties": true,
+              "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+              "properties": {
+                "backendRequest": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -4804,6 +4864,21 @@
               "required": [],
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "additionalProperties": true,
+              "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+              "properties": {
+                "backendRequest": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -6304,6 +6379,21 @@
               "required": [],
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "additionalProperties": true,
+              "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+              "properties": {
+                "backendRequest": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -7422,6 +7512,21 @@
               "required": [],
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "additionalProperties": true,
+              "description": "Timeouts for the HTTPRoute rule (Gateway API HTTPRouteTimeouts).\nExample:\ntimeouts:\n  request: 60s\n  backendRequest: 55s",
+              "properties": {
+                "backendRequest": {
+                  "type": "string"
+                },
+                "request": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -512,6 +512,13 @@ bucket:
       #       add:
       #         - name: X-Forwarded-Proto
       #           value: https
+      # -- Timeouts for the Bucketweb HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+      # @default -- {}
+      timeouts: {}
+      # Example:
+      # timeouts:
+      #   request: 60s
+      #   backendRequest: 55s
       # -- Additional custom rules for Bucketweb HTTPRoute
       # Each item should be a complete HTTPRouteRule object with
       # its own backendRefs, matches, filters, etc.
@@ -828,6 +835,13 @@ compactor:
     #       add:
     #         - name: X-Forwarded-Proto
     #           value: https
+    # -- Timeouts for the Compactor HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+    # @default -- {}
+    timeouts: {}
+    # Example:
+    # timeouts:
+    #   request: 60s
+    #   backendRequest: 55s
     # -- Additional custom rules for Compactor HTTPRoute
     # Each item should be a complete HTTPRouteRule object with
     # its own backendRefs, matches, filters, etc.
@@ -1184,6 +1198,13 @@ query:
     #       add:
     #         - name: X-Forwarded-Proto
     #           value: https
+    # -- Timeouts for the Query HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+    # @default -- {}
+    timeouts: {}
+    # Example:
+    # timeouts:
+    #   request: 60s
+    #   backendRequest: 55s
     # -- Additional custom rules for Query HTTPRoute
     # Each item should be a complete HTTPRouteRule object with
     # its own backendRefs, matches, filters, etc.
@@ -1527,6 +1548,13 @@ queryFrontend:
     #       add:
     #         - name: X-Forwarded-Proto
     #           value: https
+    # -- Timeouts for the Query Frontend HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+    # @default -- {}
+    timeouts: {}
+    # Example:
+    # timeouts:
+    #   request: 60s
+    #   backendRequest: 55s
     # -- Additional custom rules for Query Frontend HTTPRoute
     # Each item should be a complete HTTPRouteRule object with
     # its own backendRefs, matches, filters, etc.
@@ -1902,6 +1930,13 @@ storegateway:
     #       add:
     #         - name: X-Forwarded-Proto
     #           value: https
+    # -- Timeouts for the Store Gateway HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+    # @default -- {}
+    timeouts: {}
+    # Example:
+    # timeouts:
+    #   request: 60s
+    #   backendRequest: 55s
     # -- Additional custom rules for Store Gateway HTTPRoute
     # Each item should be a complete HTTPRouteRule object with
     # its own backendRefs, matches, filters, etc.
@@ -2351,6 +2386,13 @@ receive:
     #       add:
     #         - name: X-Forwarded-Proto
     #           value: https
+    # -- Timeouts for the Receive HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+    # @default -- {}
+    timeouts: {}
+    # Example:
+    # timeouts:
+    #   request: 60s
+    #   backendRequest: 55s
     # -- Additional custom rules for Receive HTTPRoute
     # Each item should be a complete HTTPRouteRule object with
     # its own backendRefs, matches, filters, etc.
@@ -2748,6 +2790,13 @@ receive:
       #       add:
       #         - name: X-Forwarded-Proto
       #           value: https
+      # -- Timeouts for the Router HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+      # @default -- {}
+      timeouts: {}
+      # Example:
+      # timeouts:
+      #   request: 60s
+      #   backendRequest: 55s
       # -- Additional custom rules for Router HTTPRoute
       # Each item should be a complete HTTPRouteRule object with
       # its own backendRefs, matches, filters, etc.
@@ -3135,6 +3184,13 @@ ruler:
     #       add:
     #         - name: X-Forwarded-Proto
     #           value: https
+    # -- Timeouts for the Ruler HTTPRoute rule (Gateway API HTTPRouteTimeouts).
+    # @default -- {}
+    timeouts: {}
+    # Example:
+    # timeouts:
+    #   request: 60s
+    #   backendRequest: 55s
     # -- Additional custom rules for Ruler HTTPRoute
     # Each item should be a complete HTTPRouteRule object with
     # its own backendRefs, matches, filters, etc.


### PR DESCRIPTION
#### What this PR does / why we need it:

`HTTPRouteTimeouts` was the only non-experimental field of `HTTPRouteRule` the chart did not render, so users needing a longer request timeout had to deploy an HTTPRoute outside the chart or add a dummy `extraRules` entry. The reporter hit `504 upstream timeout` from Grafana because of it.

Adds `<component>.httpRoute.timeouts`, rendered on the generated rule for all eight HTTPRoutes (bucketweb, compactor, query, query-frontend, receive, receive router, ruler, storegateway).

```yaml
query:
  httpRoute:
    enabled: true
    timeouts:
      request: 60s
      backendRequest: 55s
```

#### Which issue this PR fixes

- fixes #194

#### Special notes for your reviewer:

- Takes option 1 from the issue (typed `timeouts`) rather than arbitrary keys or a disable-the-primary-rule switch, so the value stays schema-validated like its siblings.
- **GRPCRoute is deliberately left alone**: `GRPCRouteRule.timeouts` is still an experimental field, whereas `HTTPRouteTimeouts` is Extended and stable — same tier as `name`, which the chart already renders.
- Purely additive: `timeouts` defaults to `{}` and nothing is emitted unless set.
- Tests: 3 new cases in `gateway_api_test.yaml` (query timeouts, absent by default, query-frontend `request: 0s`). Full suite `helm unittest charts/thanos` → 746/746.
- The README diff includes pre-existing drift on master: the version badge was stale at `0.32.0` and the kube-prometheus-stack row at `88.0.1`. `helm-docs` corrects both.
- @briend offered to send this in the issue — happy to close this in favour of their PR if they prefer.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (0.33.0 → 0.34.0)
- [x] Variables are documented in the README.md