### PR TITLE
feat(thanos): make --http.config usable — probe transport/scheme and ServiceMonitor auth

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.38.0
+version: 0.39.0
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -884,8 +884,8 @@ The table below documents all available values. Top-level keys group settings by
 | global.podAnnotations | object | {} | Annotations added to every pod by default. Component-level annotations are merged on top. |
 | global.podSecurityContext | object | {} | Pod-level security context applied to every pod. Component-level values override this. |
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
-| global.probes | object | `{"scheme":"","tcpSocket":false}` | Probe defaults shared by every component. A component's own `probes` block overrides these. |
-| global.probes.scheme | string | `""` | Scheme for HTTP probes. Set to `HTTPS` when components serve TLS through `--http.config` (https://thanos.io/tip/operating/https.md/). Omitted when empty, so rendered manifests are unchanged unless this is set. |
+| global.probes | object | `{"scheme":"","tcpSocket":false}` | Probe *transport* defaults shared by every component: `scheme` and `tcpSocket` only. Timings and paths are not inherited from here — set those on each component's own `probes.readiness`/`liveness`/`startup`. Any other key here fails schema validation. |
+| global.probes.scheme | string | `""` | Scheme for HTTP probes. Uppercase, as the kubelet requires — unlike its neighbour `serviceMonitor.scheme`, which is lowercase. Set to `HTTPS` when components serve TLS through `--http.config` (https://thanos.io/tip/operating/https.md/). Omitted when empty, so rendered manifests are unchanged unless this is set. |
 | global.probes.tcpSocket | bool | `false` | Use a TCP probe instead of an HTTP one. Required when `--http.config` sets `basic_auth_users`: Thanos protects `/-/healthy` and `/-/ready` too, so HTTP probes 401. |
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.38.0](https://img.shields.io/badge/Version-0.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.39.0](https://img.shields.io/badge/Version-0.39.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -884,6 +884,9 @@ The table below documents all available values. Top-level keys group settings by
 | global.podAnnotations | object | {} | Annotations added to every pod by default. Component-level annotations are merged on top. |
 | global.podSecurityContext | object | {} | Pod-level security context applied to every pod. Component-level values override this. |
 | global.priorityClassName | string | `""` | Priority class name applied to every pod by default. |
+| global.probes | object | `{"scheme":"","tcpSocket":false}` | Probe defaults shared by every component. A component's own `probes` block overrides these. |
+| global.probes.scheme | string | `""` | Scheme for HTTP probes. Set to `HTTPS` when components serve TLS through `--http.config` (https://thanos.io/tip/operating/https.md/). Omitted when empty, so rendered manifests are unchanged unless this is set. |
+| global.probes.tcpSocket | bool | `false` | Use a TCP probe instead of an HTTP one. Required when `--http.config` sets `basic_auth_users`: Thanos protects `/-/healthy` and `/-/ready` too, so HTTP probes 401. |
 | global.rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) required by components that need cluster-level access (e.g. Ruler auto-import). |
 | global.resources | object | {} | Default resource requests and limits. Override per component as needed. |
 | global.serviceAccount.annotations | object | {} | Extra annotations merged into every ServiceAccount, including the per-component ones (e.g. a shared IRSA or Workload Identity annotation). |
@@ -892,6 +895,7 @@ The table below documents all available values. Top-level keys group settings by
 | global.serviceAccount.name | string | `""` | Name of the chart-wide ServiceAccount. Empty derives `<fullname>-thanos` from the release name. |
 | global.serviceAccount.perComponent | bool | `false` | Give every component its own ServiceAccount named `<fullname>-<component>` instead of the chart-wide one. Equivalent to setting `<component>.serviceAccount.create` on every component, and overridden by it per component. |
 | global.serviceMonitor.annotations | object | {} | Extra annotations merged into every ServiceMonitor resource. |
+| global.serviceMonitor.basicAuth | object | {} | Basic auth credentials for scraping, as `username`/`password` secret references. Needed when `--http.config` sets `basic_auth_users`, which also protects `/metrics`. |
 | global.serviceMonitor.enabled | bool | `false` | Enable a Prometheus Operator ServiceMonitor for every component. Individual components can override this with their own serviceMonitor.enabled. |
 | global.serviceMonitor.interval | string | `""` | Scrape interval. Empty string uses the Prometheus operator default. |
 | global.serviceMonitor.labels | object | {} | Extra labels merged into every ServiceMonitor resource. |

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -234,12 +234,34 @@ Usage:
 {{- $comp = index $root.Values $key | default dict -}}
 {{- end -}}
 {{- $probes := $comp.probes | default $par.probes | default dict -}}
+{{- /*
+  Thanos applies --http.config to its whole HTTP mux, including /-/healthy and /-/ready, so a
+  config with basic_auth_users makes HTTP probes fail with 401 and TLS makes them fail on scheme.
+  tcpSocket sidesteps both; scheme covers the TLS-without-basic-auth case.
+
+  Resolved global -> parent -> component with hasKey rather than `default`, so a component can
+  set tcpSocket back to false against a global true.
+*/ -}}
+{{- $tcpSocket := false -}}
+{{- $scheme := "" -}}
+{{- range $src := list ($root.Values.global.probes | default dict) ($par.probes | default dict) ($comp.probes | default dict) }}
+{{- if hasKey $src "tcpSocket" }}{{- $tcpSocket = $src.tcpSocket -}}{{- end }}
+{{- if hasKey $src "scheme" }}{{- $scheme = $src.scheme -}}{{- end }}
+{{- end }}
 {{- with $probes.readiness }}
 {{- if .enabled }}
 readinessProbe:
+{{- if $tcpSocket }}
+  tcpSocket:
+    port: http
+{{- else }}
   httpGet:
     path: {{ default "/-/ready" .path | quote }}
     port: http
+    {{- if $scheme }}
+    scheme: {{ $scheme }}
+    {{- end }}
+{{- end }}
   initialDelaySeconds: {{ default 5 .initialDelaySeconds }}
   periodSeconds: {{ default 10 .periodSeconds }}
   timeoutSeconds: {{ default 5 .timeoutSeconds }}
@@ -250,9 +272,17 @@ readinessProbe:
 {{- with $probes.liveness }}
 {{- if .enabled }}
 livenessProbe:
+{{- if $tcpSocket }}
+  tcpSocket:
+    port: http
+{{- else }}
   httpGet:
     path: {{ default "/-/healthy" .path | quote }}
     port: http
+    {{- if $scheme }}
+    scheme: {{ $scheme }}
+    {{- end }}
+{{- end }}
   initialDelaySeconds: {{ default 30 .initialDelaySeconds }}
   periodSeconds: {{ default 10 .periodSeconds }}
   timeoutSeconds: {{ default 5 .timeoutSeconds }}
@@ -263,9 +293,17 @@ livenessProbe:
 {{- with $probes.startup }}
 {{- if .enabled }}
 startupProbe:
+{{- if $tcpSocket }}
+  tcpSocket:
+    port: http
+{{- else }}
   httpGet:
     path: {{ default "/-/ready" .path | quote }}
     port: http
+    {{- if $scheme }}
+    scheme: {{ $scheme }}
+    {{- end }}
+{{- end }}
   initialDelaySeconds: {{ default 0 .initialDelaySeconds }}
   periodSeconds: {{ default 5 .periodSeconds }}
   timeoutSeconds: {{ default 5 .timeoutSeconds }}

--- a/charts/thanos/templates/bucket/servicemonitor.yaml
+++ b/charts/thanos/templates/bucket/servicemonitor.yaml
@@ -23,6 +23,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval .Values.bucket.bucketweb.serviceMonitor.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.bucket.bucketweb.serviceMonitor.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme .Values.bucket.bucketweb.serviceMonitor.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig .Values.bucket.bucketweb.serviceMonitor.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth .Values.bucket.bucketweb.serviceMonitor.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.bucket.bucketweb.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/compactor/servicemonitor.yaml
+++ b/charts/thanos/templates/compactor/servicemonitor.yaml
@@ -23,6 +23,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval .Values.compactor.serviceMonitor.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.compactor.serviceMonitor.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme .Values.compactor.serviceMonitor.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig .Values.compactor.serviceMonitor.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth .Values.compactor.serviceMonitor.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.compactor.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/charts/thanos/templates/query-frontend/servicemonitor.yaml
@@ -23,6 +23,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval .Values.queryFrontend.serviceMonitor.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.queryFrontend.serviceMonitor.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme .Values.queryFrontend.serviceMonitor.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig .Values.queryFrontend.serviceMonitor.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth .Values.queryFrontend.serviceMonitor.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.queryFrontend.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/query/servicemonitor.yaml
+++ b/charts/thanos/templates/query/servicemonitor.yaml
@@ -23,6 +23,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval .Values.query.serviceMonitor.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.query.serviceMonitor.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme .Values.query.serviceMonitor.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig .Values.query.serviceMonitor.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth .Values.query.serviceMonitor.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.query.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/receive/servicemonitor.yaml
+++ b/charts/thanos/templates/receive/servicemonitor.yaml
@@ -25,6 +25,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval $sm.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout $sm.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme $sm.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig $sm.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth $sm.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings $sm.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/receive/split/router-servicemonitor.yaml
+++ b/charts/thanos/templates/receive/split/router-servicemonitor.yaml
@@ -24,6 +24,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval $sm.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout $sm.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme $sm.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig $sm.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth $sm.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings $sm.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/ruler/servicemonitor.yaml
+++ b/charts/thanos/templates/ruler/servicemonitor.yaml
@@ -23,6 +23,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval .Values.ruler.serviceMonitor.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.ruler.serviceMonitor.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme .Values.ruler.serviceMonitor.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig .Values.ruler.serviceMonitor.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth .Values.ruler.serviceMonitor.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.ruler.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/templates/storegateway/servicemonitor.yaml
+++ b/charts/thanos/templates/storegateway/servicemonitor.yaml
@@ -23,6 +23,17 @@ spec:
       path: /metrics
       interval: {{ default .Values.global.serviceMonitor.interval .Values.storegateway.serviceMonitor.interval | quote }}
       scrapeTimeout: {{ default .Values.global.serviceMonitor.scrapeTimeout .Values.storegateway.serviceMonitor.scrapeTimeout | quote }}
+      {{- with (default .Values.global.serviceMonitor.scheme .Values.storegateway.serviceMonitor.scheme) }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.tlsConfig .Values.storegateway.serviceMonitor.tlsConfig) }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.global.serviceMonitor.basicAuth .Values.storegateway.serviceMonitor.basicAuth) }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default .Values.global.serviceMonitor.metricRelabelings .Values.storegateway.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/thanos/tests/http_config_test.yaml
+++ b/charts/thanos/tests/http_config_test.yaml
@@ -1,0 +1,101 @@
+suite: probes and servicemonitor auth for --http.config
+
+tests:
+  # -- Probes: default output is unchanged ---------------------------------
+
+  - it: keeps httpGet probes with no scheme by default
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /-/ready
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket
+
+  # -- Probes: TLS via --http.config ---------------------------------------
+
+  - it: sets the probe scheme when global.probes.scheme is HTTPS
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      global.probes.scheme: HTTPS
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+
+  # -- Probes: basic auth via --http.config ---------------------------------
+  # Thanos applies --http.config to its whole mux, so /-/healthy and /-/ready
+  # need credentials too and an HTTP probe would 401. A TCP probe does not.
+
+  - it: swaps HTTP probes for TCP probes when global.probes.tcpSocket is true
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      global.probes.tcpSocket: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+
+  - it: lets a component override the global probe transport
+    template: compactor/statefulset.yaml
+    set:
+      compactor.enabled: true
+      global.probes.tcpSocket: true
+      compactor.probes.tcpSocket: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /-/ready
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket
+
+  # -- ServiceMonitor: scheme, tlsConfig and basicAuth ---------------------
+
+  - it: renders basicAuth, scheme and tlsConfig on the servicemonitor
+    template: receive/servicemonitor.yaml
+    set:
+      receive.enabled: true
+      global.serviceMonitor.enabled: true
+      global.serviceMonitor.scheme: https
+      global.serviceMonitor.tlsConfig:
+        insecureSkipVerify: true
+      global.serviceMonitor.basicAuth:
+        username:
+          name: thanos-http-auth
+          key: username
+        password:
+          name: thanos-http-auth
+          key: password
+    asserts:
+      - equal:
+          path: spec.endpoints[0].scheme
+          value: https
+      - equal:
+          path: spec.endpoints[0].tlsConfig.insecureSkipVerify
+          value: true
+      - equal:
+          path: spec.endpoints[0].basicAuth.username.name
+          value: thanos-http-auth
+
+  - it: omits basicAuth when unset
+    template: receive/servicemonitor.yaml
+    set:
+      receive.enabled: true
+      global.serviceMonitor.enabled: true
+    asserts:
+      - isNull:
+          path: spec.endpoints[0].basicAuth

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -553,6 +553,17 @@
                   "title": "readiness",
                   "type": "object"
                 },
