### PR TITLE
feat(service): allow static node ports on component Services

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.34.0
+version: 0.35.0
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -617,6 +617,7 @@ The table below documents all available values. Top-level keys group settings by
 | bucket.bucketweb.resources | object | {} | Resource requests and limits for the Bucketweb container. |
 | bucket.bucketweb.service.annotations | object | {} | Extra annotations for the Bucketweb Service. |
 | bucket.bucketweb.service.labels | object | {} | Extra labels for the Bucketweb Service. |
+| bucket.bucketweb.service.nodePort | string | `null` (allocated by Kubernetes) | Static node port for the Bucketweb HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | bucket.bucketweb.service.port | int | `10902` | HTTP port exposed by the Bucketweb Service. |
 | bucket.bucketweb.service.type | string | `"ClusterIP"` | Kubernetes Service type for Bucketweb. |
 | bucket.bucketweb.serviceAccount.annotations | object | {} | Extra annotations for the Bucketweb ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Bucketweb. Requires `create`. |
@@ -706,6 +707,7 @@ The table below documents all available values. Top-level keys group settings by
 | compactor.retention.resolutionRaw | string | `"30d"` | Retention for raw resolution blocks (--retention.resolution-raw). |
 | compactor.service.annotations | object | {} | Extra annotations for the Compactor Service. |
 | compactor.service.labels | object | {} | Extra labels for the Compactor Service. |
+| compactor.service.nodePort | string | `null` (allocated by Kubernetes) | Static node port for the Compactor HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | compactor.service.port | int | `10902` | HTTP port exposed by the Compactor Service. |
 | compactor.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Compactor HTTP endpoint. |
 | compactor.serviceAccount.annotations | object | {} | Extra annotations for the Compactor ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Compactor. Requires `create`. |
@@ -913,7 +915,9 @@ The table below documents all available values. Top-level keys group settings by
 | query.replicaLabels[2] | string | `"ruler_replica"` |  |
 | query.resources | object | {} | Resource requests and limits for the Query container. |
 | query.service.annotations | object | {} | Extra annotations for the Query Service. |
+| query.service.grpcNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Query gRPC port. |
 | query.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Query Service. |
+| query.service.httpNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Query HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | query.service.httpPort | int | `9090` | HTTP/PromQL port exposed by the Query Service. |
 | query.service.labels | object | {} | Extra labels for the Query Service. |
 | query.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Query component. |
@@ -1000,6 +1004,7 @@ The table below documents all available values. Top-level keys group settings by
 | queryFrontend.resources | object | {} | Resource requests and limits for the Query Frontend container. |
 | queryFrontend.service.annotations | object | {} | Extra annotations for the Query Frontend Service. |
 | queryFrontend.service.labels | object | {} | Extra labels for the Query Frontend Service. |
+| queryFrontend.service.nodePort | string | `null` (allocated by Kubernetes) | Static node port for the Query Frontend HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | queryFrontend.service.port | int | `9090` | HTTP port exposed by the Query Frontend Service. |
 | queryFrontend.service.type | string | `"ClusterIP"` | Kubernetes Service type for Query Frontend. |
 | queryFrontend.serviceAccount.annotations | object | {} | Extra annotations for the Query Frontend ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Query Frontend. Requires `create`. |
@@ -1178,8 +1183,10 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.replicationFactor | int | `1` | Replication factor used when forwarding writes to Ingesters. Each write is sent to this many Ingesters. Must be <= ingester replicaCount. |
 | receive.router.resources | object | {} | Resource requests and limits for the Router container. |
 | receive.router.service.annotations | object | {} | Extra annotations for the Router Service. |
+| receive.router.service.httpNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Router HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | receive.router.service.httpPort | int | `10902` | HTTP port exposed by the Router Service (metrics, probes). |
 | receive.router.service.labels | object | {} | Extra labels for the Router Service. |
+| receive.router.service.remoteWriteNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Router remote-write port. |
 | receive.router.service.remoteWritePort | int | `10908` | Remote-write ingestion port exposed by the Router Service. |
 | receive.router.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Router component. |
 | receive.router.serviceAccount.annotations | object | {} | Extra annotations for the Router ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Router. Requires `create`. |
