### PR TITLE
fix(selectors)!: add app.kubernetes.io/name to selector labels

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -56,4 +56,8 @@ annotations:
     - kind: added
       description: Chart labels (app.kubernetes.io/name, instance, part-of, component and global.commonLabels) on ServiceMonitors, on the Ruler rule-importer ConfigMap and on every volumeClaimTemplate, all of which previously rendered without them
     - kind: added
+      description: app.kubernetes.io/component on the metadata of every workload, PodDisruptionBudget, ConfigMap, Ingress, HorizontalPodAutoscaler and VerticalPodAutoscaler, so 'kubectl get ... -l app.kubernetes.io/component=<component>' now selects them
+    - kind: fixed
+      description: The Receive ServiceMonitor no longer scrapes every Receive pod twice. It matched both the ClusterIP Service and the headless Service, since both carried app.kubernetes.io/component; the headless Service now omits that label, as the per-shard Store Gateway Services already did
+    - kind: added
       description: thanos.selectorLabels template helper, now the single source of every selector in the chart and the basis of thanos.labels

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.35.0
+version: 0.36.0
 appVersion: "v0.42.4"
 keywords:
   - thanos
@@ -51,5 +51,9 @@ annotations:
     - name: Slack
       url: https://cloud-native.slack.com/archives/CL25937SP
   artifacthub.io/changes: |
+    - kind: changed
+      description: "BREAKING: app.kubernetes.io/name is now part of every spec.selector and spec.podSelector, so a component can no longer select the pods of another application installed under the same release name and namespace. Deployment and StatefulSet selectors are immutable, so recreate those workloads once with 'kubectl delete statefulset,deployment -l app.kubernetes.io/part-of=thanos,app.kubernetes.io/instance=<release> --cascade=orphan' before upgrading; pods and PVCs stay up and are re-adopted. See the Upgrading section of the chart README"
     - kind: added