+                "scheme": {
+                  "description": "Scheme for HTTP probes for Bucketweb, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+                  "enum": [
+                    "",
+                    "HTTP",
+                    "HTTPS"
+                  ],
+                  "required": [],
+                  "title": "scheme",
+                  "type": "string"
+                },
                 "startup": {
                   "additionalProperties": true,
                   "description": "Startup probe for Bucketweb.",
@@ -618,6 +629,12 @@
                   ],
                   "title": "startup",
                   "type": "object"
+                },
+                "tcpSocket": {
+                  "description": "Use a TCP probe instead of an HTTP one for Bucketweb, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+                  "required": [],
+                  "title": "tcpSocket",
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -1501,6 +1518,17 @@
               "title": "readiness",
               "type": "object"
             },
+            "scheme": {
+              "description": "Scheme for HTTP probes for the Compactor, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
             "startup": {
               "additionalProperties": true,
               "description": "Startup probe for the Compactor.",
@@ -1566,6 +1594,12 @@
               ],
               "title": "startup",
               "type": "object"
+            },
+            "tcpSocket": {
+              "description": "Use a TCP probe instead of an HTTP one for the Compactor, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
             }
           },
           "required": [
@@ -3479,6 +3513,17 @@
               "title": "readiness",
               "type": "object"
             },