@@ -1206,8 +1213,10 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.vpa.updateMode | string | `"Auto"` | VPA update mode for Router. One of Auto, Off, or Initial. |
 | receive.service.annotations | object | {} | Extra annotations for the Receive Service. |
 | receive.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Receive Service. |
+| receive.service.httpNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Receive HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | receive.service.httpPort | int | `10902` | HTTP port exposed by the Receive Service. |
 | receive.service.labels | object | {} | Extra labels for the Receive Service. |
+| receive.service.remoteWriteNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Receive remote-write port. |
 | receive.service.remoteWritePort | int | `10908` | Remote-write ingestion port exposed by the Receive Service. |
 | receive.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Receive component. |
 | receive.serviceAccount.annotations | object | {} | Extra annotations for the Receive ServiceAccount, merged on top of `global.serviceAccount.annotations`. Use it to scope an IRSA or Workload Identity binding to Receive. Requires `create`. |
@@ -1313,6 +1322,7 @@ The table below documents all available values. Top-level keys group settings by
 | ruler.rules."example-alerts.yaml" | string | `"groups:\n  - name: thanos-example\n    rules:\n      - alert: ExampleAlwaysFiring\n        expr: vector(1)\n        for: 1m\n        labels:\n          severity: warning\n        annotations:\n          summary: Example alert firing\n"` |  |
 | ruler.service.annotations | object | {} | Extra annotations for the Ruler Service. |
 | ruler.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Ruler headless Service. |
+| ruler.service.httpNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Ruler HTTP port. The gRPC port is only exposed on the headless Service, which never has node ports. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | ruler.service.httpPort | int | `10902` | HTTP port exposed by the Ruler Service. |
 | ruler.service.labels | object | {} | Extra labels for the Ruler Service. |
 | ruler.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Ruler component. |
@@ -1430,7 +1440,9 @@ The table below documents all available values. Top-level keys group settings by
 | storegateway.replicaCount | int | `2` | Number of Store Gateway pod replicas. Two or more is recommended for HA. In sharded mode this is the replica count *per shard*. |
 | storegateway.resources | object | {} | Resource requests and limits for the Store Gateway container. |
 | storegateway.service.annotations | object | {} | Extra annotations for the Store Gateway Service. |
+| storegateway.service.grpcNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Store Gateway gRPC port. Ignored when sharding is enabled. |
 | storegateway.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Store Gateway Service. |
+| storegateway.service.httpNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Store Gateway HTTP port. Ignored when sharding is enabled, because the aggregate Service is headless then and the per-shard Services cannot share a single node port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | storegateway.service.httpPort | int | `10902` | HTTP port exposed by the Store Gateway Service. |
 | storegateway.service.labels | object | {} | Extra labels for the Store Gateway Service. |
 | storegateway.service.type | string | `"ClusterIP"` | Kubernetes Service type for the Store Gateway. |

--- a/charts/thanos/templates/bucket/service.yaml
+++ b/charts/thanos/templates/bucket/service.yaml
@@ -21,6 +21,9 @@ spec:
     - name: http
       port: {{ .Values.bucket.bucketweb.service.port }}
       targetPort: http