-      description: Per-component ServiceAccounts, each rendered from its own templates/<component>/serviceaccount.yaml with its own name, annotations (IRSA / Workload Identity) and token automount. Opt in per component with <component>.serviceAccount.create or for all components at once with global.serviceAccount.perComponent; the chart-wide ServiceAccount stays the default and is toggled by global.serviceAccount.create
+      description: Chart labels (app.kubernetes.io/name, instance, part-of, component and global.commonLabels) on ServiceMonitors, on the Ruler rule-importer ConfigMap and on every volumeClaimTemplate, all of which previously rendered without them
+    - kind: added
+      description: thanos.selectorLabels template helper, now the single source of every selector in the chart and the basis of thanos.labels

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.36.0](https://img.shields.io/badge/Version-0.36.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -542,6 +542,36 @@ helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
 
 > [!WARNING]
 > Registry now lives in `global.image.registry`, repository must be the path without the registry host, and tag defaults to the chart `appVersion`.
+
+### Upgrading to 0.36.0 — selector labels
+
+`app.kubernetes.io/name` is now part of every `spec.selector` / `spec.podSelector` the chart renders ([#197](https://github.com/thanos-community/helm-charts/issues/197)). Without it, `component: compactor` + `instance: <release>` was the whole discriminator, so a Thanos component installed by an umbrella chart could select the pods of another application sharing the release name and namespace — a Loki compactor, for instance.
+
+Pod templates have always carried this label, so the tightened selectors match exactly the same pods as before. Services, PodDisruptionBudgets and NetworkPolicies update in place.
+
+`spec.selector` on a Deployment or StatefulSet is immutable, however, so those workloads must be recreated once. Orphan them first, which leaves the pods and PVCs running:
+
+```bash
+kubectl delete statefulset,deployment --namespace monitoring \
+  --selector app.kubernetes.io/part-of=thanos,app.kubernetes.io/instance=thanos \
+  --cascade=orphan
+
+helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
+  --namespace monitoring \
+  -f values.yaml
+```
+
+The recreated StatefulSets adopt the orphaned pods, and the Deployments adopt their existing ReplicaSets — the pod template is unchanged, so its hash is unchanged and no pod restarts. Skipping the step makes `helm upgrade` fail with `field is immutable`.
+
+The same release also adds the chart labels to `volumeClaimTemplates`, which is likewise immutable and covered by the recreation above. Claims that already exist are not relabelled, because a StatefulSet never touches existing PVCs; relabel them by name if you select PVCs by label for backups or cost reporting:
+
+```bash
+kubectl label pvc --namespace monitoring data-thanos-compactor-0 \
+  app.kubernetes.io/name=thanos \
+  app.kubernetes.io/instance=thanos \
+  app.kubernetes.io/part-of=thanos \
+  app.kubernetes.io/component=compactor
+```
 
 ## Values Reference
 

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -531,6 +531,36 @@ helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
 > [!WARNING]
 > Registry now lives in `global.image.registry`, repository must be the path without the registry host, and tag defaults to the chart `appVersion`.
 
+### Upgrading to 0.36.0 — selector labels
+
+`app.kubernetes.io/name` is now part of every `spec.selector` / `spec.podSelector` the chart renders ([#197](https://github.com/thanos-community/helm-charts/issues/197)). Without it, `component: compactor` + `instance: <release>` was the whole discriminator, so a Thanos component installed by an umbrella chart could select the pods of another application sharing the release name and namespace — a Loki compactor, for instance.
+
+Pod templates have always carried this label, so the tightened selectors match exactly the same pods as before. Services, PodDisruptionBudgets and NetworkPolicies update in place.
+
+`spec.selector` on a Deployment or StatefulSet is immutable, however, so those workloads must be recreated once. Orphan them first, which leaves the pods and PVCs running:
+
+```bash
+kubectl delete statefulset,deployment --namespace monitoring \
+  --selector app.kubernetes.io/part-of=thanos,app.kubernetes.io/instance=thanos \
+  --cascade=orphan
+
+helm upgrade thanos oci://ghcr.io/thanos-community/helm-charts/thanos \
+  --namespace monitoring \
+  -f values.yaml
+```
+
+The recreated StatefulSets adopt the orphaned pods, and the Deployments adopt their existing ReplicaSets — the pod template is unchanged, so its hash is unchanged and no pod restarts. Skipping the step makes `helm upgrade` fail with `field is immutable`.
+
+The same release also adds the chart labels to `volumeClaimTemplates`, which is likewise immutable and covered by the recreation above. Claims that already exist are not relabelled, because a StatefulSet never touches existing PVCs; relabel them by name if you select PVCs by label for backups or cost reporting:
+
+```bash
+kubectl label pvc --namespace monitoring data-thanos-compactor-0 \
+  app.kubernetes.io/name=thanos \
+  app.kubernetes.io/instance=thanos \
+  app.kubernetes.io/part-of=thanos \
+  app.kubernetes.io/component=compactor
+```
+
 ## Values Reference
 
 The table below documents all available values. Top-level keys group settings by component. Component-level keys always take precedence over `global` defaults.

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -29,9 +29,40 @@ Defaults to the release namespace unless `.Values.namespaceOverride` overrides i
 {{- printf "%s-%s" (include "thanos.fullname" $root) $comp | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- /*
+Selector labels identifying the pods of a single component. Rendered into every
+`spec.selector` / `spec.podSelector` in the chart and always a subset of the pod
+template labels produced by `thanos.labels`.
+
+`app.kubernetes.io/name` is part of the set so that an umbrella chart deploying
+another application under the same release name and namespace cannot collide:
+`component: compactor` + `instance: <release>` alone also matches, say, a Loki
+compactor.
+
+Deliberately excludes `global.commonLabels` and `app.kubernetes.io/part-of`:
+workload selectors are immutable, so anything user-tunable must stay out of them.
+
+The root context is passed explicitly because callers such as the Store Gateway
+templates render selectors inside a `range` where `.` is the shard, not the root.
+`component` is optional.
+Usage:
+  {{- include "thanos.selectorLabels" (dict "root" $ "component" "compactor") | nindent 6 }}
+*/ -}}
+{{- define "thanos.selectorLabels" -}}
+{{- $root := .root -}}
+app.kubernetes.io/name: {{ include "thanos.name" $root }}
+app.kubernetes.io/instance: {{ $root.Release.Name }}
+{{- with .component }}
+app.kubernetes.io/component: {{ . }}
+{{- end }}
+{{- end -}}
+
+{{- /*
+Labels stamped on every resource the chart renders: the selector labels plus the
+chart-wide `part-of` marker and any `global.commonLabels`.
+*/ -}}
 {{- define "thanos.labels" -}}
-app.kubernetes.io/name: {{ include "thanos.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "thanos.selectorLabels" (dict "root" .) }}
 app.kubernetes.io/part-of: thanos
 {{- range $k, $v := .Values.global.commonLabels }}
 {{ $k }}: {{ $v | quote }}

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -19,8 +19,7 @@ spec:
   replicas: {{ .Values.bucket.bucketweb.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: bucketweb
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "bucketweb") | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/thanos/templates/bucket/deployment.yaml
+++ b/charts/thanos/templates/bucket/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
     {{- with .Values.bucket.bucketweb.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/bucket/hpa.yaml
+++ b/charts/thanos/templates/bucket/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/bucket/ingress.yaml
+++ b/charts/thanos/templates/bucket/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
   annotations:
     {{- with .Values.bucket.bucketweb.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/bucket/networkpolicy.yaml
+++ b/charts/thanos/templates/bucket/networkpolicy.yaml
@@ -15,8 +15,7 @@ spec:
         - port: http
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: bucketweb
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "bucketweb") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/bucket/pdb.yaml
+++ b/charts/thanos/templates/bucket/pdb.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: bucketweb
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "bucketweb") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/bucket/pdb.yaml
+++ b/charts/thanos/templates/bucket/pdb.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "bucketweb") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/bucket/service.yaml
+++ b/charts/thanos/templates/bucket/service.yaml
@@ -25,6 +25,5 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: bucketweb
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "bucketweb") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/bucket/servicemonitor.yaml
+++ b/charts/thanos/templates/bucket/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "thanos.compName" (list . "bucketweb") }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.bucket.bucketweb.serviceMonitor.labels }}{{ toYaml .Values.bucket.bucketweb.serviceMonitor.labels | nindent 4 }}{{- end }}
   annotations:
@@ -15,9 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: bucketweb
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "bucketweb") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/compactor/ingress.yaml
+++ b/charts/thanos/templates/compactor/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
   annotations:
     {{- with .Values.compactor.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/compactor/networkpolicy.yaml
+++ b/charts/thanos/templates/compactor/networkpolicy.yaml
@@ -15,8 +15,7 @@ spec:
         - port: http
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "compactor") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/compactor/pdb.yaml
+++ b/charts/thanos/templates/compactor/pdb.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "compactor") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/compactor/pdb.yaml
+++ b/charts/thanos/templates/compactor/pdb.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/compactor/service.yaml
+++ b/charts/thanos/templates/compactor/service.yaml
@@ -25,6 +25,5 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: compactor
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "compactor") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/compactor/servicemonitor.yaml
+++ b/charts/thanos/templates/compactor/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "thanos.compName" (list . "compactor") }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: compactor
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.compactor.serviceMonitor.labels }}{{ toYaml .Values.compactor.serviceMonitor.labels | nindent 4 }}{{- end }}
   annotations:
@@ -15,9 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: compactor
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "compactor") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -22,8 +22,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "compactor") | nindent 6 }}
   template:
     metadata:
       labels:
@@ -101,6 +100,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        labels:
+          {{- include "thanos.labels" $ | nindent 10 }}
+          app.kubernetes.io/component: compactor
       spec:
         accessModes:
         {{- range .Values.compactor.persistence.accessModes | default (list "ReadWriteOnce") }}

--- a/charts/thanos/templates/compactor/statefulset.yaml
+++ b/charts/thanos/templates/compactor/statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
     {{- with .Values.compactor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/compactor/vpa.yaml
+++ b/charts/thanos/templates/compactor/vpa.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "compactor") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
     {{- with .Values.queryFrontend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/query-frontend/deployment.yaml
+++ b/charts/thanos/templates/query-frontend/deployment.yaml
@@ -18,8 +18,7 @@ spec:
   replicas: {{ .Values.queryFrontend.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query-frontend") | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/thanos/templates/query-frontend/hpa.yaml
+++ b/charts/thanos/templates/query-frontend/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query-frontend/ingress.yaml
+++ b/charts/thanos/templates/query-frontend/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
   annotations:
     {{- with .Values.queryFrontend.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/query-frontend/networkpolicy.yaml
+++ b/charts/thanos/templates/query-frontend/networkpolicy.yaml
@@ -15,8 +15,7 @@ spec:
         - port: http
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query-frontend") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/query-frontend/pdb.yaml
+++ b/charts/thanos/templates/query-frontend/pdb.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query-frontend") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query-frontend/pdb.yaml
+++ b/charts/thanos/templates/query-frontend/pdb.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query-frontend") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/query-frontend/service.yaml
+++ b/charts/thanos/templates/query-frontend/service.yaml
@@ -25,6 +25,5 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "query-frontend") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/charts/thanos/templates/query-frontend/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "thanos.compName" (list . "query-frontend") }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.queryFrontend.serviceMonitor.labels }}{{ toYaml .Values.queryFrontend.serviceMonitor.labels | nindent 4 }}{{- end }}
   annotations:
@@ -15,9 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: query-frontend
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query-frontend") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
     {{- with .Values.query.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/query/deployment.yaml
+++ b/charts/thanos/templates/query/deployment.yaml
@@ -18,8 +18,7 @@ spec:
   replicas: {{ .Values.query.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: query
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query") | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/thanos/templates/query/hpa.yaml
+++ b/charts/thanos/templates/query/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query/ingress.yaml
+++ b/charts/thanos/templates/query/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "query") | nindent 4 }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: query
   name: {{ include "thanos.compName" (list $ (printf "query%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
   namespace: {{ include "thanos.namespace" $ }}
 spec:

--- a/charts/thanos/templates/query/networkpolicy.yaml
+++ b/charts/thanos/templates/query/networkpolicy.yaml
@@ -16,8 +16,7 @@ spec:
         - port: http
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: query
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/query/pdb.yaml
+++ b/charts/thanos/templates/query/pdb.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "query") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/query/pdb.yaml
+++ b/charts/thanos/templates/query/pdb.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: query
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/query/service.yaml
+++ b/charts/thanos/templates/query/service.yaml
@@ -31,6 +31,5 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: query
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "query") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/query/servicemonitor.yaml
+++ b/charts/thanos/templates/query/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "thanos.compName" (list . "query") }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: query
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.query.serviceMonitor.labels }}{{ toYaml .Values.query.serviceMonitor.labels | nindent 4 }}{{- end }}
   annotations:
@@ -15,9 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: query
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "query") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/receive/configmap-hashrings.yaml
+++ b/charts/thanos/templates/receive/configmap-hashrings.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ingester" "parent" "receive") | nindent 4 }}
 data:

--- a/charts/thanos/templates/receive/ingress.yaml
+++ b/charts/thanos/templates/receive/ingress.yaml
@@ -18,6 +18,7 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "receive") | nindent 4 }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: receive
   name: {{ include "thanos.compName" (list $ (printf "receive%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
   namespace: {{ include "thanos.namespace" $ }}
 spec:

--- a/charts/thanos/templates/receive/networkpolicy.yaml
+++ b/charts/thanos/templates/receive/networkpolicy.yaml
@@ -17,8 +17,7 @@ spec:
         - port: remote-write
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: receive
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/receive/pdb.yaml
+++ b/charts/thanos/templates/receive/pdb.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/receive/pdb.yaml
+++ b/charts/thanos/templates/receive/pdb.yaml
@@ -15,8 +15,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: receive
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -32,8 +32,7 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: receive
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -59,6 +58,5 @@ spec:
       port: {{ $cfg.service.grpcPort }}
       targetPort: grpc
   selector:
-    app.kubernetes.io/component: receive
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -34,13 +34,17 @@ spec:
   selector:
     {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 4 }}
 ---
+# Headless Service backing the StatefulSet: stable per-pod DNS for the hashring
+# endpoints. Like the per-shard Store Gateway Services, it intentionally omits
+# the `app.kubernetes.io/component: receive` metadata label so the shared
+# ServiceMonitor selects only the ClusterIP Service above and does not scrape
+# every pod twice.
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.receiveHeadless" . }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
-    app.kubernetes.io/component: receive
     {{- include "thanos.labels" . | nindent 4 }}
     {{- with $cfg.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/receive/servicemonitor.yaml
+++ b/charts/thanos/templates/receive/servicemonitor.yaml
@@ -7,6 +7,8 @@ metadata:
   name: {{ include "thanos.receive.workloadName" . }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: receive
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if $sm.labels }}{{ toYaml $sm.labels | nindent 4 }}{{- end }}
   annotations:
@@ -17,9 +19,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: receive
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -23,8 +23,7 @@ spec:
   replicas: {{ $rt.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: receive-router
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive-router") | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/thanos/templates/receive/split/router-networkpolicy.yaml
+++ b/charts/thanos/templates/receive/split/router-networkpolicy.yaml
@@ -16,8 +16,7 @@ spec:
         - port: remote-write
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: receive-router
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive-router") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/receive/split/router-pdb.yaml
+++ b/charts/thanos/templates/receive/split/router-pdb.yaml
@@ -14,8 +14,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: receive-router
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive-router") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/receive/split/router-service.yaml
+++ b/charts/thanos/templates/receive/split/router-service.yaml
@@ -32,6 +32,5 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: receive-router
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive-router") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/receive/split/router-servicemonitor.yaml
+++ b/charts/thanos/templates/receive/split/router-servicemonitor.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ include "thanos.receive.routerName" . }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: receive-router
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if $sm.labels }}{{ toYaml $sm.labels | nindent 4 }}{{- end }}
   annotations:
@@ -16,9 +18,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: receive-router
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive-router") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -24,8 +24,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: receive
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 6 }}
   template:
     metadata:
       labels:
@@ -141,6 +140,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        labels:
+          {{- include "thanos.labels" $ | nindent 10 }}
+          app.kubernetes.io/component: receive
       spec:
         accessModes: ["ReadWriteOnce"]
         {{- if $cfg.persistence.storageClass }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
     {{- with $cfg.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/receive/vpa.yaml
+++ b/charts/thanos/templates/receive/vpa.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: receive
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "receive") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
+++ b/charts/thanos/templates/ruler/configmap-alertmanagers.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-am") | nindent 4 }}
 data:

--- a/charts/thanos/templates/ruler/configmap-auto-import-prometheus-rules.yaml
+++ b/charts/thanos/templates/ruler/configmap-auto-import-prometheus-rules.yaml
@@ -4,6 +4,9 @@ kind: ConfigMap
 metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}-rule-importer
   namespace: {{ include "thanos.namespace" . }}
+  labels:
+    {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
 data:
   import.sh: |
     set -e

--- a/charts/thanos/templates/ruler/configmap-query.yaml
+++ b/charts/thanos/templates/ruler/configmap-query.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-query") | nindent 4 }}
 data:

--- a/charts/thanos/templates/ruler/configmaprules.yaml
+++ b/charts/thanos/templates/ruler/configmaprules.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler-rules") | nindent 4 }}
 data:

--- a/charts/thanos/templates/ruler/ingress.yaml
+++ b/charts/thanos/templates/ruler/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
   annotations:
     {{- with .Values.ruler.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/thanos/templates/ruler/networkpolicy.yaml
+++ b/charts/thanos/templates/ruler/networkpolicy.yaml
@@ -16,8 +16,7 @@ spec:
         - port: http
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/ruler/pdb.yaml
+++ b/charts/thanos/templates/ruler/pdb.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
   annotations:
     {{- include "thanos.annotations" (dict "Values" .Values "component" "ruler") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/ruler/pdb.yaml
+++ b/charts/thanos/templates/ruler/pdb.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 6 }}
   {{- if $minAvail }}
   minAvailable: {{ $minAvail }}
   {{- else if $maxUnavail }}

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -24,8 +24,7 @@ spec:
       nodePort: {{ . }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: ruler
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 4 }}
   type: {{ .Values.ruler.service.type }}
 ---
 apiVersion: v1
@@ -51,6 +50,5 @@ spec:
       port: {{ .Values.ruler.service.grpcPort }}
       targetPort: grpc
   selector:
-    app.kubernetes.io/component: ruler
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/ruler/service.yaml
+++ b/charts/thanos/templates/ruler/service.yaml
@@ -27,6 +27,11 @@ spec:
     {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 4 }}
   type: {{ .Values.ruler.service.type }}
 ---
+# Headless Service backing the StatefulSet: stable per-pod DNS for Query's gRPC
+# fan-out. Like the per-shard Store Gateway Services, it intentionally omits the
+# `app.kubernetes.io/component: ruler` metadata label so the shared
+# ServiceMonitor selects only the ClusterIP Service above and does not scrape
+# every pod twice.
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/thanos/templates/ruler/servicemonitor.yaml
+++ b/charts/thanos/templates/ruler/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "thanos.compName" (list . "ruler") }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: ruler
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.ruler.serviceMonitor.labels }}{{ toYaml .Values.ruler.serviceMonitor.labels | nindent 4 }}{{- end }}
   annotations:
@@ -15,9 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: ruler
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -22,8 +22,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "ruler") | nindent 6 }}
   template:
     metadata:
       labels:
@@ -156,6 +155,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        labels:
+          {{- include "thanos.labels" $ | nindent 10 }}
+          app.kubernetes.io/component: ruler
       spec:
         accessModes:
         {{- range .Values.ruler.persistence.accessModes | default (list "ReadWriteOnce") }}

--- a/charts/thanos/templates/ruler/statefulset.yaml
+++ b/charts/thanos/templates/ruler/statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "thanos.namespace" . }}
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
     {{- with .Values.ruler.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/storegateway/hpa.yaml
+++ b/charts/thanos/templates/storegateway/hpa.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: storegateway
   annotations:
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "storegateway") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/storegateway/ingress.yaml
+++ b/charts/thanos/templates/storegateway/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "storegateway") | nindent 4 }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: storegateway
   name: {{ include "thanos.compName" (list $ (printf "storegateway%s" (eq $port "http" | ternary "" (printf "-%s" $port)))) }}
   namespace: {{ include "thanos.namespace" $ }}
 spec:

--- a/charts/thanos/templates/storegateway/networkpolicy.yaml
+++ b/charts/thanos/templates/storegateway/networkpolicy.yaml
@@ -16,8 +16,7 @@ spec:
         - port: http
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: storegateway
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "storegateway") | nindent 6 }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/thanos/templates/storegateway/pdb.yaml
+++ b/charts/thanos/templates/storegateway/pdb.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: storegateway
   annotations:
     {{- include "thanos.annotations" (dict "Values" $.Values "component" "storegateway") | nindent 4 }}
 spec:

--- a/charts/thanos/templates/storegateway/pdb.yaml
+++ b/charts/thanos/templates/storegateway/pdb.yaml
@@ -18,8 +18,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: storegateway
-      app.kubernetes.io/instance: {{ $.Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "storegateway") | nindent 6 }}
       {{- if $shard.isSharded }}
       thanos.io/storegateway-shard: {{ $shard.index | quote }}
       {{- end }}

--- a/charts/thanos/templates/storegateway/service.yaml
+++ b/charts/thanos/templates/storegateway/service.yaml
@@ -43,8 +43,7 @@ spec:
       {{- end }}
       {{- end }}
   selector:
-    app.kubernetes.io/component: storegateway
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "storegateway") | nindent 4 }}
 {{- if eq (include "thanos.storegateway.sharded" .) "true" }}
 {{- $shards := (include "thanos.storegateway.shards" . | fromYaml).shards }}
 {{- range $shard := $shards }}
@@ -78,8 +77,7 @@ spec:
       port: {{ $.Values.storegateway.service.httpPort }}
       targetPort: http
   selector:
-    app.kubernetes.io/component: storegateway
-    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- include "thanos.selectorLabels" (dict "root" $ "component" "storegateway") | nindent 4 }}
     thanos.io/storegateway-shard: {{ $shard.index | quote }}
 {{- end }}
 {{- end }}

--- a/charts/thanos/templates/storegateway/servicemonitor.yaml
+++ b/charts/thanos/templates/storegateway/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "thanos.compName" (list . "storegateway") }}
   namespace: {{ include "thanos.namespace" . }}
   labels:
+    {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: storegateway
     {{- if .Values.global.serviceMonitor.labels }}{{ toYaml .Values.global.serviceMonitor.labels | nindent 4 }}{{- end }}
     {{- if .Values.storegateway.serviceMonitor.labels }}{{ toYaml .Values.storegateway.serviceMonitor.labels | nindent 4 }}{{- end }}
   annotations:
@@ -15,9 +17,7 @@ spec:
       - {{ include "thanos.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "thanos.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: storegateway
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "storegateway") | nindent 6 }}
   endpoints:
     - port: http
       path: /metrics

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{ include "thanos.namespace" $ }}
   labels:
     {{- include "thanos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: storegateway
     {{- with $.Values.storegateway.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/charts/thanos/templates/storegateway/statefulset.yaml
@@ -27,8 +27,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: storegateway
-      app.kubernetes.io/instance: {{ $.Release.Name }}
+      {{- include "thanos.selectorLabels" (dict "root" $ "component" "storegateway") | nindent 6 }}
       {{- if $shard.isSharded }}
       thanos.io/storegateway-shard: {{ $shard.index | quote }}
       {{- end }}
@@ -130,6 +129,12 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        labels:
+          {{- include "thanos.labels" $ | nindent 10 }}
+          app.kubernetes.io/component: storegateway
+          {{- if $shard.isSharded }}
+          thanos.io/storegateway-shard: {{ $shard.index | quote }}
+          {{- end }}
       spec:
         accessModes:
         {{- range $.Values.storegateway.persistence.accessModes | default (list "ReadWriteOnce") }}

--- a/charts/thanos/tests/selector_labels_test.yaml
+++ b/charts/thanos/tests/selector_labels_test.yaml
@@ -376,6 +376,120 @@ tests:
           path: spec.volumeClaimTemplates[0].metadata.labels["thanos.io/storegateway-shard"]
           value: "1"
 
+  # -- headless Services stay out of the ServiceMonitor ---------------------
+  #
+  # A ServiceMonitor selects on name + instance + component, and matchLabels is
+  # a subset match, so any Service carrying all three is scraped. The headless
+  # Services front the very same pods as the ClusterIP Service, so they must
+  # omit `component` or every pod is scraped twice. The per-shard Store Gateway
+  # Services omit it for the same reason.
+
+  - it: keeps the component label off the receive headless Service
+    template: receive/service.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+      - isNull:
+          path: metadata.labels["app.kubernetes.io/component"]
+
+  - it: keeps the component label off the ruler headless Service
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - isNull:
+          path: metadata.labels["app.kubernetes.io/component"]
+
+  - it: keeps the component label off the per-shard storegateway Services
+    template: storegateway/service.yaml
+    documentIndex: 1
+    set:
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+    asserts:
+      - isNull:
+          path: metadata.labels["app.kubernetes.io/component"]
+      - equal:
+          path: metadata.labels["thanos.io/storegateway-shard"]
+          value: "0"
+
+  - it: keeps the component label on the ClusterIP Service the ServiceMonitor selects
+    template: receive/service.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: receive
+
+  # -- component label on every other resource ------------------------------
+
+  - it: labels the compactor StatefulSet with its component
+    template: compactor/statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: compactor
+
+  - it: labels the query Deployment with its component
+    template: query/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: query
+
+  - it: labels the query PDB with its component
+    template: query/pdb.yaml
+    set:
+      query.pdb.enabled: true
+      query.pdb.minAvailable: 1
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: query
+
+  - it: labels the query HPA with its component
+    template: query/hpa.yaml
+    set:
+      query.autoscaling.enabled: true
+      query.autoscaling.minReplicas: 1
+      query.autoscaling.maxReplicas: 3
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: query
+
+  - it: labels the query Ingress with its component
+    template: query/ingress.yaml
+    set:
+      query.ingress.enabled: true
+      query.ingress.hosts:
+        - host: q.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: query
+
+  - it: labels the receive hashrings ConfigMap with its component
+    template: receive/configmap-hashrings.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: receive
+
   # -- the rule-importer ConfigMap ------------------------------------------
 
   - it: labels the ruler rule-importer ConfigMap

--- a/charts/thanos/tests/selector_labels_test.yaml
+++ b/charts/thanos/tests/selector_labels_test.yaml
@@ -1,0 +1,392 @@
+suite: selector labels
+
+# Every `spec.selector` / `spec.podSelector` in the chart is rendered by the
+# `thanos.selectorLabels` helper and carries the same three labels:
+#   app.kubernetes.io/name       chart name (nameOverride-aware)
+#   app.kubernetes.io/instance   release name
+#   app.kubernetes.io/component  component
+#
+# `app.kubernetes.io/name` is what keeps an umbrella-chart deployment from
+# colliding with another application installed under the same release name and
+# namespace (thanos-community/helm-charts#197): `component: compactor` +
+# `instance: <release>` on its own also matches e.g. a Loki compactor.
+#
+# Two invariants the suite guards:
+#   1. selector labels are always a SUBSET of the pod template labels, so a
+#      tightened selector never orphans a running pod;
+#   2. `global.commonLabels` never leaks into a selector — workload selectors
+#      are immutable, so nothing user-tunable may end up in them.
+
+tests:
+  # -- workload selectors -------------------------------------------------
+
+  - it: selects compactor pods by name, instance and component
+    template: compactor/statefulset.yaml
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/component: compactor
+
+  - it: selects query pods by name, instance and component
+    template: query/deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/component: query
+
+  - it: selects query-frontend pods by name, instance and component
+    template: query-frontend/deployment.yaml
+    set:
+      queryFrontend.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: thanos
+
+  - it: selects bucketweb pods by name, instance and component
+    template: bucket/deployment.yaml
+    set:
+      bucket.enabled: true
+      bucket.bucketweb.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: thanos
+
+  - it: selects receive pods by name, instance and component
+    template: receive/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: thanos
+
+  - it: selects ruler pods by name, instance and component
+    template: ruler/statefulset.yaml
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: thanos
+
+  - it: selects storegateway pods by name, instance and component
+    template: storegateway/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: storegateway
+
+  # -- the selector is a subset of the pod labels -------------------------
+
+  - it: labels compactor pods with everything its selector matches on
+    template: compactor/statefulset.yaml
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: my-release
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: compactor
+
+  - it: labels query pods with everything its selector matches on
+    template: query/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: query
+
+  # -- commonLabels must stay out of selectors ----------------------------
+
+  - it: keeps global.commonLabels out of the workload selector
+    template: compactor/statefulset.yaml
+    set:
+      global.commonLabels:
+        my.company/team: observability
+    asserts:
+      - isNull:
+          path: spec.selector.matchLabels["my.company/team"]
+      - equal:
+          path: metadata.labels["my.company/team"]
+          value: observability
+      - equal:
+          path: spec.template.metadata.labels["my.company/team"]
+          value: observability
+
+  - it: keeps global.commonLabels out of the Service selector
+    template: query/service.yaml
+    set:
+      global.commonLabels:
+        my.company/team: observability
+    asserts:
+      - isNull:
+          path: spec.selector["my.company/team"]
+
+  # -- Services -----------------------------------------------------------
+
+  - it: routes the query Service by name, instance and component
+    template: query/service.yaml
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/component: query
+
+  - it: routes the receive headless Service by name, instance and component
+    template: receive/service.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: thanos
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: receive
+
+  - it: routes the ruler headless Service by name, instance and component
+    template: ruler/service.yaml
+    documentIndex: 1
+    set:
+      ruler.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: thanos
+
+  # -- PodDisruptionBudgets -----------------------------------------------
+
+  - it: scopes the compactor PDB by name, instance and component
+    template: compactor/pdb.yaml
+    release:
+      name: my-release
+    set:
+      compactor.pdb.enabled: true
+      compactor.pdb.minAvailable: 1
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/component: compactor
+
+  # -- NetworkPolicies ----------------------------------------------------
+
+  - it: scopes the query NetworkPolicy by name, instance and component
+    template: query/networkpolicy.yaml
+    release:
+      name: my-release
+    set:
+      global.networkPolicies: true
+    asserts:
+      - equal:
+          path: spec.podSelector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: my-release
+            app.kubernetes.io/component: query
+
+  # -- nameOverride propagation -------------------------------------------
+
+  - it: uses nameOverride in the workload selector and the pod labels alike
+    template: compactor/statefulset.yaml
+    set:
+      nameOverride: custom-thanos
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: custom-thanos
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: custom-thanos
+
+  - it: uses nameOverride in the Service selector
+    template: query/service.yaml
+    set:
+      nameOverride: custom-thanos
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: custom-thanos
+
+  # -- storegateway shards -------------------------------------------------
+
+  - it: keeps the shard label alongside the selector labels on a sharded shard
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: storegateway
+            thanos.io/storegateway-shard: "1"
+
+  - it: keeps the shard label on the per-shard Service selector
+    template: storegateway/service.yaml
+    set:
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: storegateway
+            thanos.io/storegateway-shard: "0"
+
+  # -- receive split mode --------------------------------------------------
+
+  - it: selects receive router pods by name, instance and component
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: receive-router
+
+  - it: selects receive ingester pods by name, instance and component in split mode
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: receive
+
+  # -- ServiceMonitors and the Services they match -------------------------
+
+  - it: matches the compactor Service labels from the compactor ServiceMonitor
+    templates:
+      - compactor/service.yaml
+      - compactor/servicemonitor.yaml
+    set:
+      compactor.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+        template: compactor/service.yaml
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: compactor
+        template: compactor/service.yaml
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: compactor
+        template: compactor/servicemonitor.yaml
+
+  - it: stamps the chart labels on the ServiceMonitor itself
+    template: compactor/servicemonitor.yaml
+    set:
+      compactor.serviceMonitor.enabled: true
+      global.commonLabels:
+        my.company/team: observability
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: thanos
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: compactor
+      - equal:
+          path: metadata.labels["my.company/team"]
+          value: observability
+
+  - it: lets serviceMonitor.labels win over the chart labels
+    template: compactor/servicemonitor.yaml
+    set:
+      compactor.serviceMonitor.enabled: true
+      compactor.serviceMonitor.labels:
+        release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: metadata.labels["release"]
+          value: kube-prometheus-stack
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+
+  # -- PersistentVolumeClaims ----------------------------------------------
+
+  - it: labels the compactor volumeClaimTemplate
+    template: compactor/statefulset.yaml
+    set:
+      compactor.persistence.enabled: true
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/component"]
+          value: compactor
+
+  - it: labels the storegateway volumeClaimTemplate with its shard
+    template: storegateway/statefulset.yaml
+    set:
+      storegateway.persistence.enabled: true
+      storegateway.sharded.enabled: true
+      storegateway.sharded.hashPartitioning.shards: 2
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["thanos.io/storegateway-shard"]
+          value: "1"
+
+  # -- the rule-importer ConfigMap ------------------------------------------
+
+  - it: labels the ruler rule-importer ConfigMap
+    template: ruler/configmap-auto-import-prometheus-rules.yaml
+    set:
+      ruler.enabled: true
+      ruler.autoImportPrometheusRules.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: thanos
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: ruler


### PR DESCRIPTION
Closes #197

## Problem

Every `spec.selector` / `spec.podSelector` in the chart discriminated on `app.kubernetes.io/component` plus `app.kubernetes.io/instance` alone:

```yaml
selector:
  matchLabels:
    app.kubernetes.io/component: compactor
    app.kubernetes.io/instance: {{ .Release.Name }}
```

Under an umbrella chart, another application sharing the release name and namespace emits exactly that pair for a like-named component, so a Thanos component could select foreign pods — the reported case was a Thanos compactor watching a Loki compactor.

The chart was already inconsistent here: all 8 ServiceMonitors selected on the correct `name` + `instance` + `component` triple, while the other 35 selector sites did not. There was no `thanos.selectorLabels` helper — the pattern was copy-pasted.

## Changes

**`thanos.selectorLabels` helper**, now the single source of every selector. It takes an explicit `root` so it also works inside the Store Gateway shard `range`, and excludes `global.commonLabels` and `part-of` — workload selectors are immutable, so nothing user-tunable may end up in them. `thanos.labels` is built on top of it and its output is unchanged.

**All 43 selectors** render from that helper: 35 gained `app.kubernetes.io/name`, the 8 ServiceMonitors were refactored with zero output change.

**Resources that rendered with no chart labels at all** now carry them: ServiceMonitors, the Ruler rule-importer ConfigMap, and every `volumeClaimTemplate`.

**`app.kubernetes.io/component` on metadata** across all workloads, PDBs, ConfigMaps, Ingresses and autoscalers, so `kubectl get sts -l app.kubernetes.io/component=receive` works. Three resources are deliberately excluded: the chart-wide ServiceAccount and the PrometheusRule belong to no single component, and the headless Services are the case below.

**A pre-existing double-scrape, fixed.** A ServiceMonitor selects on name + instance + component, and `matchLabels` is a subset match, so every Service carrying all three is scraped. The Receive headless Service carried `app.kubernetes.io/component: receive` and fronts the same pods as the ClusterIP Service, so Prometheus built two target sets per Receive pod and emitted duplicate series differing only in the `service`/`endpoint` labels. The label is dropped — which is what the per-shard Store Gateway Services already do for exactly this reason — and the rule is now documented on the Ruler headless Service too, which was relying on the same omission with nothing to say why.

## Upgrade impact

Pod templates have always carried `app.kubernetes.io/name`, so the tightened selectors match exactly the same pods as before. Services, PDBs and NetworkPolicies update in place.

`spec.selector` on a Deployment or StatefulSet is immutable, so those workloads need a one-time recreation. Orphan them first, which leaves pods and PVCs running:

```bash
kubectl delete statefulset,deployment --namespace monitoring \
  --selector app.kubernetes.io/part-of=thanos,app.kubernetes.io/instance=<release> \
  --cascade=orphan
```

The recreated StatefulSets adopt the orphaned pods, and the Deployments adopt their existing ReplicaSets — the pod template is unchanged, so its hash is unchanged and no pod restarts. Skipping the step makes `helm upgrade` fail with `field is immutable`. `volumeClaimTemplates` is likewise immutable and is covered by the same recreation; existing PVCs are not relabelled, since a StatefulSet never touches existing claims.

Documented under **Upgrading** in the chart README, and chart bumped to 0.36.0.

## Verification

- **803 unit tests pass**, including a new `selector_labels_test.yaml` (38 cases) covering the subset invariant (selector ⊆ pod labels), `commonLabels` exclusion from selectors, `nameOverride` propagation, shard labels, split mode, and the headless-Service omissions.
- Rendered and audited four configurations — all components, split Receive, sharded Store Gateway, and ingress/routes/HPA/VPA/PVC. Every resource carries `app.kubernetes.io/name`, and every ServiceMonitor matches exactly one Service.
- The rendered diff against `master` is purely additive: 42 `name` labels and 12 new label blocks, zero removals beyond the intentional headless one.
- `helm lint` clean.