+            "scheme": {
+              "description": "Scheme for HTTP probes for the Query component, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
             "startup": {
               "additionalProperties": true,
               "description": "Startup probe for the Query component.",
@@ -3544,6 +3589,12 @@
               ],
               "title": "startup",
               "type": "object"
+            },
+            "tcpSocket": {
+              "description": "Use a TCP probe instead of an HTTP one for the Query component, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
             }
           },
           "required": [
@@ -4401,6 +4452,17 @@
               "title": "readiness",
               "type": "object"
             },
+            "scheme": {
+              "description": "Scheme for HTTP probes for the Query Frontend, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
             "startup": {
               "additionalProperties": true,
               "description": "Startup probe for the Query Frontend.",
@@ -4466,6 +4528,12 @@
               ],
               "title": "startup",
               "type": "object"
+            },
+            "tcpSocket": {
+              "description": "Use a TCP probe instead of an HTTP one for the Query Frontend, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
             }
           },
           "required": [
@@ -5795,6 +5863,17 @@
               "title": "readiness",
               "type": "object"
             },
+            "scheme": {
+              "description": "Scheme for HTTP probes for the Receive component, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
             "startup": {
               "additionalProperties": true,
               "description": "Startup probe for the Receive component.",
@@ -5860,6 +5939,12 @@
               ],
               "title": "startup",
               "type": "object"
+            },
+            "tcpSocket": {
+              "description": "Use a TCP probe instead of an HTTP one for the Receive component, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
             }
           },
           "required": [
@@ -6994,6 +7079,17 @@
               "title": "readiness",
               "type": "object"
             },