+      {{- with .Values.bucket.bucketweb.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: bucketweb
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/compactor/service.yaml
+++ b/charts/thanos/templates/compactor/service.yaml
@@ -21,6 +21,9 @@ spec:
     - name: http
       port: {{ .Values.compactor.service.port }}
       targetPort: http
+      {{- with .Values.compactor.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/query-frontend/service.yaml
+++ b/charts/thanos/templates/query-frontend/service.yaml
@@ -21,6 +21,9 @@ spec:
     - name: http
       port: {{ .Values.queryFrontend.service.port }}
       targetPort: http
+      {{- with .Values.queryFrontend.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: query-frontend
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/query/service.yaml
+++ b/charts/thanos/templates/query/service.yaml
@@ -21,9 +21,15 @@ spec:
     - name: http
       port: {{ .Values.query.service.httpPort }}
       targetPort: http
+      {{- with .Values.query.service.httpNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: grpc
       port: {{ .Values.query.service.grpcPort }}
       targetPort: grpc
+      {{- with .Values.query.service.grpcNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: query
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -22,9 +22,15 @@ spec:
     - name: http
       port: {{ $cfg.service.httpPort }}
       targetPort: http
+      {{- with $cfg.service.httpNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: remote-write
       port: {{ $cfg.service.remoteWritePort }}
       targetPort: remote-write
+      {{- with $cfg.service.remoteWriteNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: receive
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/receive/split/router-service.yaml
+++ b/charts/thanos/templates/receive/split/router-service.yaml
@@ -22,9 +22,15 @@ spec:
     - name: http
       port: {{ $rt.service.httpPort | default 10902 }}
       targetPort: http
+      {{- with $rt.service.httpNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: remote-write
       port: {{ $rt.service.remoteWritePort | default 10908 }}
       targetPort: remote-write
+      {{- with $rt.service.remoteWriteNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: receive-router
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -20,6 +20,9 @@ spec:
     - name: http
       port: {{ .Values.ruler.service.httpPort }}
       targetPort: http
+      {{- with .Values.ruler.service.httpNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: ruler
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/templates/storegateway/service.yaml
+++ b/charts/thanos/templates/storegateway/service.yaml
@@ -23,12 +23,25 @@ spec:
   clusterIP: None
   {{- end }}
   ports:
+    # nodePorts are only valid on the aggregate Service while it has a cluster
+    # IP: sharding turns it headless, and the per-shard Services below cannot
+    # share one fixed node port.
     - name: http
       port: {{ .Values.storegateway.service.httpPort }}
       targetPort: http
+      {{- if ne (include "thanos.storegateway.sharded" .) "true" }}
+      {{- with .Values.storegateway.service.httpNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+      {{- end }}
     - name: grpc
       port: {{ .Values.storegateway.service.grpcPort }}
       targetPort: grpc
+      {{- if ne (include "thanos.storegateway.sharded" .) "true" }}
+      {{- with .Values.storegateway.service.grpcNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: storegateway
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/thanos/tests/service_nodeport_test.yaml
+++ b/charts/thanos/tests/service_nodeport_test.yaml
@@ -1,0 +1,241 @@
+suite: service node ports
+
+tests:
+  # -- Bucketweb ------------------------------------------------------
+
+  - it: sets nodePort on the bucketweb service
+    template: bucket/service.yaml
+    set:
+      bucket.bucketweb.enabled: true
+      bucket.bucketweb.service.type: NodePort
+      bucket.bucketweb.service.nodePort: 30902
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30902
+
+  - it: omits nodePort on the bucketweb service by default
+    template: bucket/service.yaml
+    set:
+      bucket.bucketweb.enabled: true
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  # -- Compactor ------------------------------------------------------
+
+  - it: sets nodePort on the compactor service
+    template: compactor/service.yaml
+    set:
+      compactor.enabled: true
+      compactor.service.type: NodePort
+      compactor.service.nodePort: 30903
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30903
+
+  # -- Query ----------------------------------------------------------
+
+  - it: sets http and grpc node ports on the query service
+    template: query/service.yaml
+    set:
+      query.enabled: true
+      query.service.type: NodePort
+      query.service.httpNodePort: 30090
+      query.service.grpcNodePort: 30901
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30090
+      - equal:
+          path: spec.ports[1].name
+          value: grpc
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 30901
+
+  - it: sets only the http node port when the grpc one is unset
+    template: query/service.yaml
+    set:
+      query.enabled: true
+      query.service.type: NodePort
+      query.service.httpNodePort: 30090
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30090
+      - notExists:
+          path: spec.ports[1].nodePort
+
+  - it: omits node ports on the query service by default
+    template: query/service.yaml
+    set:
+      query.enabled: true
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+      - notExists:
+          path: spec.ports[1].nodePort
+
+  # -- Query Frontend -------------------------------------------------
+
+  - it: sets nodePort on the query-frontend service
+    template: query-frontend/service.yaml
+    set:
+      queryFrontend.enabled: true
+      queryFrontend.service.type: NodePort
+      queryFrontend.service.nodePort: 30909
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30909
+
+  - it: omits nodePort on the query-frontend service by default
+    template: query-frontend/service.yaml
+    set:
+      queryFrontend.enabled: true
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  # -- Receive --------------------------------------------------------
+
+  - it: sets http and remote-write node ports on the receive service
+    template: receive/service.yaml
+    documentIndex: 0
+    set:
+      receive.enabled: true
+      receive.service.type: NodePort
+      receive.service.httpNodePort: 30902
+      receive.service.remoteWriteNodePort: 30908
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30902
+      - equal:
+          path: spec.ports[1].name
+          value: remote-write
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 30908
+
+  - it: never sets a node port on the receive headless service
+    template: receive/service.yaml
+    documentIndex: 1
+    set:
+      receive.enabled: true
+      receive.service.type: NodePort
+      receive.service.httpNodePort: 30902
+      receive.service.remoteWriteNodePort: 30908
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  # -- Receive Router (split mode) -------------------------------------
+
+  - it: sets node ports on the receive router service
+    template: receive/split/router-service.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.router.service.type: NodePort
+      receive.router.service.httpNodePort: 31902
+      receive.router.service.remoteWriteNodePort: 31908
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 31902
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 31908
+
+  # -- Ruler ----------------------------------------------------------
+
+  - it: sets the http node port on the ruler service
+    template: ruler/service.yaml
+    documentIndex: 0
+    set:
+      ruler.enabled: true
+      ruler.service.type: NodePort
+      ruler.service.httpNodePort: 30904
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30904
+
+  - it: never sets a node port on the ruler headless service
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+      ruler.service.type: NodePort
+      ruler.service.httpNodePort: 30904
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  # -- Store Gateway ---------------------------------------------------
+
+  - it: sets http and grpc node ports on the storegateway service
+    template: storegateway/service.yaml
+    set:
+      storegateway.enabled: true
+      storegateway.sharded.enabled: false
+      storegateway.service.type: NodePort
+      storegateway.service.httpNodePort: 30905
+      storegateway.service.grpcNodePort: 30906
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30905
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 30906
+
+  - it: ignores node ports on the storegateway service when sharded
+    template: storegateway/service.yaml
+    documentIndex: 0
+    set:
+      storegateway.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+      storegateway.service.type: NodePort
+      storegateway.service.httpNodePort: 30905
+      storegateway.service.grpcNodePort: 30906
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - notExists:
+          path: spec.ports[0].nodePort
+      - notExists:
+          path: spec.ports[1].nodePort
+
+  - it: never sets node ports on the per-shard storegateway services
+    template: storegateway/service.yaml
+    documentIndex: 1
+    set:
+      storegateway.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+      storegateway.service.type: NodePort
+      storegateway.service.httpNodePort: 30905
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thanos-storegateway-0
+      - notExists:
+          path: spec.ports[0].nodePort

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -673,6 +673,15 @@
                   "required": [],
                   "title": "type",
                   "type": "string"
+                },
+                "nodePort": {
+                  "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+                  "required": [],
+                  "title": "nodePort",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 }
               },
               "required": [
@@ -1612,6 +1621,15 @@
               "required": [],
               "title": "type",
               "type": "string"
+            },
+            "nodePort": {
+              "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "nodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [
@@ -3554,6 +3572,24 @@
               "required": [],
               "title": "type",
               "type": "string"
+            },
+            "grpcNodePort": {
+              "description": "Static node port for the gRPC port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "grpcNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "httpNodePort": {
+              "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "httpNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [
@@ -4436,6 +4472,15 @@
               "required": [],
               "title": "type",
               "type": "string"
+            },
+            "nodePort": {
+              "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "nodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [
@@ -5769,6 +5814,24 @@
               "required": [],
               "title": "type",
               "type": "string"
+            },
+            "httpNodePort": {
+              "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "httpNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "remoteWriteNodePort": {
+              "description": "Static node port for the remote-write port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "remoteWriteNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [
@@ -6973,6 +7036,15 @@
               "required": [],
               "title": "type",
               "type": "string"
+            },
+            "httpNodePort": {
+              "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "httpNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [
@@ -8279,6 +8351,24 @@
               "required": [],
               "title": "type",
               "type": "string"
+            },
+            "grpcNodePort": {
+              "description": "Static node port for the gRPC port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "grpcNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "httpNodePort": {
+              "description": "Static node port for the HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range.",
+              "required": [],
+              "title": "httpNodePort",
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -442,6 +442,11 @@ bucket:
       type: ClusterIP
       # -- HTTP port exposed by the Bucketweb Service.
       port: 10902
+      # -- Static node port for the Bucketweb HTTP port.
+      # Only honoured when `type` is NodePort or LoadBalancer; null lets
+      # Kubernetes allocate one from the node-port range.
+      # @default -- `null` (allocated by Kubernetes)
+      nodePort: null
       # -- Extra annotations for the Bucketweb Service.
       # @default -- {}
       annotations: {}
@@ -773,6 +778,11 @@ compactor:
     type: ClusterIP
     # -- HTTP port exposed by the Compactor Service.
     port: 10902
+    # -- Static node port for the Compactor HTTP port.
+    # Only honoured when `type` is NodePort or LoadBalancer; null lets
+    # Kubernetes allocate one from the node-port range.
+    # @default -- `null` (allocated by Kubernetes)
+    nodePort: null
     # -- Extra annotations for the Compactor Service.
     # @default -- {}
     annotations: {}
@@ -1096,6 +1106,14 @@ query:
     httpPort: 9090
     # -- gRPC Store API port exposed by the Query Service.
     grpcPort: 10901
+    # -- Static node port for the Query HTTP port.
+    # Only honoured when `type` is NodePort or LoadBalancer; null lets
+    # Kubernetes allocate one from the node-port range.
+    # @default -- `null` (allocated by Kubernetes)
+    httpNodePort: null
+    # -- Static node port for the Query gRPC port.
+    # @default -- `null` (allocated by Kubernetes)
+    grpcNodePort: null
     # -- Extra annotations for the Query Service.
     # @default -- {}
     annotations: {}
@@ -1483,6 +1501,11 @@ queryFrontend:
     type: ClusterIP
     # -- HTTP port exposed by the Query Frontend Service.
     port: 9090
+    # -- Static node port for the Query Frontend HTTP port.
+    # Only honoured when `type` is NodePort or LoadBalancer; null lets
+    # Kubernetes allocate one from the node-port range.
+    # @default -- `null` (allocated by Kubernetes)
+    nodePort: null
     # -- Extra annotations for the Query Frontend Service.
     # @default -- {}
     annotations: {}
@@ -1827,6 +1850,17 @@ storegateway:
     grpcPort: 10901
     # -- HTTP port exposed by the Store Gateway Service.
     httpPort: 10902
+    # -- Static node port for the Store Gateway HTTP port. Ignored when
+    # sharding is enabled, because the aggregate Service is headless then and
+    # the per-shard Services cannot share a single node port.
+    # Only honoured when `type` is NodePort or LoadBalancer; null lets
+    # Kubernetes allocate one from the node-port range.
+    # @default -- `null` (allocated by Kubernetes)
+    httpNodePort: null
+    # -- Static node port for the Store Gateway gRPC port. Ignored when
+    # sharding is enabled.
+    # @default -- `null` (allocated by Kubernetes)
+    grpcNodePort: null
     # -- Extra annotations for the Store Gateway Service.
     # @default -- {}
     annotations: {}
@@ -2265,6 +2299,14 @@ receive:
     httpPort: 10902
     # -- Remote-write ingestion port exposed by the Receive Service.
     remoteWritePort: 10908
+    # -- Static node port for the Receive HTTP port.
+    # Only honoured when `type` is NodePort or LoadBalancer; null lets
+    # Kubernetes allocate one from the node-port range.
+    # @default -- `null` (allocated by Kubernetes)
+    httpNodePort: null
+    # -- Static node port for the Receive remote-write port.
+    # @default -- `null` (allocated by Kubernetes)
+    remoteWriteNodePort: null
     # -- Extra annotations for the Receive Service.
     # @default -- {}
     annotations: {}
@@ -2706,6 +2748,14 @@ receive:
       httpPort: 10902
       # -- Remote-write ingestion port exposed by the Router Service.
       remoteWritePort: 10908
+      # -- Static node port for the Router HTTP port.
+      # Only honoured when `type` is NodePort or LoadBalancer; null lets
+      # Kubernetes allocate one from the node-port range.
+      # @default -- `null` (allocated by Kubernetes)
+      httpNodePort: null
+      # -- Static node port for the Router remote-write port.
+      # @default -- `null` (allocated by Kubernetes)
+      remoteWriteNodePort: null
       # -- Extra annotations for the Router Service.
       # @default -- {}
       annotations: {}
@@ -3119,6 +3169,12 @@ ruler:
     grpcPort: 10901
     # -- HTTP port exposed by the Ruler Service.
     httpPort: 10902
+    # -- Static node port for the Ruler HTTP port. The gRPC port is only
+    # exposed on the headless Service, which never has node ports.
+    # Only honoured when `type` is NodePort or LoadBalancer; null lets
+    # Kubernetes allocate one from the node-port range.
+    # @default -- `null` (allocated by Kubernetes)
+    httpNodePort: null
     # -- Extra annotations for the Ruler Service.
     # @default -- {}
     annotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Node ports were not configurable anywhere in the chart, so exposing a component on a fixed port meant patching the Service after install.

The issue asks for Query Frontend, but shipping it for one component only invites the same request for the other seven, so this covers every component Service:

| Component | Values |
| --- | --- |
| Bucketweb, Compactor, Query Frontend | `service.nodePort` |
| Query | `service.httpNodePort`, `service.grpcNodePort` |
| Receive, Receive Router | `service.httpNodePort`, `service.remoteWriteNodePort` |
| Ruler | `service.httpNodePort` |
| Store Gateway | `service.httpNodePort`, `service.grpcNodePort` |

`nodePort` where the Service has a single port, `<port>NodePort` where it has several — matching the existing `port` / `httpPort` / `grpcPort` naming.

```yaml
queryFrontend:
  service:
    type: NodePort
    nodePort: 30909
```

#### Which issue this PR fixes

- fixes #191

#### Special notes for your reviewer:

- All values default to `null` and are only rendered when set, so Kubernetes keeps allocating a port exactly as before. No behaviour change for existing installs.
- Two places where a node port cannot exist, and the templates skip it rather than rendering something the API server rejects:
  - **Headless Services** — Receive and Ruler expose gRPC only on their headless Service.
  - **Sharded Store Gateway** — the aggregate Service becomes headless when sharding is on, and the per-shard Services cannot share one fixed node port. Guarded in the template and documented on the value.
- No validation that `service.type` is `NodePort`/`LoadBalancer`; the API server already rejects that combination with a clear message, and gating on type would silently swallow the misconfiguration.
- Tests: new `tests/service_nodeport_test.yaml`, 16 cases including the headless and sharded negatives. Full suite `helm unittest charts/thanos` → 759/759.
- The README diff includes pre-existing drift on master: the version badge was stale at `0.32.0` and the kube-prometheus-stack row at `88.0.1`. `helm-docs` corrects both.

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (0.33.0 → 0.34.0 — conflicts with #199 by design, see below)
- [x] Variables are documented in the README.md

#### Merge order

Three PRs are open off `master` and each bumps `Chart.yaml`, so they conflict on that one line by design:

1. #198 — `fix/servicemonitor-name-label` (0.33.1)
2. #199 — `feat/httproute-timeouts` (0.34.0)
3. #200 — this one

Whichever lands second and third just needs a rebase and a renumbered version.
