### PR TITLE
feat(receive): support Cap'n Proto replication

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.42.0
+version: 0.43.0
 appVersion: "v0.42.4"
 keywords:
   - thanos

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.43.0](https://img.shields.io/badge/Version-0.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -379,6 +379,23 @@ Three things to keep in mind:
 - The `checksum/hashrings` pod annotation is dropped, since the ring content is unknown at render time. Receive watches the hashring file with fsnotify and re-reads it on change; `--receive.hashrings-file-refresh-interval` (Thanos default `5m`) re-reads it regardless, which covers the case where the watch cannot be re-established after the file is replaced — what a ConfigMap update does. `refreshInterval` tightens that bound.
 
 `hashrings.algorithm` is independent of all this and applies to standalone and split mode alike: `ketama` (the default, consistent hashing) or the legacy `hashmod`.
+
+#### Cap'n Proto replication
+
+`receive.replication.protocol` selects the wire protocol used to replicate writes between Receive endpoints. It is read in both modes, like `mode`: in split mode the Router dials over it and the Ingester listens on it, in standalone mode the same workload does both.
+
+```yaml
+receive:
+  replication:
+    protocol: capnproto     # protobuf (default) | capnproto
+  service:
+    capnprotoPort: 19391    # this is the default
+```
+
+Two things to keep in mind:
+
+- The port is rendered on the container, on the headless Service and — with `global.networkPolicies` enabled — in the NetworkPolicy. It is deliberately left off the ClusterIP Service, since replication addresses one specific peer through its per-pod DNS name and a load-balanced port would reach a different one.
+- Auto-generated hashrings switch from plain string endpoints to objects carrying an explicit `capnproto_address`, which [the Thanos docs](https://thanos.io/tip/components/receive.md/) recommend over letting Thanos infer it from the gRPC address. Rings the chart does not render are untouched — `hashrings.static`, and an externally managed ring under `hashrings.external` — so their owner has to add `capnproto_address` to the endpoints.
 
 ### Store Gateway
 
@@ -1276,6 +1293,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.probes.startup.successThreshold | int | `1` | Consecutive successes before the Receive startup probe is considered passed. |
 | receive.probes.startup.timeoutSeconds | int | `5` | Seconds after which the Receive startup probe times out. |
 | receive.replicaCount | int | `3` | Number of Receive pod replicas. Minimum 3 is recommended for replication factor 2 (write quorum = floor(replicaCount/2)+1). In `split` mode this controls the Ingester StatefulSet replica count. |
+| receive.replication.protocol | string | `"protobuf"` | Wire protocol used to replicate writes between Receive endpoints. `capnproto` needs `service.capnprotoPort` reachable between the pods. |
 | receive.resources | object | {} | Resource requests and limits for the Receive container. |
 | receive.router.affinity | object | {} | Affinity rules for Router pod scheduling. Falls back to receive.affinity. |
 | receive.router.annotations | object | {} | Extra annotations applied to Router resources. |
@@ -1372,6 +1390,7 @@ The table below documents all available values. Top-level keys group settings by
 | receive.router.vpa.targetKind | string | `"Deployment"` | Kubernetes workload kind targeted by the Router VPA. |
 | receive.router.vpa.updateMode | string | `"Auto"` | VPA update mode for Router. One of Auto, Off, or Initial. |
 | receive.service.annotations | object | {} | Extra annotations for the Receive Service. |
+| receive.service.capnprotoPort | int | `19391` | Cap'n Proto replication port. Only rendered when `replication.protocol` is `capnproto`. |
 | receive.service.grpcPort | int | `10901` | gRPC Store API port exposed by the Receive Service. |
 | receive.service.httpNodePort | string | `null` (allocated by Kubernetes) | Static node port for the Receive HTTP port. Only honoured when `type` is NodePort or LoadBalancer; null lets Kubernetes allocate one from the node-port range. |
 | receive.service.httpPort | int | `10902` | HTTP port exposed by the Receive Service. |

--- a/charts/thanos/README.md.gotmpl
+++ b/charts/thanos/README.md.gotmpl
@@ -368,6 +368,23 @@ Three things to keep in mind:
 
 `hashrings.algorithm` is independent of all this and applies to standalone and split mode alike: `ketama` (the default, consistent hashing) or the legacy `hashmod`.
 
+#### Cap'n Proto replication
+
+`receive.replication.protocol` selects the wire protocol used to replicate writes between Receive endpoints. It is read in both modes, like `mode`: in split mode the Router dials over it and the Ingester listens on it, in standalone mode the same workload does both.
+
+```yaml
+receive:
+  replication:
+    protocol: capnproto     # protobuf (default) | capnproto
+  service:
+    capnprotoPort: 19391    # this is the default
+```
+
+Two things to keep in mind:
+
+- The port is rendered on the container, on the headless Service and — with `global.networkPolicies` enabled — in the NetworkPolicy. It is deliberately left off the ClusterIP Service, since replication addresses one specific peer through its per-pod DNS name and a load-balanced port would reach a different one.
+- Auto-generated hashrings switch from plain string endpoints to objects carrying an explicit `capnproto_address`, which [the Thanos docs](https://thanos.io/tip/components/receive.md/) recommend over letting Thanos infer it from the gRPC address. Rings the chart does not render are untouched — `hashrings.static`, and an externally managed ring under `hashrings.external` — so their owner has to add `capnproto_address` to the endpoints.
+
 ### Store Gateway
 
 The Store Gateway exposes historical blocks from the object store over the Store API. Query routes requests for older data to this component.

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -820,11 +820,31 @@ hashrings.json
 {{- dig "hashrings" "refreshInterval" "" $cfg -}}
 {{- end -}}
 
+{{- /* Replication protocol between Receive endpoints: protobuf (default) or capnproto. */ -}}
+{{- define "thanos.receive.replicationProtocol" -}}
+{{- dig "replication" "protocol" "protobuf" .Values.receive -}}
+{{- end -}}
+
+{{- /* "true" when replication runs over Cap'n Proto; empty string otherwise. */ -}}
+{{- define "thanos.receive.isCapnproto" -}}
+{{- if eq (include "thanos.receive.replicationProtocol" .) "capnproto" -}}true{{- end -}}
+{{- end -}}
+
+{{- /* Cap'n Proto port of the resolved workload (standalone or Ingester). */ -}}
+{{- define "thanos.receive.capnprotoPort" -}}
+{{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
+{{- dig "service" "capnprotoPort" 19391 $cfg -}}
+{{- end -}}
+
 {{- /*
 Render the hashrings JSON. Endpoints reference the Receive workload pods
 via its headless service. The workload name is resolved by
 `thanos.receive.workloadName` (`-ingester` suffix in split mode), so the
 same helper produces a valid hashring for both standalone and split modes.
+
+Under Cap'n Proto replication each endpoint becomes an object carrying an
+explicit `capnproto_address`, as Thanos would otherwise have to infer it
+from the gRPC address.
 */ -}}
 {{- define "thanos.receive.hashrings" -}}
 {{- $vals := include "thanos.receive.cfg" . | fromYaml -}}
@@ -832,6 +852,8 @@ same helper produces a valid hashring for both standalone and split modes.
 {{- $rc := int (default 1 $vals.replicaCount) -}}
 {{- $ns := include "thanos.namespace" . -}}
 {{- $domain := .Values.global.clusterDomain | default "cluster.local" -}}
+{{- $capnproto := eq (include "thanos.receive.isCapnproto" .) "true" -}}
+{{- $capnprotoPort := int (include "thanos.receive.capnprotoPort" .) -}}
 
 {{- if and (hasKey $vals "hashrings") (hasKey $vals.hashrings "static") (gt (len $vals.hashrings.static) 0) -}}
 {{ $vals.hashrings.static | toPrettyJson }}
@@ -842,6 +864,9 @@ same helper produces a valid hashring for both standalone and split modes.
   {{- $eps := list -}}
   {{- range $i, $_ := until $rc -}}
     {{- $ep := printf "%s-%d.%s.%s.svc.%s:%d" $name $i $svcName $ns $domain $grpcPort -}}
+    {{- if $capnproto -}}
+      {{- $ep = dict "address" $ep "capnproto_address" (printf "%s-%d.%s.%s.svc.%s:%d" $name $i $svcName $ns $domain $capnprotoPort) -}}
+    {{- end -}}
     {{- $eps = append $eps $ep -}}
   {{- end -}}
   {{- $rings := list (dict "endpoints" $eps) -}}
@@ -850,8 +875,11 @@ same helper produces a valid hashring for both standalone and split modes.
 {{- else -}}
   {{- $name := include "thanos.receive.workloadName" . -}}
   {{- $svcName := include "thanos.receiveHeadless" . -}}
-  {{- $eps := list (printf "%s-0.%s.%s.svc.%s:%d" $name $svcName $ns $domain $grpcPort) -}}
-  {{- $rings := list (dict "endpoints" $eps) -}}
+  {{- $ep := printf "%s-0.%s.%s.svc.%s:%d" $name $svcName $ns $domain $grpcPort -}}
+  {{- if $capnproto -}}
+    {{- $ep = dict "address" $ep "capnproto_address" (printf "%s-0.%s.%s.svc.%s:%d" $name $svcName $ns $domain $capnprotoPort) -}}
+  {{- end -}}
+  {{- $rings := list (dict "endpoints" (list $ep)) -}}
 {{ $rings | toPrettyJson }}
 {{- end -}}
 {{- end -}}

--- a/charts/thanos/templates/receive/networkpolicy.yaml
+++ b/charts/thanos/templates/receive/networkpolicy.yaml
@@ -15,6 +15,9 @@ spec:
         - port: grpc
         - port: http
         - port: remote-write
+        {{- if eq (include "thanos.receive.isCapnproto" .) "true" }}
+        - port: capnproto
+        {{- end }}
   podSelector:
     matchLabels:
       {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 6 }}

--- a/charts/thanos/templates/receive/service.yaml
+++ b/charts/thanos/templates/receive/service.yaml
@@ -61,6 +61,13 @@ spec:
     - name: grpc
       port: {{ $cfg.service.grpcPort }}
       targetPort: grpc
+    {{- if eq (include "thanos.receive.isCapnproto" .) "true" }}
+    # Peer-to-peer over the per-pod DNS names in the hashring, so this port
+    # stays off the ClusterIP Service, which would balance it to another pod.
+    - name: capnproto
+      port: {{ include "thanos.receive.capnprotoPort" . }}
+      targetPort: capnproto
+    {{- end }}
   selector:
     {{- include "thanos.selectorLabels" (dict "root" $ "component" "receive") | nindent 4 }}
 {{- end }}

--- a/charts/thanos/templates/receive/split/router-deployment.yaml
+++ b/charts/thanos/templates/receive/split/router-deployment.yaml
@@ -62,6 +62,9 @@ spec:
             - --receive.hashrings-file-refresh-interval={{ . }}
             {{- end }}
             - --receive.replication-factor={{ $rt.replicationFactor | default 1 }}
+            {{- if eq (include "thanos.receive.isCapnproto" .) "true" }}
+            - --receive.replication-protocol=capnproto
+            {{- end }}
             - --label=receive_router_replica="$(POD_NAME)"
             {{- if $cfg.tenancyHeader }}
             - --receive.tenant-header={{ $cfg.tenancyHeader }}

--- a/charts/thanos/templates/receive/statefulset.yaml
+++ b/charts/thanos/templates/receive/statefulset.yaml
@@ -2,6 +2,7 @@
 {{- $isSplit := eq (include "thanos.receive.isSplit" .) "true" -}}
 {{- $cfg := include "thanos.receive.cfg" . | fromYaml -}}
 {{- $external := include "thanos.receive.hashringsExternal" . | fromYaml -}}
+{{- $capnproto := eq (include "thanos.receive.isCapnproto" .) "true" -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -68,6 +69,12 @@ spec:
             {{- end }}
             - --receive.local-endpoint=$(NAME).{{ include "thanos.receiveHeadless" . }}.$(NAMESPACE).svc.{{ .Values.global.clusterDomain }}:{{ $cfg.service.grpcPort }}
             {{- end }}
+            {{- if $capnproto }}
+            - --receive.capnproto-address=0.0.0.0:{{ include "thanos.receive.capnprotoPort" . }}
+            {{- if not $isSplit }}
+            - --receive.replication-protocol=capnproto
+            {{- end }}
+            {{- end }}
             {{- if $cfg.tenancyHeader }}
             - --receive.tenant-header={{ $cfg.tenancyHeader }}
             {{- end }}
@@ -87,6 +94,10 @@ spec:
               containerPort: {{ default 10902 $cfg.service.httpPort }}
             - name: remote-write
               containerPort: {{ $cfg.service.remoteWritePort }}
+            {{- if $capnproto }}
+            - name: capnproto
+              containerPort: {{ include "thanos.receive.capnprotoPort" . }}
+            {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/thanos/tests/receive_capnproto_test.yaml
+++ b/charts/thanos/tests/receive_capnproto_test.yaml
@@ -1,0 +1,205 @@
+suite: receive Cap'n Proto replication
+
+tests:
+  # -- Default (protobuf) ----------------------------------------------
+
+  - it: passes no replication flags by default
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-protocol=capnproto
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.capnproto-address=0.0.0.0:19391
+
+  - it: exposes no Cap'n Proto container port by default
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: capnproto
+            containerPort: 19391
+
+  # -- Standalone mode --------------------------------------------------
+
+  - it: routes and listens over Cap'n Proto in standalone mode
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.replication.protocol: capnproto
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-protocol=capnproto
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.capnproto-address=0.0.0.0:19391
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: capnproto
+            containerPort: 19391
+
+  - it: honours a custom Cap'n Proto port
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.replication.protocol: capnproto
+      receive.service.capnprotoPort: 29391
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.capnproto-address=0.0.0.0:29391
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: capnproto
+            containerPort: 29391
+
+  # -- Hashring ----------------------------------------------------------
+
+  - it: keeps plain string endpoints in the hashring by default
+    template: receive/configmap-hashrings.yaml
+    set:
+      receive.enabled: true
+      receive.replicaCount: 2
+    asserts:
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: '"RELEASE-NAME-thanos-receive-0\.RELEASE-NAME-thanos-receive-headless\.NAMESPACE\.svc\.cluster\.local:10901"'
+
+  - it: renders explicit capnproto_address endpoints in the hashring
+    template: receive/configmap-hashrings.yaml
+    set:
+      receive.enabled: true
+      receive.replicaCount: 2
+      receive.replication.protocol: capnproto
+    asserts:
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: '"address": "RELEASE-NAME-thanos-receive-0\.RELEASE-NAME-thanos-receive-headless\.NAMESPACE\.svc\.cluster\.local:10901"'
+      - matchRegex:
+          path: data["hashrings.json"]
+          pattern: '"capnproto_address": "RELEASE-NAME-thanos-receive-1\.RELEASE-NAME-thanos-receive-headless\.NAMESPACE\.svc\.cluster\.local:19391"'
+
+  # -- Services and NetworkPolicy ----------------------------------------
+
+  - it: adds the Cap'n Proto port to the headless Service only
+    template: receive/service.yaml
+    set:
+      receive.enabled: true
+      receive.replication.protocol: capnproto
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: capnproto
+            port: 19391
+            targetPort: capnproto
+
+  - it: leaves the ClusterIP Service untouched
+    template: receive/service.yaml
+    set:
+      receive.enabled: true
+      receive.replication.protocol: capnproto
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: capnproto
+            port: 19391
+            targetPort: capnproto
+
+  - it: opens the Cap'n Proto port in the NetworkPolicy
+    template: receive/networkpolicy.yaml
+    set:
+      receive.enabled: true
+      global.networkPolicies: true
+      receive.replication.protocol: capnproto
+    asserts:
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: capnproto
+
+  - it: leaves the NetworkPolicy ports untouched by default
+    template: receive/networkpolicy.yaml
+    set:
+      receive.enabled: true
+      global.networkPolicies: true
+    asserts:
+      - notContains:
+          path: spec.ingress[0].ports
+          content:
+            port: capnproto
+
+  # -- Externally managed hashring ----------------------------------------
+
+  - it: renders no ring to inject capnproto_address into when the ring is external
+    template: receive/configmap-hashrings.yaml
+    set:
+      receive.enabled: true
+      receive.replication.protocol: capnproto
+      receive.hashrings.external.enabled: true
+      receive.hashrings.external.configMapName: thanos-receive-controller-generated
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still configures the workload for Cap'n Proto with an external ring
+    template: receive/statefulset.yaml
+    set:
+      receive.enabled: true
+      receive.replication.protocol: capnproto
+      receive.hashrings.external.enabled: true
+      receive.hashrings.external.configMapName: thanos-receive-controller-generated
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-protocol=capnproto
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.capnproto-address=0.0.0.0:19391
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: capnproto
+            containerPort: 19391
+      - equal:
+          path: spec.template.spec.volumes[0].projected.sources[1].configMap.name
+          value: thanos-receive-controller-generated
+
+  # -- Split mode ---------------------------------------------------------
+
+  - it: dials over Cap'n Proto from the router
+    template: receive/split/router-deployment.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.replication.protocol: capnproto
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-protocol=capnproto
+
+  - it: listens on Cap'n Proto from the ingester without routing
+    template: receive/statefulset.yaml
+    values:
+      - _split_defaults.yaml
+    set:
+      receive.replication.protocol: capnproto
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.capnproto-address=0.0.0.0:19391
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --receive.replication-protocol=capnproto

--- a/charts/thanos/values.schema.json
+++ b/charts/thanos/values.schema.json
@@ -6031,6 +6031,28 @@
           "title": "resources",
           "type": "object"
         },
+        "replication": {
+          "additionalProperties": true,
+          "description": "Replication between Receive endpoints. Read in both modes, like `mode`.",
+          "properties": {
+            "protocol": {
+              "default": "protobuf",
+              "description": "Wire protocol used to replicate writes between Receive endpoints. `capnproto` needs `service.capnprotoPort` reachable between the pods.",
+              "enum": [
+                "protobuf",
+                "capnproto"
+              ],
+              "required": [],
+              "title": "protocol",
+              "type": "string"
+            }
+          },
+          "required": [
+            "protocol"
+          ],
+          "title": "replication",
+          "type": "object"
+        },
         "service": {
           "additionalProperties": true,
           "description": "Kubernetes Service configuration for the Receive component.",
@@ -6070,6 +6092,13 @@
               "title": "remoteWritePort",
               "type": "integer"
             },
+            "capnprotoPort": {
+              "default": 19391,
+              "description": "Cap'n Proto replication port. Only rendered when `replication.protocol` is `capnproto`.",
+              "required": [],
+              "title": "capnprotoPort",
+              "type": "integer"
+            },
             "type": {
               "default": "ClusterIP",
               "description": "Kubernetes Service type for the Receive component.",
@@ -6101,6 +6130,7 @@
             "grpcPort",
             "httpPort",
             "remoteWritePort",
+            "capnprotoPort",
             "annotations",
             "labels"
           ],
@@ -6393,6 +6423,7 @@
         "minReadySeconds",
         "tenancyHeader",
         "tsdb",
+        "replication",
         "hashrings",
         "service",
         "ingress",

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -2309,6 +2309,17 @@ receive:
     # -- Enable WAL compression to reduce disk I/O and storage usage.
     walCompression: true
 
+  # Replication between Receive endpoints. Read in both modes, like `mode`.
+  replication:
+    # @schema
+    # enum:
+    #   - protobuf
+    #   - capnproto
+    # @schema
+    # -- Wire protocol used to replicate writes between Receive endpoints.
+    # `capnproto` needs `service.capnprotoPort` reachable between the pods.
+    protocol: protobuf
+
   # Hashring topology configuration for the Receive StatefulSet.
   hashrings:
     # @schema
@@ -2361,6 +2372,9 @@ receive:
     httpPort: 10902
     # -- Remote-write ingestion port exposed by the Receive Service.
     remoteWritePort: 10908
+    # -- Cap'n Proto replication port. Only rendered when
+    # `replication.protocol` is `capnproto`.
+    capnprotoPort: 19391
     # -- Static node port for the Receive HTTP port.
     # Only honoured when `type` is NodePort or LoadBalancer; null lets
     # Kubernetes allocate one from the node-port range.


### PR DESCRIPTION
Adds receive.replication.protocol (protobuf or capnproto) and receive.service.capnprotoPort. Under capnproto the standalone StatefulSet gets --receive.replication-protocol and --receive.capnproto-address, the split Router gets the protocol flag and the split Ingester the address flag, since only the routing side dials its peers. The default protobuf renders no flags at all.

The port is rendered on the container, on the headless Service and, with global.networkPolicies enabled, in the NetworkPolicy. It is left off the ClusterIP Service, because replication addresses one specific peer through its per-pod DNS name and a load-balanced port would reach a different one.

Auto-generated hashrings emit endpoint objects with an explicit capnproto_address instead of plain strings when the protocol is capnproto, which is what the Thanos docs recommend over address inference. Static hashrings are passed through untouched.

<!--
Thank you for contributing to thanos-community/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a GitHub Actions pipeline
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