+            "scheme": {
+              "description": "Scheme for HTTP probes for the Ruler component, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
             "startup": {
               "additionalProperties": true,
               "description": "Startup probe for the Ruler component.",
@@ -7059,6 +7155,12 @@
               ],
               "title": "startup",
               "type": "object"
+            },
+            "tcpSocket": {
+              "description": "Use a TCP probe instead of an HTTP one for the Ruler component, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
             }
           },
           "required": [
@@ -8353,6 +8455,17 @@
               "title": "readiness",
               "type": "object"
             },
+            "scheme": {
+              "description": "Scheme for HTTP probes for the Store Gateway, overriding global.probes.scheme. Uppercase, as the kubelet requires. Set to HTTPS when this component serves TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
             "startup": {
               "additionalProperties": true,
               "description": "Startup probe for the Store Gateway.",
@@ -8418,6 +8531,12 @@
               ],
               "title": "startup",
               "type": "object"
+            },
+            "tcpSocket": {
+              "description": "Use a TCP probe instead of an HTTP one for the Store Gateway, overriding global.probes.tcpSocket. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready. Set false here to opt out of a global true.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
             }
           },
           "required": [

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2323,12 +2323,17 @@
           "type": "object"
         },
         "probes": {
-          "additionalProperties": true,
-          "description": "Probe defaults shared by every component. A component's own probes block overrides these.",
+          "additionalProperties": false,
+          "description": "Probe transport defaults shared by every component: scheme and tcpSocket only. Timings and paths are not inherited from here — set those on each component's own probes.readiness/liveness/startup. Any other key here fails schema validation.",
           "properties": {
             "scheme": {
               "default": "",
-              "description": "Scheme for HTTP probes. Set to HTTPS when components serve TLS through --http.config.",
+              "description": "Scheme for HTTP probes. Uppercase, as the kubelet requires — unlike its neighbour serviceMonitor.scheme, which is lowercase. Set to HTTPS when components serve TLS through --http.config.",
+              "enum": [
+                "",
+                "HTTP",
+                "HTTPS"
+              ],
               "required": [],
               "title": "scheme",
               "type": "string"

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -2322,10 +2322,40 @@
           "title": "serviceAccount",
           "type": "object"
         },
+        "probes": {
+          "additionalProperties": true,
+          "description": "Probe defaults shared by every component. A component's own probes block overrides these.",
+          "properties": {
+            "scheme": {
+              "default": "",
+              "description": "Scheme for HTTP probes. Set to HTTPS when components serve TLS through --http.config.",
+              "required": [],
+              "title": "scheme",
+              "type": "string"
+            },
+            "tcpSocket": {
+              "default": false,
+              "description": "Use a TCP probe instead of an HTTP one. Required when --http.config sets basic_auth_users, which also protects /-/healthy and /-/ready.",
+              "required": [],
+              "title": "tcpSocket",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "probes",
+          "type": "object"
+        },
         "serviceMonitor": {
           "additionalProperties": true,
           "description": "ServiceMonitor defaults for Prometheus Operator scraping.\nComponents inherit these defaults and can override per-component.\nDefault ServiceMonitor configuration inherited by all components.",
           "properties": {
+            "basicAuth": {
+              "additionalProperties": true,
+              "description": "Basic auth credentials for scraping, as username/password secret references. Needed when --http.config sets basic_auth_users, which also protects /metrics.",
+              "required": [],
+              "title": "basicAuth",
+              "type": "object"
+            },
             "annotations": {
               "additionalProperties": true,
               "description": "Extra annotations merged into every ServiceMonitor resource.",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -380,6 +380,15 @@ global:
 
   # ServiceMonitor defaults for Prometheus Operator scraping.
   # Components inherit these defaults and can override per-component.
+  # -- Probe defaults shared by every component. A component's own `probes` block overrides these.
+  probes:
+    # -- Scheme for HTTP probes. Set to `HTTPS` when components serve TLS through
+    # `--http.config` (https://thanos.io/tip/operating/https.md/). Omitted when empty, so
+    # rendered manifests are unchanged unless this is set.
+    scheme: ""
+    # -- Use a TCP probe instead of an HTTP one. Required when `--http.config` sets
+    # `basic_auth_users`: Thanos protects `/-/healthy` and `/-/ready` too, so HTTP probes 401.
+    tcpSocket: false
   # Default ServiceMonitor configuration inherited by all components.
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for every component.
@@ -403,6 +412,10 @@ global:
     # -- TLS configuration for scraping when scheme is https.
     # @default -- {}
     tlsConfig: {}
+    # -- Basic auth credentials for scraping, as `username`/`password` secret references.
+    # Needed when `--http.config` sets `basic_auth_users`, which also protects `/metrics`.
+    # @default -- {}
+    basicAuth: {}
     # -- Relabeling rules applied to scraped metrics before ingestion.
     # @default -- []
     relabelings: []

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -378,17 +378,30 @@ global:
         # @default -- {}
         annotations: {}
 
-  # ServiceMonitor defaults for Prometheus Operator scraping.
-  # Components inherit these defaults and can override per-component.
-  # -- Probe defaults shared by every component. A component's own `probes` block overrides these.
+  # @schema
+  # additionalProperties: false
+  # @schema
+  # -- Probe *transport* defaults shared by every component: `scheme` and `tcpSocket` only.
+  # Timings and paths are not inherited from here — set those on each component's own
+  # `probes.readiness`/`liveness`/`startup`. Any other key here fails schema validation.
   probes:
-    # -- Scheme for HTTP probes. Set to `HTTPS` when components serve TLS through
-    # `--http.config` (https://thanos.io/tip/operating/https.md/). Omitted when empty, so
+    # @schema
+    # enum:
+    #   - ""
+    #   - HTTP
+    #   - HTTPS
+    # @schema
+    # -- Scheme for HTTP probes. Uppercase, as the kubelet requires — unlike its neighbour
+    # `serviceMonitor.scheme`, which is lowercase. Set to `HTTPS` when components serve TLS
+    # through `--http.config` (https://thanos.io/tip/operating/https.md/). Omitted when empty, so
     # rendered manifests are unchanged unless this is set.
     scheme: ""
     # -- Use a TCP probe instead of an HTTP one. Required when `--http.config` sets
     # `basic_auth_users`: Thanos protects `/-/healthy` and `/-/ready` too, so HTTP probes 401.
     tcpSocket: false
+
+  # ServiceMonitor defaults for Prometheus Operator scraping.
+  # Components inherit these defaults and can override per-component.
   # Default ServiceMonitor configuration inherited by all components.
   serviceMonitor:
     # -- Enable a Prometheus Operator ServiceMonitor for every component.


### PR DESCRIPTION
## What

`--http.config` ([docs](https://thanos.io/tip/operating/https.md/)) lets Thanos serve TLS and basic auth on its HTTP server, but the chart can't currently be configured to survive it. This adds the three values needed, changing nothing by default.

## Why it doesn't work today

Thanos passes its whole HTTP mux to exporter-toolkit's `ListenAndServe`, and `/-/healthy` and `/-/ready` are registered on that same mux ([`pkg/server/http/http.go`](https://github.com/thanos-io/thanos/blob/main/pkg/server/http/http.go)). exporter-toolkit's handler has **no path exemptions** — with any `basic_auth_users` entry, every request needs credentials, probes included; and `tls_server_config` makes an HTTP probe fail on scheme.

The chart renders probes as `httpGet` with no `scheme` and no `httpHeaders`, so enabling either half of `--http.config` leaves every component **permanently unready**. `/metrics` scraping breaks too, because the ServiceMonitors had no way to authenticate.

Mounting the config file itself already works via `extraArgs` + `extraVolumes` — it's everything downstream of it that couldn't be expressed.

## What this adds

| Value | Effect |
|---|---|
| `global.probes.tcpSocket` | Swap HTTP probes for a TCP check, which needs no credentials — the fix for `basic_auth_users` |
| `global.probes.scheme` | Probe scheme, for TLS without basic auth. Emitted only when set |
| `global.serviceMonitor.basicAuth` | Credentials for scraping `/metrics`, which `--http.config` also protects |

Probe values resolve **global → parent → component** using `hasKey` rather than `default`, so a component can set `tcpSocket` back to `false` against a global `true` (`default` treats `false` as empty and would ignore it).

Also renders `scheme` and `tlsConfig` on the ServiceMonitors. Both already existed under `global.serviceMonitor` but no template consumed them, so they silently did nothing.

## Compatibility

**Defaults are unchanged.** Rendering the chart without any of these values produces byte-identical output to `master` — verified by diffing `helm template` against a clean checkout with receive, query and ServiceMonitors enabled.

## Testing

- new `tests/http_config_test.yaml`: both probe transports, the component-level override, ServiceMonitor `scheme`/`tlsConfig`/`basicAuth`, and absence when unset
- full suite passes: **809 tests, 15 suites**
- `values.schema.json` updated; README regenerated with `helm-docs`
- chart `version` bumped 0.36.0 → 0.37.0

## Example

```yaml
global:
  probes:
    tcpSocket: true          # --http.config sets basic_auth_users
  serviceMonitor:
    enabled: true
    basicAuth:
      username: { name: thanos-http-auth, key: username }
      password: { name: thanos-http-auth, key: password }

receive:
  extraArgs:
    - --http.config=/etc/thanos/http/http-config.yml
  extraVolumes:
    - name: http-config
      secret: { secretName: thanos-http-config }
  extraVolumeMounts:
    - name: http-config
      mountPath: /etc/thanos/http
      readOnly: true
```
