### PR TITLE
fix(chart-source): flip sources for better org.opencontainers annotation

### DIFF
--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: A helm chart to setup Thanos on Kubernetes, a highly available Prometheus setup with long term storage capabilities.
 type: application
-version: 0.41.0
+version: 0.41.1
 appVersion: "v0.42.4"
 keywords:
   - thanos
@@ -14,8 +14,8 @@ keywords:
   - kube-prometheus-stack
 home: https://thanos.io/
 sources:
-  - https://github.com/thanos-io/thanos
   - https://github.com/thanos-community/helm-charts
+  - https://github.com/thanos-io/thanos
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 deprecated: false
 kubeVersion: ">= 1.30.0-0"

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -61,3 +61,5 @@ annotations:
       description: The Receive ServiceMonitor no longer scrapes every Receive pod twice. It matched both the ClusterIP Service and the headless Service, since both carried app.kubernetes.io/component; the headless Service now omits that label, as the per-shard Store Gateway Services already did
     - kind: added
       description: thanos.selectorLabels template helper, now the single source of every selector in the chart and the basis of thanos.labels
+    - kind: fixed
+      description: Swapped the order of the sources in the Chart.yaml so https://github.com/thanos-community/helm-charts is on top and will be in the package annotation for org.opencontainers.image.source

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Helm Chart
 
-![Version: 0.39.0](https://img.shields.io/badge/Version-0.39.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
+![Version: 0.41.1](https://img.shields.io/badge/Version-0.41.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.42.4](https://img.shields.io/badge/AppVersion-v0.42.4-informational?style=flat-square)
 
 <p align="center"><img src="../../docs/imgs/thanos_logo_full.svg" alt="Thanos Logo" width="300"/></p>
 
@@ -30,8 +30,8 @@ Refer to the [Thanos component docs](https://thanos.io/tip/thanos/quick-tutorial
 
 ## Source Code
 
-* <https://github.com/thanos-io/thanos>
 * <https://github.com/thanos-community/helm-charts>
+* <https://github.com/thanos-io/thanos>
 
 ## Prerequisites
 
@@ -46,7 +46,7 @@ Kubernetes: `>= 1.30.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.rustfs.com/ | rustfs | 0.12.0 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 88.2.0 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack(kube-prometheus-stack) | 88.6.0 |
 
 ## Component Overview
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Noticed on a renovate PR to update the helm chart the "Release Notes" section was for thanos and not the thanos helm chart.

#### Which issue this PR fixes

- fixes #206

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
